### PR TITLE
style: apply black formatting to json output changes

### DIFF
--- a/breakfast.py
+++ b/breakfast.py
@@ -291,26 +291,28 @@ def breakfast(organization, repo_filter, ignore_author, mine_only, age, json_out
     if json_output:
         json_data = []
         for pr_detail in pr_details:
-            json_data.append({
-                "repo": pr_detail["base"]["repo"]["name"],
-                "pr_number": pr_detail["number"],
-                "title": pr_detail["title"],
-                "author": pr_detail["user"]["login"],
-                "url": pr_detail["html_url"],
-                "state": pr_detail["state"],
-                "draft": pr_detail.get("draft", False),
-                "created_at": pr_detail.get("created_at"),
-                "updated_at": pr_detail.get("updated_at"),
-                "additions": pr_detail.get("additions"),
-                "deletions": pr_detail.get("deletions"),
-                "changed_files": pr_detail.get("changed_files"),
-                "commits": pr_detail.get("commits"),
-                "review_comments": pr_detail.get("review_comments"),
-                "labels": [lb["name"] for lb in pr_detail.get("labels", [])],
-                "requested_reviewers": [
-                    r["login"] for r in pr_detail.get("requested_reviewers", [])
-                ],
-            })
+            json_data.append(
+                {
+                    "repo": pr_detail["base"]["repo"]["name"],
+                    "pr_number": pr_detail["number"],
+                    "title": pr_detail["title"],
+                    "author": pr_detail["user"]["login"],
+                    "url": pr_detail["html_url"],
+                    "state": pr_detail["state"],
+                    "draft": pr_detail.get("draft", False),
+                    "created_at": pr_detail.get("created_at"),
+                    "updated_at": pr_detail.get("updated_at"),
+                    "additions": pr_detail.get("additions"),
+                    "deletions": pr_detail.get("deletions"),
+                    "changed_files": pr_detail.get("changed_files"),
+                    "commits": pr_detail.get("commits"),
+                    "review_comments": pr_detail.get("review_comments"),
+                    "labels": [lb["name"] for lb in pr_detail.get("labels", [])],
+                    "requested_reviewers": [
+                        r["login"] for r in pr_detail.get("requested_reviewers", [])
+                    ],
+                }
+            )
             click.echo(random.choices(BREAKFAST_ITEMS)[0], nl=False, err=True)
         click.echo("...Done", err=True)
         click.echo(json.dumps(json_data, indent=2))

--- a/test_breakfast.py
+++ b/test_breakfast.py
@@ -318,7 +318,7 @@ def test_cli_outputs_json(monkeypatch):
     result = runner.invoke(breakfast.breakfast, ["-o", "org", "-r", "repo", "--json"])
 
     assert result.exit_code == 0
-    data = json.loads(result.output[result.output.index("["):])
+    data = json.loads(result.output[result.output.index("[") :])
     assert len(data) == 1
     pr = data[0]
     assert pr["repo"] == "repo"
@@ -343,7 +343,7 @@ def test_cli_json_output_is_valid_json_when_empty(monkeypatch):
     result = runner.invoke(breakfast.breakfast, ["-o", "org", "-r", "repo", "--json"])
 
     assert result.exit_code == 0
-    assert json.loads(result.output[result.output.index("["):]) == []
+    assert json.loads(result.output[result.output.index("[") :]) == []
 
 
 def test_cli_mine_only_filters_to_authenticated_user(monkeypatch):


### PR DESCRIPTION
## Summary
- Applies `black` formatting to `breakfast.py` and `test_breakfast.py`
- These files were reformatted after the `--json` feature landed in #47 without running the linter first

## Test plan
- [ ] `make lint` passes
- [ ] `make test` passes (20 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)