### PR TITLE
#19: Parallelize PR detail fetching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,9 @@ jobs:
       - name: Build binary
         run: make build
 
+      - name: Verify binary version
+        run: utils/check_binary_version.sh
+
   release:
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     runs-on: ubuntu-latest

--- a/test_breakfast.py
+++ b/test_breakfast.py
@@ -185,6 +185,7 @@ def test_cli_outputs_table(monkeypatch):
 
     def fake_api_request(_path):
         return {
+            "base": {"repo": {"name": "repo"}},
             "mergeable": True,
             "mergeable_state": "clean",
             "additions": 5,

--- a/utils/check_binary_version.sh
+++ b/utils/check_binary_version.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+expected_version="$(python utils/read_version.py)"
+actual_version="$(./breakfast --version | awk '{print $NF}')"
+
+if [[ "${actual_version}" != "${expected_version}" ]]; then
+  echo "Version mismatch: expected ${expected_version}, got ${actual_version}" >&2
+  exit 1
+fi


### PR DESCRIPTION
## Purpose
- Fetch PR details in parallel to reduce runtime
- Verify the built binary reports the expected version

## Linked issues
- #19

## Verification
- make test
- make lint
