### PR TITLE
#21: Keep bump_version output clean for release CI

### DIFF
--- a/utils/bump_version_if_tag_exists.sh
+++ b/utils/bump_version_if_tag_exists.sh
@@ -9,8 +9,8 @@ if git rev-parse -q --verify "refs/tags/v${version}"; then
   git mkver patch >/dev/null
   version=$(python utils/read_version.py)
   git add pyproject.toml
-  git commit -m "chore: bump version to ${version}"
-  git push
+  git commit -m "chore: bump version to ${version}" >/dev/null
+  git push >/dev/null
 fi
 
 echo "${version}"

--- a/utils/install_git_mkver.sh
+++ b/utils/install_git_mkver.sh
@@ -2,24 +2,15 @@
 set -euo pipefail
 
 api_url="https://api.github.com/repos/idc101/git-mkver/releases/latest"
-auth_token="${GH_TOKEN:-${GITHUB_TOKEN:-}}"
 
-asset_url=$(AUTH_TOKEN="${auth_token}" python - <<'PY'
+asset_url=$(python - <<'PY'
 import json
 import sys
-import os
-from urllib.request import Request, urlopen
+from urllib.request import urlopen
 
 api_url = "https://api.github.com/repos/idc101/git-mkver/releases/latest"
-auth_token = os.getenv("AUTH_TOKEN", "")
 
-request = Request(api_url)
-if auth_token:
-    request.add_header("Authorization", f"Bearer {auth_token}")
-    request.add_header("X-GitHub-Api-Version", "2022-11-28")
-    request.add_header("Accept", "application/vnd.github+json")
-
-with urlopen(request) as response:
+with urlopen(api_url) as response:
     data = json.load(response)
 
 assets = data.get("assets", [])


### PR DESCRIPTION
## Purpose
Prevent the release job from writing invalid data to `GITHUB_OUTPUT` by silencing git command stdout in `utils/bump_version_if_tag_exists.sh`.

## Linked issue
- #21

## Verification
- Not run (CI will validate).