### PR TITLE
#32: Add CI status badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # breakfast
+[![CI](https://github.com/mrsixw/breakfast/actions/workflows/ci.yml/badge.svg)](https://github.com/mrsixw/breakfast/actions/workflows/ci.yml)
+
 Simple tool for pulling PRs you might be interested in.
 
 ## Usage


### PR DESCRIPTION
## Purpose
Add the CI status badge to `README.md` so the current workflow status is visible on the repository homepage.

## Linked issue
Closes #32

## Verification
- `make lint`
- `make test`
