### PR TITLE
#51: Add CLAUDE.md and CONTRIBUTING.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,57 @@
+# Claude Instructions
+
+## Project Overview
+- **breakfast** is a CLI tool that displays open GitHub pull requests across an organization's repos in a terminal table.
+- Built with Python and Click. Uses the GitHub REST and GraphQL APIs.
+- Single-module project: main code in `breakfast.py`, tests in `test_breakfast.py`.
+
+## Project Structure
+- `breakfast.py` — CLI entry point and all application logic
+- `test_breakfast.py` — all tests (pytest)
+- `pyproject.toml` — project metadata, dependencies, tool config
+- `Makefile` — build, test, lint, and format targets
+- `utils/read_version.py` — version helper for CI
+- `mkver.conf` — version bump configuration
+
+## Environment
+- Python >= 3.11
+- Package manager: **uv** (not pip). Use `uv sync`, `uv run`, etc.
+- Requires `GITHUB_TOKEN` environment variable at runtime.
+
+## Common Commands
+- `make test` — run tests (`uv run pytest -v`)
+- `make lint` — check linting and formatting (`ruff check` + `black --check`)
+- `make format` — auto-fix lint and formatting (`ruff check --fix` + `black`)
+- `make build` — build a shiv executable
+
+## Testing
+- Tests use `pytest` with `monkeypatch` for mocking and `click.testing.CliRunner` for CLI tests.
+- Run `make test` before committing.
+
+## Work Items
+- This project uses GitHub issues (not Jira). Reference the GitHub issue number in branch names and PR titles.
+- Branch names should include the issue number and a short description (e.g., `issue-26_filter_pr_authors`).
+
+## Commit Messages
+- Use Conventional Commits (e.g., `feat: ...`, `fix: ...`, `chore: ...`, `docs: ...`, `refactor: ...`, `test: ...`, `ci: ...`).
+- Keep the summary short and imperative.
+
+## Pull Requests
+- Include the issue number in PR titles (e.g., `#7: Split test deps and migrate to uv`).
+- Ensure CI is green before requesting review or merging PRs.
+
+## mkver Usage
+- `git mkver patch` mutates the version file; avoid running it as part of routine local builds on feature branches.
+- Prefer running mkver only when preparing a release/version bump commit, then commit the version change explicitly.
+- If a build requires mkver, reset the version file afterward to keep the working tree clean.
+
+## CI and Releases
+- CI should run tests on pull requests and pushes.
+- On merges to `main`, create a release and tag; ensure the version is bumped before release.
+- Add a sanity check: if a tag already exists for the current version, run `git mkver patch` to bump it before releasing.
+- Prefer using Makefile targets for CI steps (add targets as needed to keep local/CI workflows consistent).
+
+## Code Quality
+- Use `ruff` (lint + import sorting) and `black` (formatting).
+- Prefer running checks via CI and pre-commit hooks where possible.
+- Before committing and pushing changes, run `make test`, `make lint`, and `make format` locally.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,99 @@
+# Contributing to breakfast
+
+Thanks for your interest in contributing to **breakfast**! This guide covers setup, development workflow, and project conventions.
+
+## Prerequisites
+
+- Python >= 3.11
+- [uv](https://docs.astral.sh/uv/) package manager (not pip)
+- A `GITHUB_TOKEN` environment variable for running the tool
+
+## Getting Started
+
+1. Fork and clone the repository.
+2. Create a virtual environment and install dev dependencies:
+
+   ```bash
+   make .venv
+   ```
+
+   This runs `uv venv` and `uv sync --extra dev` to set up everything you need.
+
+3. Run the tests to make sure things work:
+
+   ```bash
+   make test
+   ```
+
+## Project Structure
+
+- `breakfast.py` — CLI entry point and all application logic
+- `test_breakfast.py` — all tests (pytest)
+- `pyproject.toml` — project metadata, dependencies, tool config
+- `Makefile` — build, test, lint, and format targets
+- `utils/read_version.py` — version helper for CI
+- `mkver.conf` — version bump configuration
+
+## Development Workflow
+
+### Branching
+
+- Create a branch from `main` with the issue number and a short description:
+
+  ```
+  issue-26_filter_pr_authors
+  ```
+
+### Running Tests
+
+```bash
+make test        # uv run pytest -v
+```
+
+Tests use `pytest` with `monkeypatch` for mocking and `click.testing.CliRunner` for CLI tests.
+
+### Linting and Formatting
+
+```bash
+make lint        # ruff check + black --check
+make format      # ruff check --fix + black
+```
+
+Run both `make test` and `make lint` before committing.
+
+### Building
+
+```bash
+make build       # builds a shiv executable
+```
+
+## Commit Messages
+
+Use [Conventional Commits](https://www.conventionalcommits.org/):
+
+- `feat:` — new feature
+- `fix:` — bug fix
+- `docs:` — documentation only
+- `refactor:` — code change that neither fixes a bug nor adds a feature
+- `test:` — adding or updating tests
+- `chore:` — maintenance tasks
+- `ci:` — CI/CD changes
+
+Keep the summary short and imperative (e.g., `feat: add label filtering`).
+
+## Pull Requests
+
+- Include the issue number in the PR title (e.g., `#7: Split test deps and migrate to uv`).
+- Ensure CI is green before requesting review.
+- Keep PRs focused — one issue per PR where possible.
+
+## Code Quality
+
+- **Linter:** [ruff](https://docs.astral.sh/ruff/) (lint rules: E, F, I)
+- **Formatter:** [black](https://black.readthedocs.io/) (line length 88, target Python 3.11)
+- Run checks locally before pushing. CI will also verify these.
+
+## mkver / Versioning
+
+- Do **not** run `git mkver patch` on feature branches — it mutates the version file.
+- Version bumps happen when preparing a release, not during regular development.


### PR DESCRIPTION
## Summary
- Adds `CLAUDE.md` with project context and conventions for Claude Code
- Adds `CONTRIBUTING.md` with setup, workflow, and conventions for human contributors
- Both files are consistent with existing `AGENTS.md`

Closes #51

## Test plan
- [x] `make test` passes (20/20)
- [ ] Review both files for accuracy and completeness