### PR TITLE
#50: Add update notification with 24h cache

### DIFF
--- a/breakfast.py
+++ b/breakfast.py
@@ -358,8 +358,23 @@ def generate_terminal_url_anchor(url, url_text="Link"):
     default=False,
     help="Output results as JSON instead of a table. Progress messages go to stderr.",
 )
+@click.option(
+    "--no-update-check",
+    is_flag=True,
+    default=False,
+    envvar="BREAKFAST_NO_UPDATE_CHECK",
+    help="Disable the automatic update check.",
+)
 @click.version_option(package_name="breakfast")
-def breakfast(organization, repo_filter, ignore_author, mine_only, age, json_output):
+def breakfast(
+    organization,
+    repo_filter,
+    ignore_author,
+    mine_only,
+    age,
+    json_output,
+    no_update_check,
+):
     if SECRET_GITHUB_TOKEN is None:
         message = "GITHUB_TOKEN not set in environment - exiting..."
         click.echo(click.style(message, fg="red", bold=True))
@@ -427,9 +442,10 @@ def breakfast(organization, repo_filter, ignore_author, mine_only, age, json_out
             click.echo(random.choices(BREAKFAST_ITEMS)[0], nl=False, err=True)
         click.echo("...Done", err=True)
         click.echo(json.dumps(json_data, indent=2))
-        update_msg = check_for_update()
-        if update_msg:
-            click.echo(click.style(update_msg, fg="cyan", bold=True), err=True)
+        if not no_update_check:
+            update_msg = check_for_update()
+            if update_msg:
+                click.echo(click.style(update_msg, fg="cyan", bold=True), err=True)
         return
 
     for pr_detail in pr_details:
@@ -465,9 +481,10 @@ def breakfast(organization, repo_filter, ignore_author, mine_only, age, json_out
         tabulate(pr_data, headers="keys", showindex="always", tablefmt="outline")
     )
 
-    update_msg = check_for_update()
-    if update_msg:
-        click.echo(click.style(update_msg, fg="cyan", bold=True), err=True)
+    if not no_update_check:
+        update_msg = check_for_update()
+        if update_msg:
+            click.echo(click.style(update_msg, fg="cyan", bold=True), err=True)
 
 
 if __name__ == "__main__":

--- a/docs/manual/options.md
+++ b/docs/manual/options.md
@@ -145,6 +145,16 @@ breakfast automatically checks for new versions once per day (cached for 24 hour
 
 The check is non-blocking and non-fatal — network failures are silently ignored. The notification is sent to stderr so it won't interfere with `--json` output piping.
 
+To disable the update check:
+
+```bash
+# Via CLI flag
+breakfast -o my-org -r my-app --no-update-check
+
+# Via environment variable (useful in CI or scripts)
+export BREAKFAST_NO_UPDATE_CHECK=1
+```
+
 ## Other options
 
 ### `--version`

--- a/test_breakfast.py
+++ b/test_breakfast.py
@@ -637,3 +637,46 @@ def test_write_and_read_version_cache(monkeypatch, tmp_path):
 
     breakfast._write_version_cache("3.0.0")
     assert breakfast._read_version_cache() == "3.0.0"
+
+
+def test_no_update_check_flag_skips_update(monkeypatch):
+    monkeypatch.setattr(breakfast, "SECRET_GITHUB_TOKEN", "token-123")
+    monkeypatch.setattr(breakfast, "BREAKFAST_ITEMS", ["*"])
+    monkeypatch.setattr(breakfast, "get_github_prs", lambda _o, _r: [])
+    check_called = []
+    monkeypatch.setattr(
+        breakfast,
+        "check_for_update",
+        lambda: check_called.append(1) or "update!",
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        breakfast.breakfast,
+        ["-o", "org", "-r", "repo", "--no-update-check"],
+    )
+
+    assert result.exit_code == 0
+    assert len(check_called) == 0
+
+
+def test_no_update_check_env_var(monkeypatch):
+    monkeypatch.setattr(breakfast, "SECRET_GITHUB_TOKEN", "token-123")
+    monkeypatch.setattr(breakfast, "BREAKFAST_ITEMS", ["*"])
+    monkeypatch.setattr(breakfast, "get_github_prs", lambda _o, _r: [])
+    monkeypatch.setenv("BREAKFAST_NO_UPDATE_CHECK", "1")
+    check_called = []
+    monkeypatch.setattr(
+        breakfast,
+        "check_for_update",
+        lambda: check_called.append(1) or "update!",
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        breakfast.breakfast,
+        ["-o", "org", "-r", "repo"],
+    )
+
+    assert result.exit_code == 0
+    assert len(check_called) == 0


### PR DESCRIPTION
## Issue

Closes #50

## Description

Adds automatic update checking so users know when a newer version of breakfast is available. Keeps it lightweight with file-based caching and completely non-fatal error handling.

## Changes

- **`breakfast.py`** — Add `get_latest_version()`, `check_for_update()`, and cache helpers. Query GitHub releases API, compare semver tuples, show notification on stderr after main output
- **`test_breakfast.py`** — 8 new tests covering version parsing, update detection, cache read/write, expired cache, API failures
- **`docs/manual/options.md`** — Document update notification behaviour

## How it works

- After displaying PR results, checks GitHub for the latest release
- Results cached in `~/.cache/breakfast/latest_version.json` for 24 hours
- If a newer version exists, shows: `🍳 A fresh breakfast is ready! v0.10.0 → v0.11.0`
- Notification goes to stderr (won't break `--json` piping)
- Any failure (network, API, cache) is silently swallowed

## Testing

- [x] `make test` passes (34 tests)
- [x] `make lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)