### PR TITLE
#118: fix colour grading orange band not rendering

### DIFF
--- a/src/breakfast/ui.py
+++ b/src/breakfast/ui.py
@@ -46,7 +46,7 @@ def click_colour_grade_number(num):
     elif num < 20:
         colour = "yellow"
     elif num < 50:
-        colour = (255, 165, 0)  # orange
+        colour = 208  # orange (256-colour)
     return click.style(str(num), fg=colour, bold=True)
 
 

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -9,7 +9,7 @@ from breakfast import ui
     [
         (5, "green"),
         (15, "yellow"),
-        (30, (255, 165, 0)),
+        (30, 208),
         (60, "red"),
     ],
 )


### PR DESCRIPTION
## Summary

- `click_colour_grade_number()` was passing an RGB tuple `(255, 165, 0)` to `click.style()` for the orange band (values 20–49)
- Click emits a 24-bit true-colour ANSI sequence for tuples, which many terminals don't support — causing the orange band to silently fall back to the terminal default
- Replace with `208`, the standard 256-colour palette index for orange, which is widely supported

## Change

```python
# before
colour = (255, 165, 0)  # orange

# after
colour = 208  # orange (256-colour)
```

Closes #118

🤖 Generated with [Claude Code](https://claude.com/claude-code)