### PR TITLE
#95: Fix non-portable shebang in release binary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,10 +119,15 @@ jobs:
     runs-on: ubuntu-latest
     needs: release
     steps:
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
       - name: Install latest release
         run: |
           curl -sSL https://raw.githubusercontent.com/${{ github.repository }}/${{ github.sha }}/install.sh | bash
-      
+
       - name: Verify installation
         run: |
           ~/.local/bin/breakfast --version

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ activate: .venv
 build: .venv
 
 	uv sync --extra build
-	uv run shiv -c breakfast -o breakfast --python "$(shell uv python find)" .
+	uv run shiv -c breakfast -o breakfast --python '/usr/bin/env python3' .
 
 version-bump:
 	git mkver patch


### PR DESCRIPTION
## Summary

- Replaces `--python "$(uv python find)"` (absolute CI runner path) with `--python '/usr/bin/env python3'` in the shiv build command
- Adds a `setup-python 3.11` step to the `verify-release` job so `python3` is available when the installed binary runs

## Why it was broken

The shiv binary embedded an absolute path like `/opt/hostedtoolcache/Python/3.11.x/bin/python3.11` as its shebang. This path exists on the `build` runner but not on the fresh `verify-release` runner, causing `cannot execute: required file not found` on every release.

## Test plan

- [ ] CI passes on this PR (build + lint + test)
- [ ] After merge, `verify-release` job succeeds and `~/.local/bin/breakfast --version` runs correctly

Closes #95