### PR TITLE
#59: Add auto-generated release notes

### DIFF
--- a/utils/create_release.sh
+++ b/utils/create_release.sh
@@ -6,5 +6,5 @@ tag="v${version}"
 
 gh release create "${tag}" ./breakfast \
   --title "${tag}" \
-  --notes "Automated release." \
+  --generate-notes \
   --target "$(git rev-parse HEAD)"


### PR DESCRIPTION
## Issue

Closes #59

## Description

Replace the static "Automated release." message with GitHub's `--generate-notes` flag so each CI release automatically includes a changelog based on merged PRs and commits.

Existing releases (v0.1.0 through v0.9.0) have been retroactively updated with commit-based release notes.

## Changes

- Update `utils/create_release.sh` to use `--generate-notes` instead of `--notes "Automated release."`

## Testing

- [ ] `make test` passes
- [ ] `make lint` passes

## Notes

The backfill of existing releases was done manually via `gh release edit` and is not part of this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)