### PR TITLE
#81: Fix install and build instructions for clean environments

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ Thanks for your interest in contributing to **breakfast**! This guide covers set
 ## Prerequisites
 
 - Python >= 3.11
-- [uv](https://docs.astral.sh/uv/) package manager (not pip)
+- [uv](https://docs.astral.sh/uv/) package manager (not pip). If you do not already have it, install it with `python -m pip install --user uv`.
 - A `GITHUB_TOKEN` environment variable for running the tool
 
 ## Getting Started

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
 .ONESHELL:
 SHELL = /bin/bash
 
+.PHONY: activate build version-bump release breakfast smoketest test lint format
+
 .venv:
 	uv venv .venv
 	uv sync --extra dev
@@ -8,7 +10,8 @@ SHELL = /bin/bash
 activate: .venv
 	. .venv/bin/activate
 
-build: activate
+build:
+	uv sync --extra build
 	uv run shiv -c breakfast -o breakfast .
 
 version-bump:

--- a/docs/manual/installation.md
+++ b/docs/manual/installation.md
@@ -5,9 +5,17 @@
 - Python 3.11 or later
 - A [GitHub personal access token](https://github.com/settings/tokens) with `repo` scope
 
+## Install uv
+
+If you do not already have [uv](https://docs.astral.sh/uv/), install it first:
+
+```bash
+python -m pip install --user uv
+```
+
 ## Install from source
 
-Clone the repository and install with [uv](https://docs.astral.sh/uv/):
+Clone the repository and install the runtime dependencies:
 
 ```bash
 git clone https://github.com/mrsixw/breakfast.git
@@ -20,7 +28,8 @@ uv sync
 breakfast can be built as a standalone [shiv](https://github.com/linkedin/shiv) executable:
 
 ```bash
-make build
+uv sync --extra build
+uv run shiv -c breakfast -o breakfast .
 ```
 
 This produces a `./breakfast` binary that can be copied anywhere on your `PATH`.


### PR DESCRIPTION
## Issue

Closes #81

## Description

Fixes the clean-environment install and build workflow so the documentation and Makefile match the actual dependency requirements.

## Changes

- document how to install `uv` before running project setup commands
- update the install guide to sync the `build` extra before invoking `shiv`
- make `make build` sync `--extra build` itself and mark path-colliding Make targets as `.PHONY`

## Testing

- [x] `make test` passes
- [x] `make lint` passes

## Notes

Validated the revised install/build flow in fresh `python:3.11` Docker containers, covering both the missing-`uv` and missing-`shiv` failure modes. No `.pre-commit-config.yaml` or repository Dockerfile is present in this repository.