### PR TITLE
#28: Silence bump script output

### DIFF
--- a/utils/bump_version_if_tag_exists.sh
+++ b/utils/bump_version_if_tag_exists.sh
@@ -10,7 +10,7 @@ if git rev-parse -q --verify "refs/tags/v${version}"; then
   version=$(python utils/read_version.py)
   git add pyproject.toml
   git commit -m "chore: bump version to ${version}" >/dev/null
-  git push >/dev/null
+  git push >/dev/null 2>&1
 fi
 
-echo "${version}"
+printf '%s\n' "$version"


### PR DESCRIPTION
Purpose: prevent GitHub Actions output parsing errors by ensuring the bump script emits only a single version line.\n\nLinked issue(s): #28\n\nVerification: make lint, make test