### PR TITLE
#57: Add PR template and enforce issue requirement

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,24 @@
+## Issue
+
+Closes #<!-- issue number -->
+
+## Description
+
+<!-- Brief summary of what this PR does and why. -->
+
+## Changes
+
+<!-- List the key changes made. -->
+
+-
+
+## Testing
+
+<!-- Describe how this was tested. -->
+
+- [ ] `make test` passes
+- [ ] `make lint` passes
+
+## Notes
+
+<!-- Anything reviewers should know, or follow-up work needed. -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,6 +31,7 @@
 ## Work Items
 - This project uses GitHub issues (not Jira). Reference the GitHub issue number in branch names and PR titles.
 - Branch names should include the issue number and a short description (e.g., `issue-26_filter_pr_authors`).
+- **A GitHub issue MUST exist before any work begins.** If the user requests a change and no issue exists yet, create one (or ask the user to create one) before starting implementation. Every branch, commit, and PR must reference an issue number.
 
 ## Commit Messages
 - Use Conventional Commits (e.g., `feat: ...`, `fix: ...`, `chore: ...`, `docs: ...`, `refactor: ...`, `test: ...`, `ci: ...`).


### PR DESCRIPTION
## Issue

Closes #57

## Description

Adds project governance: a standardized PR template and a rule requiring a GitHub issue before any work begins.

## Changes

- Add `.github/pull_request_template.md` with sections for Issue, Description, Changes, Testing, and Notes
- Update `CLAUDE.md` Work Items to require a GitHub issue exists before starting any work

## Testing

- [ ] `make test` passes
- [ ] `make lint` passes

## Notes

No code changes — docs/templates only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)