### PR TITLE
#46: Add TUI design document

### DIFF
--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -11,3 +11,4 @@ Each document captures the problem, proposed solution, and implementation approa
 | [Config File](config-file.md) | Proposed | [#42](https://github.com/mrsixw/breakfast/issues/42) |
 | [Demo Generation](demo-generation.md) | Implemented | [#80](https://github.com/mrsixw/breakfast/issues/80) |
 | [PR Caching](pr-caching.md) | Proposed | [#45](https://github.com/mrsixw/breakfast/issues/45) |
+| [Text User Interface](tui.md) | Proposed | [#46](https://github.com/mrsixw/breakfast/issues/46) |

--- a/docs/design/tui.md
+++ b/docs/design/tui.md
@@ -1,0 +1,33 @@
+# Design: Text User Interface (TUI)
+
+## Overview
+This document outlines the architecture for adding a Text User Interface (TUI) to the `breakfast` CLI. The goal is to provide an interactive way to view and manage GitHub PRs without losing the ability to run the tool in its original, static table mode.
+
+## Architecture
+
+### Framework
+We will use the **Textual** framework (`textual` package on PyPI). Textual is the modern standard for Python TUIs, built on top of `rich`. It provides a robust, event-driven, asynchronous architecture for building terminal applications.
+
+### Integration Approach: Threading
+The current `breakfast` architecture relies on synchronous API calls via the `requests` library (located in `api.py` / `src/breakfast/api.py`).
+
+To integrate this synchronous API with the asynchronous Textual framework without blocking the event loop (which would freeze the UI), we will adopt the **Threading** approach:
+
+1. **Async Wrapper:** We will use `asyncio.to_thread` within the Textual application to execute the existing, unmodified synchronous functions from `api.py`.
+2. **Preservation of CLI:** The existing `cli.py` (or `breakfast.py`) logic will remain synchronous. The TUI will be gated behind a new `--tui` flag.
+3. **Execution Flow:**
+   - If `breakfast` is run without `--tui`, it executes the traditional static table rendering.
+   - If `breakfast --tui` is executed, it parses configuration and launches the `Textual` app. The app's `on_mount` lifecycle event will trigger a background thread to fetch data via `api.get_github_prs()`.
+
+### Why Threading?
+Rewriting the API layer to use asynchronous I/O (e.g., `httpx`) would require either maintaining two parallel API modules or heavily refactoring the existing synchronous CLI to use `asyncio.run()`, adding unnecessary complexity and risk. The threading approach isolates the TUI complexity while leaving the proven CLI core untouched.
+
+## TUI Layout
+The TUI will consist of:
+- **Header:** Displaying the tool name and current context.
+- **Main Content:** A `DataTable` or custom list view to present PRs, reusing existing formatting logic (e.g., check status colors).
+- **Footer:** Displaying interactive keybindings (e.g., `q` to quit, `r` to refresh, `o` to open PR in browser, `enter` to view details).
+
+## Future Considerations
+- Adding a detail pane to view PR descriptions and comments.
+- Adding action buttons to approve or merge PRs directly from the TUI.


### PR DESCRIPTION
## Summary

- Adds `docs/design/tui.md` — design document for the Text User Interface feature
- Proposes Textual as the framework, with a threading approach to keep the existing synchronous API layer untouched
- Adds the TUI entry (with `#46` reference) to `docs/design/README.md`

## Design decisions captured

- **Framework:** Textual (async, event-driven, built on `rich`)
- **Integration:** `asyncio.to_thread` wraps the existing synchronous `api.py` calls — no rewrite of the API layer needed
- **Gating:** New `--tui` flag; default behaviour unchanged

Closes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)