### PR TITLE
#14: Fix release version bump output

### DIFF
--- a/utils/bump_version_if_tag_exists.sh
+++ b/utils/bump_version_if_tag_exists.sh
@@ -6,7 +6,7 @@ version="$1"
 if git rev-parse -q --verify "refs/tags/v${version}"; then
   git config user.name "github-actions[bot]"
   git config user.email "github-actions[bot]@users.noreply.github.com"
-  make version-bump
+  git mkver patch >/dev/null
   version=$(python utils/read_version.py)
   git add pyproject.toml
   git commit -m "chore: bump version to ${version}"


### PR DESCRIPTION
## Purpose
- Ensure the release bump script only emits the version for GitHub Actions outputs

## Linked issues
- #14

## Verification
- Not run (CI-only change)
