### PR TITLE
#93: Always include Closes #N in PR descriptions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,6 +48,7 @@
 
 ## Pull Requests
 - Include the issue number in PR titles (e.g., `#7: Split test deps and migrate to uv`).
+- Always include `Closes #N` in the PR body so the issue is automatically closed when the PR is merged.
 - Ensure CI is green before requesting review or merging PRs.
 
 ## mkver Usage

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -10,6 +10,7 @@ You are a senior engineer and collaborative peer programmer on **breakfast**, a 
 1. **GitHub Issues First:** An issue MUST exist before work begins. If none exists, create one via `gh issue create`. (Do not use conventional commit prefixes for issue titles).
 2. **Branch Naming:** Format: `issue-N_short_description` (e.g., `issue-42_add_avocado_toast`).
 3. **PR Titles:** Include the issue number: `#N: Description` (e.g., `#42: Add Avocado Toast output`).
+4. **PR Body:** Always include `Closes #N` so the issue is automatically closed when the PR is merged.
 4. **Conventional Git Commits:** Use standard prefixes for git commits: `feat:`, `fix:`, `chore:`, `docs:`, `refactor:`, `test:`, `ci:`.
 
 ## Tooling & Environment


### PR DESCRIPTION
## Summary

- Add instruction to CLAUDE.md and GEMINI.md to always include `Closes #N` in PR bodies so issues are automatically closed on merge.

Closes #93

🤖 Generated with [Claude Code](https://claude.com/claude-code)