### PR TITLE
#30: Add optional PR age column to output

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,11 @@ Simple tool for pulling PRs you might be interested in.
 ```bash
 ./breakfast --organization cisco-sbg --repo-filter foo
 ./breakfast --organization cisco-sbg --repo-filter foo --ignore-author dependabot[bot] --ignore-author renovate[bot]
+./breakfast --organization cisco-sbg --repo-filter foo --age
 ```
 
 ## Options
 - `--organization`, `-o`: One or multiple organizations to report on.
 - `--repo-filter`, `-r`: Filter for specific repo(s) by name substring.
 - `--ignore-author`: Ignore PRs raised by one or more authors (case-insensitive). Repeat for multiple authors.
+- `--age`: Add an `Age` column (days since PR creation) between `Comments` and `Mergeable?`.


### PR DESCRIPTION
## Purpose
Add an optional PR age column to the CLI output so reviewers can quickly spot stale pull requests.

## Linked Issue
Closes #30

## What Changed
- Added `--age` flag to conditionally display an `Age` column.
- Added `get_pr_age_days` to compute age from `created_at` in whole days.
- Inserted `Age` between `Comments` and `Mergeable?`.
- Reused existing numeric color grading for age values.
- Updated tests and README usage/options.

## Verification
- `make lint`
- `make test`
- `make build`
- `SHIV_ROOT=/tmp/.shiv ./breakfast --version`