### PR TITLE
fix: improve auto-fit table width handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ breakfast -o my-org -r my-app --ignore-author dependabot[bot] --ignore-author re
 breakfast -o my-org -r my-app --mine-only
 breakfast -o my-org -r my-app --age
 breakfast -o my-org -r my-app --checks
+breakfast -o my-org -r my-app --checks --status-style ascii
 breakfast -o my-org -r my-app --json
 ```
 
@@ -37,6 +38,7 @@ breakfast -o my-org -r my-app --json
 - `--mine-only`: Show only your own PRs.
 - `--age`: Add an age column (days since creation).
 - `--checks`: Add a checks column showing CI status (pass/fail/pending/none).
+- `--status-style`: Render status cells with emoji (default) or ASCII labels.
 - `--json`: Output as JSON instead of a table.
 - `--version`: Show version.
 

--- a/docs/manual/options.md
+++ b/docs/manual/options.md
@@ -146,9 +146,9 @@ Processing platform PRs...🍩🧇...Done
 +---------+----------------+-----------------+--------+---------+-------+---------+------------+----------+----------+--------------+--------+
 |         | Repo           | PR Title        | Author | State   | Files | Commits |    +/-     | Comments | Checks   | Mergeable?   | Link   |
 +---------+----------------+-----------------+--------+---------+-------+---------+------------+----------+----------+--------------+--------+
-|       0 | platform-api   | Add user search | alice  | open    |   3   |    1    |  +42/-10   |    0     | pass     | ✅ (clean)   | PR-142 |
-|       1 | platform-api   | Fix login bug   | bob    | open    |   1   |    1    |  +5/-2     |    3     | fail     | ✅ (clean)   | PR-138 |
-|       2 | platform-ui    | Update nav bar  | carol  | open    |  12   |    4    |  +280/-95  |    1     | pending  | ❌ (dirty)   | PR-87  |
+|       0 | platform-api   | Add user search | alice  | open    |   3   |    1    |  +42/-10   |    0     | ✅ pass  | ✅ (clean)   | PR-142 |
+|       1 | platform-api   | Fix login bug   | bob    | open    |   1   |    1    |  +5/-2     |    3     | ❌ fail  | ✅ (clean)   | PR-138 |
+|       2 | platform-ui    | Update nav bar  | carol  | open    |  12   |    4    |  +280/-95  |    1     | ⚠️ pending | ❌ (dirty)   | PR-87  |
 +---------+----------------+-----------------+--------+---------+-------+---------+------------+----------+----------+--------------+--------+
 ```
 
@@ -167,6 +167,24 @@ With `--json --checks`, a `"checks"` field is included in each PR object:
   "checks": "pass",
   ...
 }
+```
+
+### `--status-style`
+
+Choose how the `Checks` and `Mergeable?` columns are rendered in table output.
+
+```bash
+breakfast -o my-org -r platform --checks --status-style ascii
+```
+
+Supported values:
+- `emoji` - default whimsical output, such as `✅ pass` and `❌ (dirty)`
+- `ascii` - terminal-safe fallback, such as `pass` and `no (dirty)`
+
+This is also available in config:
+
+```toml
+status-style = "ascii"
 ```
 
 ### Auto-fit to terminal width
@@ -255,16 +273,30 @@ $ breakfast --help
 Usage: breakfast [OPTIONS]
 
 Options:
-  -o, --organization TEXT  One or multiple organizations to report on
-  -r, --repo-filter TEXT   Filter for specific repp(s)
-  --ignore-author TEXT     Ignore PRs raised by one or more authors
-                           (case-insensitive). Repeat for multiple authors,
-                           e.g. --ignore-author dependabot[bot].
-  --mine-only              Only include PRs authored by the currently
-                           authenticated GitHub user.
-  --age                    Include an age column showing PR age in days.
-  --json                   Output results as JSON instead of a table. Progress
-                           messages go to stderr.
-  --version                Show the version and exit.
-  --help                   Show this message and exit.
+  --config TEXT                 Path to config file.
+  --show-config                 Print the resolved config and exit.
+  --init-config                 Generate a default config file and exit.
+  -o, --organization TEXT       One or multiple organizations to report on
+  -r, --repo-filter TEXT        Filter for specific repp(s)
+  --ignore-author TEXT          Ignore PRs raised by one or more authors
+                                (case-insensitive). Repeat for multiple
+                                authors, e.g. --ignore-author
+                                dependabot[bot].
+  --no-ignore-author            Clear config defaults for ignore-author.
+  --mine-only / --no-mine-only  Only include PRs authored by the currently
+                                authenticated GitHub user.
+  --age / --no-age              Include an age column showing PR age in days.
+  --json / --no-json            Output results as JSON instead of a table.
+                                Progress messages go to stderr.
+  --checks / --no-checks        Include a checks column showing CI/check
+                                status for each PR.
+  --status-style [emoji|ascii]  Render status cells with emoji (default) or
+                                ASCII labels.
+  --limit INTEGER               Cap the number of PRs shown. Unset means show
+                                all results.
+  --max-title-length INTEGER    Truncate PR titles to this many characters.
+                                Unset means no truncation.
+  --no-update-check             Disable the automatic update check.
+  --version                     Show the version and exit.
+  --help                        Show this message and exit.
 ```

--- a/docs/manual/output-formats.md
+++ b/docs/manual/output-formats.md
@@ -32,6 +32,8 @@ The default output is a colour-coded terminal table with the following columns:
 | Mergeable? | Whether the PR can be merged cleanly |
 | Link | Clickable terminal hyperlink to the PR |
 
+Use `--status-style ascii` if your terminal font renders the status emoji with uneven column widths.
+
 ### Colour coding
 
 Numeric columns (Files, Commits, Comments, Age) are colour-graded:

--- a/docs/manual/troubleshooting.md
+++ b/docs/manual/troubleshooting.md
@@ -45,6 +45,20 @@ The "Link" column uses OSC 8 terminal hyperlinks. If you see escape codes instea
 
 Use `--json` output and extract the `url` field as an alternative.
 
+## Table columns drift around `Checks` or `Mergeable?`
+
+Some terminal and font combinations render the status emoji at uneven widths. If the `|` separators stop lining up, switch the status cells to ASCII:
+
+```bash
+breakfast -o my-org -r my-app --checks --status-style ascii
+```
+
+Or set it once in config:
+
+```toml
+status-style = "ascii"
+```
+
 ## "GraphQL request failed" errors
 
 This typically means the organization name is incorrect or your token doesn't have access to the organization. Verify:

--- a/docs/manual/usage.md
+++ b/docs/manual/usage.md
@@ -111,6 +111,12 @@ breakfast -o my-org -r my-app \
   --mine-only
 ```
 
+### Use ASCII status labels for terminal compatibility
+
+```bash
+breakfast -o my-org -r platform --checks --status-style ascii
+```
+
 ## How it works
 
 1. **Fetch repositories** - Uses the GitHub GraphQL API to paginate through all repositories in the organization

--- a/src/breakfast/cli.py
+++ b/src/breakfast/cli.py
@@ -20,6 +20,7 @@ from .ui import (
     BREAKFAST_ITEMS,
     click_colour_grade_number,
     format_check_status,
+    format_mergeable_status,
     generate_terminal_url_anchor,
 )
 from .updater import check_for_update
@@ -36,11 +37,11 @@ def _strip_ansi(s):
 
 def _table_width(rows):
     """Return visual table width via the border line (ANSI-stripped for accuracy)."""
-    plain_rows = [{k: _strip_ansi(v) for k, v in row.items()} for row in rows[:1]]
+    plain_rows = [{k: _strip_ansi(v) for k, v in row.items()} for row in rows]
     table_str = tabulate(
         plain_rows, headers="keys", showindex="always", tablefmt="outline"
     )
-    return len(table_str.split("\n")[0])
+    return len(table_str.splitlines()[0])
 
 
 def _truncate_col(pr_data, key, terminal_width, min_len=8):
@@ -105,7 +106,7 @@ def _auto_fit(pr_data, terminal_width, explicit_max_title_length):
     if fits():
         return pr_data
 
-    # 4. Compress Mergeable?: "✅ (clean)" → "✅"
+    # 4. Compress Mergeable?: drop the reason suffix
     if "Mergeable?" in pr_data[0]:
         pr_data = [
             {**row, "Mergeable?": re.sub(r" \(.*\)$", "", row["Mergeable?"])}
@@ -114,7 +115,7 @@ def _auto_fit(pr_data, terminal_width, explicit_max_title_length):
     if fits():
         return pr_data
 
-    # 5. Compress Checks: "✅ pass" → "✅" (strip ANSI then keep emoji token)
+    # 5. Compress Checks: "✅ pass" → "✅", "pending" → "pending"
     if "Checks" in pr_data[0]:
         pr_data = [
             {**row, "Checks": _strip_ansi(row["Checks"]).split()[0]} for row in pr_data
@@ -208,6 +209,12 @@ def get_pr_age_days(pr_detail, now=None):
     help="Include a checks column showing CI/check status for each PR.",
 )
 @click.option(
+    "--status-style",
+    type=click.Choice(["emoji", "ascii"], case_sensitive=False),
+    default=None,
+    help="Render status cells with emoji (default) or ASCII labels.",
+)
+@click.option(
     "--limit",
     type=int,
     default=None,
@@ -239,6 +246,7 @@ def breakfast(
     age,
     json_output,
     checks,
+    status_style,
     limit,
     max_title_length,
     no_update_check,
@@ -263,11 +271,15 @@ def breakfast(
     if json_output is None:
         json_output = cfg.get("format") == "json"
     checks = checks if checks is not None else cfg.get("checks", False)
+    if status_style is None:
+        status_style = str(cfg.get("status-style", "emoji")).lower()
     max_title_length = (
         max_title_length
         if max_title_length is not None
         else cfg.get("max-title-length")
     )
+    if status_style not in {"emoji", "ascii"}:
+        status_style = "emoji"
 
     if show_config:
         click.echo("Resolved config:")
@@ -279,6 +291,7 @@ def breakfast(
             "age": age,
             "json": json_output,
             "checks": checks,
+            "status-style": status_style,
             "max-title-length": max_title_length,
         }
         for k, v in resolved.items():
@@ -387,8 +400,6 @@ def breakfast(
         return
 
     for pr_detail in pr_details:
-        mergable = "✅" if pr_detail["mergeable"] else "❌"
-        mergable_state = pr_detail["mergeable_state"]
         adds = click.style("+" + str(pr_detail["additions"]), fg="green", bold=True)
         subs = click.style("-" + str(pr_detail["deletions"]), fg="red", bold=True)
 
@@ -406,9 +417,14 @@ def breakfast(
             row["Age"] = click_colour_grade_number(get_pr_age_days(pr_detail))
         if checks:
             row["Checks"] = format_check_status(
-                check_statuses.get(pr_detail["id"], "none")
+                check_statuses.get(pr_detail["id"], "none"),
+                style=status_style,
             )
-        row["Mergeable?"] = f"{mergable} ({mergable_state})"
+        row["Mergeable?"] = format_mergeable_status(
+            pr_detail["mergeable"],
+            pr_detail["mergeable_state"],
+            style=status_style,
+        )
         row["Link"] = generate_terminal_url_anchor(
             pr_detail["html_url"],
             f"PR-{pr_detail['number']}",

--- a/src/breakfast/config.py
+++ b/src/breakfast/config.py
@@ -70,6 +70,9 @@ def generate_default_config():
 # Always show CI/check status for each PR
 # checks = true
 
+# Render status cells using "emoji" (default) or "ascii"
+# status-style = "emoji"
+
 # Default output format: "table" or "json"
 # format = "table"
 

--- a/src/breakfast/ui.py
+++ b/src/breakfast/ui.py
@@ -50,15 +50,53 @@ def click_colour_grade_number(num):
     return click.style(str(num), fg=colour, bold=True)
 
 
-def format_check_status(status):
+def format_check_status(status, style="emoji"):
+    """Return a colour-coded check status label for table output.
+
+    Args:
+        status: Canonical CI status value such as ``pass`` or ``pending``.
+        style: Rendering style, either ``emoji`` or ``ascii``.
+
+    Returns:
+        A styled label in the requested style.
+    """
     styles = {
-        "pass": ("green", "✅ pass"),
-        "fail": ("red", "❌ fail"),
-        "pending": ("yellow", "⚠️ pending"),
-        "none": ("white", "➖ none"),
+        "emoji": {
+            "pass": ("green", "✅ pass"),
+            "fail": ("red", "❌ fail"),
+            "pending": ("yellow", "⚠️ pending"),
+            "none": ("white", "➖ none"),
+        },
+        "ascii": {
+            "pass": ("green", "pass"),
+            "fail": ("red", "fail"),
+            "pending": ("yellow", "pending"),
+            "none": ("white", "none"),
+        },
     }
-    colour, text = styles.get(status, ("white", status))
+    style_map = styles.get(style, styles["emoji"])
+    colour, text = style_map.get(status, ("white", status))
     return click.style(text, fg=colour, bold=True)
+
+
+def format_mergeable_status(is_mergeable, mergeable_state, style="emoji"):
+    """Return a mergeability label for table output.
+
+    Args:
+        is_mergeable: Whether GitHub reports the PR as mergeable.
+        mergeable_state: GitHub's mergeable-state detail such as ``clean``.
+        style: Rendering style, either ``emoji`` or ``ascii``.
+
+    Returns:
+        A label such as ``✅ (clean)`` or ``yes (clean)``.
+    """
+    if style == "ascii":
+        prefix = "yes" if is_mergeable else "no"
+    else:
+        prefix = "✅" if is_mergeable else "❌"
+    if mergeable_state:
+        return f"{prefix} ({mergeable_state})"
+    return prefix
 
 
 def generate_terminal_url_anchor(url, url_text="Link"):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 
 import requests
 from click.testing import CliRunner
+from tabulate import tabulate
 
 from breakfast import api, cli
 
@@ -68,6 +69,7 @@ def test_cli_outputs_table(monkeypatch):
     assert result.exit_code == 0
     assert "PR-1" in result.output
     assert "repo" in result.output
+    assert "✅ (clean)" in result.output
 
 
 def test_cli_outputs_age_column_when_enabled(monkeypatch):
@@ -319,7 +321,7 @@ def test_cli_outputs_checks_column(monkeypatch):
 
     assert result.exit_code == 0
     assert "Checks" in result.output
-    assert "pass" in result.output
+    assert "✅ pass" in result.output
 
 
 def test_cli_checks_no_collision_across_repos(monkeypatch):
@@ -434,6 +436,22 @@ def test_cli_checks_not_shown_by_default(monkeypatch):
 
     assert result.exit_code == 0
     assert "Checks" not in result.output
+
+
+def test_cli_show_config_includes_status_style_from_config(tmp_path):
+    cfg_path = tmp_path / "breakfast.toml"
+    cfg_path.write_text(
+        'organization = "org"\n'
+        'repo-filter = "repo"\n'
+        "checks = true\n"
+        'status-style = "ascii"\n'
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(cli.breakfast, ["--config", str(cfg_path), "--show-config"])
+
+    assert result.exit_code == 0
+    assert "status-style: ascii" in result.output
 
 
 def test_cli_json_includes_checks_when_enabled(monkeypatch):
@@ -709,6 +727,125 @@ def _make_pr_fixture(title="Test PR", number=1):
         "html_url": f"https://github.com/org/repo/pull/{number}",
         "number": number,
     }
+
+
+def test_auto_fit_measures_later_rows_when_fitting_table():
+    rows = [
+        {
+            "Repo": "short",
+            "PR Title": "short",
+            "Author": "alice",
+            "State": "open",
+            "Files": "1",
+            "Commits": "1",
+            "+/-": "+1/-0",
+            "Comments": "0",
+            "Mergeable?": "yes (clean)",
+            "Link": "PR-1",
+        },
+        {
+            "Repo": "a-very-long-repository-name-that-should-be-truncated",
+            "PR Title": "short",
+            "Author": "alice",
+            "State": "open",
+            "Files": "1",
+            "Commits": "1",
+            "+/-": "+1/-0",
+            "Comments": "0",
+            "Mergeable?": "yes (clean)",
+            "Link": "PR-2",
+        },
+    ]
+
+    terminal_width = cli._table_width(rows[:1])
+    fitted_rows = cli._auto_fit(rows, terminal_width, explicit_max_title_length=None)
+    rendered_width = len(
+        tabulate(
+            fitted_rows, headers="keys", showindex="always", tablefmt="outline"
+        ).splitlines()[0]
+    )
+
+    assert rendered_width <= terminal_width
+    assert fitted_rows[1]["Repo"].endswith("…")
+
+
+def test_cli_status_columns_use_ascii_to_keep_rows_aligned(monkeypatch):
+    monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
+    monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
+    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+
+    def fake_get_prs(_org, _repo_filter):
+        return [
+            "https://github.com/org/repo/pull/1",
+            "https://github.com/org/repo/pull/2",
+            "https://github.com/org/repo/pull/3",
+            "https://github.com/org/repo/pull/4",
+        ]
+
+    pr_details = {
+        "/repos/org/repo/pulls/1": _make_pr_fixture(number=1),
+        "/repos/org/repo/pulls/2": _make_pr_fixture(number=2),
+        "/repos/org/repo/pulls/3": _make_pr_fixture(number=3),
+        "/repos/org/repo/pulls/4": _make_pr_fixture(number=4),
+    }
+    for idx, pr_detail in enumerate(pr_details.values(), start=1):
+        pr_detail["base"]["repo"]["owner"] = {"login": "org"}
+        pr_detail["head"] = {"sha": f"sha-{idx}"}
+        pr_detail["id"] = 1000 + idx
+
+    pr_details["/repos/org/repo/pulls/3"]["mergeable"] = False
+    pr_details["/repos/org/repo/pulls/3"]["mergeable_state"] = "dirty"
+    pr_details["/repos/org/repo/pulls/4"]["mergeable_state"] = "blocked"
+
+    check_runs = {
+        "/repos/org/repo/commits/sha-1/check-runs": {
+            "check_runs": [{"status": "completed", "conclusion": "success"}]
+        },
+        "/repos/org/repo/commits/sha-1/status": {"statuses": []},
+    }
+
+    check_runs["/repos/org/repo/commits/sha-2/check-runs"] = {
+        "check_runs": [{"status": "in_progress", "conclusion": None}]
+    }
+    check_runs["/repos/org/repo/commits/sha-2/status"] = {"statuses": []}
+    check_runs["/repos/org/repo/commits/sha-3/check-runs"] = {
+        "check_runs": [{"status": "completed", "conclusion": "failure"}]
+    }
+    check_runs["/repos/org/repo/commits/sha-3/status"] = {"statuses": []}
+    check_runs["/repos/org/repo/commits/sha-4/check-runs"] = {"check_runs": []}
+    check_runs["/repos/org/repo/commits/sha-4/status"] = {"statuses": []}
+
+    def fake_api_request(path):
+        if path in check_runs:
+            return check_runs[path]
+        return pr_details[path]
+
+    monkeypatch.setattr(cli, "get_github_prs", fake_get_prs)
+    monkeypatch.setattr(api, "make_github_api_request", fake_api_request)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli.breakfast,
+        ["-o", "org", "-r", "repo", "--checks", "--status-style", "ascii"],
+    )
+
+    assert result.exit_code == 0
+    assert "yes (clean)" in result.output
+    assert "no (dirty)" in result.output
+    assert "pending" in result.output
+    assert "✅" not in result.output
+    assert "❌" not in result.output
+    assert "⚠️" not in result.output
+    assert "➖" not in result.output
+
+    table_lines = [
+        cli._strip_ansi(line)
+        for line in result.output.splitlines()
+        if line.startswith(("+", "|"))
+    ]
+    widths = {len(line) for line in table_lines}
+
+    assert len(widths) == 1
 
 
 def test_auto_fit_truncates_title_to_terminal_width(monkeypatch):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -63,6 +63,7 @@ def test_generate_default_config(tmp_path, monkeypatch):
     config_file = tmp_path / ".config" / "breakfast" / "config.toml"
     assert config_file.exists()
     assert 'organization = "my-org"' in config_file.read_text()
+    assert 'status-style = "emoji"' in config_file.read_text()
 
     # Second run: should not overwrite
     result2 = config.generate_default_config()

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -27,7 +27,17 @@ def test_generate_terminal_url_anchor():
 
 def test_format_check_status():
     result = ui.format_check_status("pass")
-    assert "pass" in result
+    assert "✅ pass" in result
 
     result = ui.format_check_status("fail")
-    assert "fail" in result
+    assert "❌ fail" in result
+
+    result = ui.format_check_status("pending", style="ascii")
+    assert "pending" in result
+    assert "⚠️" not in result
+
+
+def test_format_mergeable_status():
+    assert ui.format_mergeable_status(True, "clean") == "✅ (clean)"
+    assert ui.format_mergeable_status(False, "dirty") == "❌ (dirty)"
+    assert ui.format_mergeable_status(True, "clean", style="ascii") == "yes (clean)"


### PR DESCRIPTION
## Issue

Closes #91

## Description

Fix the remaining table-width handling regressions by measuring auto-fit across all rows and adding an opt-in ASCII status style for terminals that render the emoji status cells inconsistently.

## Changes

- Measure table width across all rows when auto-fitting instead of only the first row.
- Keep emoji status cells as the default output and add `--status-style` / `status-style` for an ASCII compatibility fallback.
- Add regression coverage for default emoji output, config resolution, and ASCII alignment fallback.
- Update the README and manual docs with the new compatibility mode and troubleshooting guidance.

## Testing

- [x] `make test` passes
- [x] `make lint` passes

## Notes

Default whimsical emoji output is preserved. Use `--status-style ascii` only as a terminal-compatibility fallback when status emoji render with uneven widths.