### PR TITLE
#70: Fix release bump push from detached HEAD

### DIFF
--- a/utils/bump_version_if_tag_exists.sh
+++ b/utils/bump_version_if_tag_exists.sh
@@ -4,13 +4,21 @@ set -euo pipefail
 version="$1"
 
 if git rev-parse -q --verify "refs/tags/v${version}" >/dev/null; then
+  branch_name="$(git symbolic-ref --quiet --short HEAD || true)"
+  branch_name="${branch_name:-${GITHUB_HEAD_REF:-${GITHUB_REF_NAME:-}}}"
+
+  if [[ -z "${branch_name}" ]]; then
+    echo "Unable to determine branch name for release version bump" >&2
+    exit 1
+  fi
+
   git config user.name "github-actions[bot]"
   git config user.email "github-actions[bot]@users.noreply.github.com"
   git mkver patch >/dev/null
   version=$(python utils/read_version.py)
   git add pyproject.toml
   git commit -m "chore: bump version to ${version}" >/dev/null
-  git push >/dev/null 2>&1
+  git push origin "HEAD:${branch_name}" >/dev/null
 fi
 
 printf '%s\n' "$version"


### PR DESCRIPTION
## Issue

Closes #70

## Description

Fix the release version-bump helper so it can push the generated bump commit when GitHub Actions is running on a detached `HEAD`.

## Changes

- detect the target branch name from the current branch or GitHub Actions branch environment variables
- fail clearly if no branch name can be determined for the version bump
- push the bump commit with an explicit `HEAD:<branch>` refspec instead of a bare `git push`

## Testing

- [x] `make test` passes
- [x] `make lint` passes

## Notes

Validated the detached-`HEAD` release path against a local bare `origin`; the patched helper successfully pushed the bump commit back to `main`.
