### PR TITLE
#121: Fix colour grading in table output and auto-fit compression

### DIFF
--- a/src/breakfast/cli.py
+++ b/src/breakfast/cli.py
@@ -58,7 +58,11 @@ def _table_width(rows):
     """Return visual table width via the border line (ANSI-stripped for accuracy)."""
     plain_rows = [{k: _strip_ansi(v) for k, v in row.items()} for row in rows]
     table_str = tabulate(
-        plain_rows, headers="keys", showindex="always", tablefmt="outline"
+        plain_rows,
+        headers="keys",
+        showindex="always",
+        tablefmt="outline",
+        disable_numparse=True,
     )
     return len(table_str.splitlines()[0])
 
@@ -100,6 +104,16 @@ def _truncate_col(pr_data, key, terminal_width, min_len=8):
     ]
 
 
+def _compress_styled(styled_text):
+    """Compress styled text to its first visible word, preserving ANSI colour."""
+    plain = _strip_ansi(styled_text)
+    words = plain.split()
+    if len(words) <= 1:
+        return styled_text
+    first_word = words[0]
+    return styled_text.replace(plain, first_word, 1)
+
+
 def _auto_fit(pr_data, terminal_width, explicit_max_title_length):
     """Progressively compress the table to fit within terminal_width."""
     if not pr_data:
@@ -127,8 +141,16 @@ def _auto_fit(pr_data, terminal_width, explicit_max_title_length):
 
     # 4. Compress Mergeable?: drop the reason suffix
     if "Mergeable?" in pr_data[0]:
+
+        def _compress_mergeable(val):
+            plain = _strip_ansi(val)
+            compressed = re.sub(r" \(.*\)$", "", plain)
+            if compressed != plain:
+                return val.replace(plain, compressed, 1)
+            return val
+
         pr_data = [
-            {**row, "Mergeable?": re.sub(r" \(.*\)$", "", row["Mergeable?"])}
+            {**row, "Mergeable?": _compress_mergeable(row["Mergeable?"])}
             for row in pr_data
         ]
     if fits():
@@ -143,19 +165,18 @@ def _auto_fit(pr_data, terminal_width, explicit_max_title_length):
     if fits():
         return pr_data
 
-    # 5. Compress Checks: "✅ pass" → "✅", "pending" → "pending"
+    # 5. Compress Checks: "✅ pass" → "✅" (preserving colour)
     if "Checks" in pr_data[0]:
         pr_data = [
-            {**row, "Checks": _strip_ansi(row["Checks"]).split()[0]} for row in pr_data
+            {**row, "Checks": _compress_styled(row["Checks"])} for row in pr_data
         ]
     if fits():
         return pr_data
 
-    # 5b. Compress Approved: "✅ approved" → "✅", "⏳ pending" → "⏳"
+    # 5b. Compress Approved: "✅ approved" → "✅" (preserving colour)
     if "Approved" in pr_data[0]:
         pr_data = [
-            {**row, "Approved": _strip_ansi(row["Approved"]).split()[0]}
-            for row in pr_data
+            {**row, "Approved": _compress_styled(row["Approved"])} for row in pr_data
         ]
     if fits():
         return pr_data
@@ -702,7 +723,14 @@ def breakfast(
         pr_data = _auto_fit(pr_data, terminal_width, max_title_length)
 
     click.echo(
-        tabulate(pr_data, headers="keys", showindex="always", tablefmt="outline")
+        tabulate(
+            pr_data,
+            headers="keys",
+            showindex="always",
+            tablefmt="outline",
+            disable_numparse=True,
+        ),
+        color=_stdout_is_tty(),
     )
 
     if not no_update_check:

--- a/src/breakfast/ui.py
+++ b/src/breakfast/ui.py
@@ -107,7 +107,7 @@ def format_approval_status(status, style="emoji"):
 
 
 def format_mergeable_status(is_mergeable, mergeable_state, style="emoji"):
-    """Return a mergeability label for table output.
+    """Return a colour-coded mergeability label for table output.
 
     Args:
         is_mergeable: Whether GitHub reports the PR as mergeable.
@@ -115,15 +115,18 @@ def format_mergeable_status(is_mergeable, mergeable_state, style="emoji"):
         style: Rendering style, either ``emoji`` or ``ascii``.
 
     Returns:
-        A label such as ``✅ (clean)`` or ``yes (clean)``.
+        A styled label such as ``✅ (clean)`` or ``yes (clean)``.
     """
+    colour = "green" if is_mergeable else "red"
     if style == "ascii":
         prefix = "yes" if is_mergeable else "no"
     else:
         prefix = "✅" if is_mergeable else "❌"
     if mergeable_state:
-        return f"{prefix} ({mergeable_state})"
-    return prefix
+        text = f"{prefix} ({mergeable_state})"
+    else:
+        text = prefix
+    return click.style(text, fg=colour, bold=True)
 
 
 def generate_terminal_url_anchor(url, url_text="Link"):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1497,3 +1497,54 @@ def test_refresh_prs_writes_fresh_pr_cache(monkeypatch, tmp_path):
 
     cached = cache.read_pr_cache("org", "repo", 300)
     assert cached is not None, "--refresh-prs should write fresh data to PR cache"
+
+
+def test_compress_styled_preserves_ansi_colour():
+    import click
+
+    styled = click.style("✅ pass", fg="green", bold=True)
+    compressed = cli._compress_styled(styled)
+    # Should keep the emoji but drop " pass"
+    assert "✅" in cli._strip_ansi(compressed)
+    assert "pass" not in cli._strip_ansi(compressed)
+    # ANSI colour codes should be preserved
+    assert "\x1b[" in compressed
+
+
+def test_compress_styled_noop_for_single_word():
+    import click
+
+    styled = click.style("✅", fg="green", bold=True)
+    assert cli._compress_styled(styled) == styled
+
+
+def test_compress_styled_plain_text():
+    assert cli._compress_styled("hello world") == "hello"
+    assert cli._compress_styled("single") == "single"
+
+
+def test_auto_fit_preserves_checks_colour(monkeypatch):
+    import click
+
+    styled_checks = click.style("✅ pass", fg="green", bold=True)
+    rows = [
+        {
+            "Repo": "myrepo",
+            "PR Title": "Some title",
+            "Author": "alice",
+            "State": "open",
+            "Files": "1",
+            "Commits": "1",
+            "+/-": "+1/-0",
+            "Comments": "0",
+            "Checks": styled_checks,
+            "Mergeable?": click.style("✅ (clean)", fg="green", bold=True),
+            "Link": "PR-1",
+        }
+    ]
+    # Very narrow width to force all compression steps
+    result = cli._auto_fit(rows, 80, explicit_max_title_length=None)
+    checks_key = "Checks" if "Checks" in result[0] else None
+    if checks_key:
+        # Colour should be preserved even after compression
+        assert "\x1b[" in result[0][checks_key]

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -58,6 +58,19 @@ def test_format_approval_status_ascii():
 
 
 def test_format_mergeable_status():
-    assert ui.format_mergeable_status(True, "clean") == "✅ (clean)"
-    assert ui.format_mergeable_status(False, "dirty") == "❌ (dirty)"
-    assert ui.format_mergeable_status(True, "clean", style="ascii") == "yes (clean)"
+    result = ui.format_mergeable_status(True, "clean")
+    assert "✅ (clean)" in result
+    assert "\x1b[" in result  # contains ANSI colour codes
+
+    result = ui.format_mergeable_status(False, "dirty")
+    assert "❌ (dirty)" in result
+    assert "\x1b[" in result
+
+    result = ui.format_mergeable_status(True, "clean", style="ascii")
+    assert "yes (clean)" in result
+
+    result = ui.format_mergeable_status(True, None)
+    assert "✅" in result
+
+    result = ui.format_mergeable_status(False, None)
+    assert "❌" in result


### PR DESCRIPTION
## Issue

Closes #121

## Description

Colour-graded columns (Age, Files, Commits, Comments) appeared as plain white text because `click.echo` was called without an explicit `color` parameter, causing ANSI codes to be stripped when stdout was not detected as a TTY. Additionally, the `_auto_fit` compression steps were stripping ANSI colour from Checks and Approved columns, and `format_mergeable_status()` had no colour styling at all.

## Changes

- Pass `color=_stdout_is_tty()` to `click.echo()` so ANSI colour codes are preserved in TTY contexts
- Add `_compress_styled()` helper that trims styled text to its first visible word while preserving ANSI colour codes
- Update `_auto_fit` steps 5 and 5b to use `_compress_styled()` instead of `_strip_ansi()` so Checks and Approved columns keep their colour after compression
- Add colour styling to `format_mergeable_status()` via `click.style()`, consistent with `format_check_status()` and `format_approval_status()`
- Update Mergeable? compression (step 4) to handle ANSI-wrapped values

## Testing

- [x] `make test` passes (all new tests pass; 31 pre-existing failures unrelated to this change)
- [x] `make lint` passes
- Added tests for `_compress_styled()` (colour preservation, single word noop, plain text)
- Added test for `_auto_fit` preserving Checks column colour
- Updated `test_format_mergeable_status` to verify ANSI colour codes are present

## Notes

The 31 pre-existing test failures on `main` are unrelated to this change (they appear identically with and without the fix).