### PR TITLE
#131 #132: add man page and shell completions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,10 +68,59 @@ jobs:
       - name: Verify binary version
         run: utils/check_binary_version.sh
 
+  man:
+    runs-on: ubuntu-latest
+    needs: [test, lint]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v3
+        with:
+          version: "latest"
+
+      - name: Generate man page
+        run: make man
+
+      - name: Verify man page
+        run: test -f man1/breakfast.1.gz
+
+  completions:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v3
+        with:
+          version: "latest"
+
+      - name: Generate completion scripts
+        run: make completions
+
+      - name: Verify completion scripts
+        run: |
+          test -f completions/breakfast.bash
+          test -f completions/_breakfast
+          test -f completions/breakfast.fish
+
   release:
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     runs-on: ubuntu-latest
-    needs: build
+    needs: [build, man, completions]
     permissions:
       contents: write
     steps:
@@ -108,6 +157,12 @@ jobs:
 
       - name: Build binary
         run: make release
+
+      - name: Generate man page
+        run: make man
+
+      - name: Generate completion scripts
+        run: make completions
 
       - name: Create release
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,7 @@ jobs:
 
   man:
     runs-on: ubuntu-latest
-    needs: [test, lint]
+    needs: [test, lint, spell]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,15 @@ jobs:
       - name: Verify binary version
         run: utils/check_binary_version.sh
 
+  spell:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Check spelling
+        uses: crate-ci/typos@master
+
   man:
     runs-on: ubuntu-latest
     needs: [test, lint]
@@ -93,7 +102,7 @@ jobs:
 
   completions:
     runs-on: ubuntu-latest
-    needs: build
+    needs: [test, lint]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.gitignore
+++ b/.gitignore
@@ -175,3 +175,7 @@ cython_debug/
 
 # Local shiv build output
 /breakfast
+
+# Generated build artifacts
+/completions/
+/man1/

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .ONESHELL:
 SHELL = /bin/bash
 
-.PHONY: activate build version-bump release breakfast smoketest test lint format
+.PHONY: activate build version-bump release breakfast smoketest test lint format man completions
 
 .venv:
 	uv venv .venv
@@ -41,3 +41,16 @@ format: .venv
 	uv sync --extra lint
 	uv run ruff check --fix .
 	uv run black .
+
+man: .venv
+	uv sync --extra build
+	mkdir -p man1
+	uv run python utils/generate_man_page.py man1
+	gzip -f man1/breakfast.1
+
+completions: .venv
+	uv sync
+	mkdir -p completions
+	_BREAKFAST_COMPLETE=bash_source uv run breakfast > completions/breakfast.bash
+	_BREAKFAST_COMPLETE=zsh_source uv run breakfast > completions/_breakfast
+	_BREAKFAST_COMPLETE=fish_source uv run breakfast > completions/breakfast.fish

--- a/docs/manual/installation.md
+++ b/docs/manual/installation.md
@@ -52,3 +52,46 @@ uv run breakfast --version
 # If using the built binary
 ./breakfast --version
 ```
+
+## Shell completions
+
+The installer (`install.sh`) automatically installs tab-completion scripts for bash, zsh, and fish. After installation, you may need to activate them for your shell:
+
+**Bash** — source the script in your `~/.bashrc`:
+```bash
+source ~/.local/share/bash-completion/completions/breakfast
+```
+Or, if your system loads all files from `~/.local/share/bash-completion/completions/` automatically (common with `bash-completion` ≥ 2.x), no action is needed.
+
+**Zsh** — add the install directory to your `fpath` in `~/.zshrc` before calling `compinit`:
+```zsh
+fpath=(~/.local/share/zsh/site-functions $fpath)
+autoload -Uz compinit && compinit
+```
+
+**Fish** — completions in `~/.config/fish/completions/` are loaded automatically. No further action needed.
+
+To regenerate completions manually from source:
+```bash
+make completions   # writes to completions/
+```
+
+## Man page
+
+The installer places the man page at `~/.local/share/man/man1/breakfast.1.gz`. To use it:
+
+```bash
+man breakfast
+```
+
+If `man` can't find it, ensure your `MANPATH` includes `~/.local/share/man`:
+```bash
+export MANPATH="${HOME}/.local/share/man:${MANPATH}"
+```
+
+Add this line to your shell profile (`~/.zshrc`, `~/.bashrc`, etc.) to make it permanent.
+
+To regenerate the man page from source:
+```bash
+make man   # writes to man1/breakfast.1.gz
+```

--- a/docs/manual/installation.md
+++ b/docs/manual/installation.md
@@ -12,6 +12,8 @@ This script will:
 1. Download the latest `breakfast` binary from GitHub Releases.
 2. Install it to `~/.local/bin/breakfast`.
 3. Initialize a default configuration file at `~/.config/breakfast/config.toml`.
+4. Install the man page to `~/.local/share/man/man1/breakfast.1.gz`.
+5. Install tab-completion scripts for bash, zsh, and fish.
 
 ## Advanced: Install from source
 

--- a/install.sh
+++ b/install.sh
@@ -54,7 +54,7 @@ echo -e "${YELLOW}Initializing default configuration...${RESET}"
 # Install man page
 echo -e "${YELLOW}Installing man page...${RESET}"
 mkdir -p "${MAN_DIR}"
-if curl -sL "${RELEASE_BASE_URL}/breakfast.1.gz" -o "${MAN_DIR}/breakfast.1.gz"; then
+if curl -sfL "${RELEASE_BASE_URL}/breakfast.1.gz" -o "${MAN_DIR}/breakfast.1.gz"; then
     echo -e "${GREEN}📖 Man page installed. Run: ${BOLD}man breakfast${RESET}"
 else
     echo -e "${YELLOW}⚠️  Could not install man page (non-fatal).${RESET}"
@@ -64,21 +64,21 @@ fi
 echo -e "${YELLOW}Installing shell completions...${RESET}"
 
 mkdir -p "${BASH_COMPLETION_DIR}"
-if curl -sL "${RELEASE_BASE_URL}/breakfast.bash" -o "${BASH_COMPLETION_DIR}/breakfast"; then
+if curl -sfL "${RELEASE_BASE_URL}/breakfast.bash" -o "${BASH_COMPLETION_DIR}/breakfast"; then
     echo -e "${GREEN}✅ Bash completion installed.${RESET}"
 else
     echo -e "${YELLOW}⚠️  Could not install bash completion (non-fatal).${RESET}"
 fi
 
 mkdir -p "${ZSH_COMPLETION_DIR}"
-if curl -sL "${RELEASE_BASE_URL}/_breakfast" -o "${ZSH_COMPLETION_DIR}/_breakfast"; then
+if curl -sfL "${RELEASE_BASE_URL}/_breakfast" -o "${ZSH_COMPLETION_DIR}/_breakfast"; then
     echo -e "${GREEN}✅ Zsh completion installed.${RESET}"
 else
     echo -e "${YELLOW}⚠️  Could not install zsh completion (non-fatal).${RESET}"
 fi
 
 mkdir -p "${FISH_COMPLETION_DIR}"
-if curl -sL "${RELEASE_BASE_URL}/breakfast.fish" -o "${FISH_COMPLETION_DIR}/breakfast.fish"; then
+if curl -sfL "${RELEASE_BASE_URL}/breakfast.fish" -o "${FISH_COMPLETION_DIR}/breakfast.fish"; then
     echo -e "${GREEN}✅ Fish completion installed.${RESET}"
 else
     echo -e "${YELLOW}⚠️  Could not install fish completion (non-fatal).${RESET}"

--- a/install.sh
+++ b/install.sh
@@ -6,6 +6,10 @@ REPO="mrsixw/breakfast"
 BINARY_NAME="breakfast"
 INSTALL_DIR="${HOME}/.local/bin"
 EXECUTABLE_PATH="${INSTALL_DIR}/${BINARY_NAME}"
+MAN_DIR="${HOME}/.local/share/man/man1"
+BASH_COMPLETION_DIR="${HOME}/.local/share/bash-completion/completions"
+ZSH_COMPLETION_DIR="${HOME}/.local/share/zsh/site-functions"
+FISH_COMPLETION_DIR="${HOME}/.config/fish/completions"
 
 # Setup colors
 BOLD="\033[1m"
@@ -20,6 +24,8 @@ echo -e "${BOLD}${BLUE}🍳 Serving up breakfast...${RESET}"
 echo -e "${YELLOW}Finding the latest version...${RESET}"
 LATEST_RELEASE_JSON=$(curl -s "https://api.github.com/repos/${REPO}/releases/latest")
 LATEST_RELEASE_URL=$(echo "${LATEST_RELEASE_JSON}" | grep -o "https://github.com/${REPO}/releases/download/[^/ ]*/${BINARY_NAME}" | head -n 1)
+LATEST_TAG=$(echo "${LATEST_RELEASE_JSON}" | grep -o '"tag_name": *"[^"]*"' | grep -o '"[^"]*"$' | tr -d '"')
+RELEASE_BASE_URL="https://github.com/${REPO}/releases/download/${LATEST_TAG}"
 
 if [ -z "${LATEST_RELEASE_URL}" ]; then
     echo -e "${BOLD}\033[31m❌ Failed to find the latest release for ${REPO}.${RESET}"
@@ -44,6 +50,39 @@ echo -ne "${BLUE}Installed version: ${RESET}"
 # Initialize default config
 echo -e "${YELLOW}Initializing default configuration...${RESET}"
 "${EXECUTABLE_PATH}" --init-config
+
+# Install man page
+echo -e "${YELLOW}Installing man page...${RESET}"
+mkdir -p "${MAN_DIR}"
+if curl -sL "${RELEASE_BASE_URL}/breakfast.1.gz" -o "${MAN_DIR}/breakfast.1.gz"; then
+    echo -e "${GREEN}📖 Man page installed. Run: ${BOLD}man breakfast${RESET}"
+else
+    echo -e "${YELLOW}⚠️  Could not install man page (non-fatal).${RESET}"
+fi
+
+# Install shell completions
+echo -e "${YELLOW}Installing shell completions...${RESET}"
+
+mkdir -p "${BASH_COMPLETION_DIR}"
+if curl -sL "${RELEASE_BASE_URL}/breakfast.bash" -o "${BASH_COMPLETION_DIR}/breakfast"; then
+    echo -e "${GREEN}✅ Bash completion installed.${RESET}"
+else
+    echo -e "${YELLOW}⚠️  Could not install bash completion (non-fatal).${RESET}"
+fi
+
+mkdir -p "${ZSH_COMPLETION_DIR}"
+if curl -sL "${RELEASE_BASE_URL}/_breakfast" -o "${ZSH_COMPLETION_DIR}/_breakfast"; then
+    echo -e "${GREEN}✅ Zsh completion installed.${RESET}"
+else
+    echo -e "${YELLOW}⚠️  Could not install zsh completion (non-fatal).${RESET}"
+fi
+
+mkdir -p "${FISH_COMPLETION_DIR}"
+if curl -sL "${RELEASE_BASE_URL}/breakfast.fish" -o "${FISH_COMPLETION_DIR}/breakfast.fish"; then
+    echo -e "${GREEN}✅ Fish completion installed.${RESET}"
+else
+    echo -e "${YELLOW}⚠️  Could not install fish completion (non-fatal).${RESET}"
+fi
 
 # Check if INSTALL_DIR is in PATH
 if [[ ":$PATH:" != *":${INSTALL_DIR}:"* ]]; then

--- a/mkver.conf
+++ b/mkver.conf
@@ -1,12 +1,12 @@
 # prefix for tags in git
 tagPrefix: v
-# defaults are used if they are not overriden by a branch config
+# defaults are used if they are not overridden by a branch config
 defaults {
   # whether to really tag the branch when `git mkver tag` is called
   tag: false
   # message for annotated version tags in git
   tagMessageFormat: "release {Tag}"
-  # format tring for the pre-release. The format must end with {PreReleaseNumber} if it is used.
+  # format string for the pre-release. The format must end with {PreReleaseNumber} if it is used.
   # Examples:
   # * alpha
   # * SNAPSHOT

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,9 +31,11 @@ lint = [
 ]
 build = [
   "shiv",
+  "click-man",
 ]
 dev = [
   "black",
+  "click-man",
   "pytest",
   "requests-mock",
   "ruff",

--- a/src/breakfast/api.py
+++ b/src/breakfast/api.py
@@ -68,7 +68,7 @@ def _fetch_pr_detail(pr_url):
     )
 
 
-def make_paginated_github_api_requst(query_string, rate=100):
+def make_paginated_github_api_request(query_string, rate=100):
     """Fetch a paginated GitHub REST resource.
 
     Args:
@@ -205,7 +205,7 @@ def get_approval_status(owner, repo, pr_number):
     - ``changes``   — at least one reviewer has requested changes
     - ``pending``   — no qualifying reviews yet
     """
-    reviews = make_paginated_github_api_requst(
+    reviews = make_paginated_github_api_request(
         f"/repos/{owner}/{repo}/pulls/{pr_number}/reviews"
     )
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -231,7 +231,7 @@ def test_make_paginated_github_api_request_adds_initial_query_separator(monkeypa
 
     monkeypatch.setattr(api, "make_github_api_request", fake_api)
 
-    result = api.make_paginated_github_api_requst(
+    result = api.make_paginated_github_api_request(
         "/repos/org/repo/pulls/1/reviews",
         rate=2,
     )

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -491,7 +491,7 @@ def test_get_approval_summary_includes_counts_for_multi_review_branch(monkeypatc
     )
     monkeypatch.setattr(
         api,
-        "make_paginated_github_api_requst",
+        "make_paginated_github_api_request",
         lambda path: [{"user": {"login": "alice"}, "state": "APPROVED"}],
     )
     monkeypatch.setattr(
@@ -517,7 +517,7 @@ def test_get_approval_summary_preserves_approved_when_github_reports_approved(
     )
     monkeypatch.setattr(
         api,
-        "make_paginated_github_api_requst",
+        "make_paginated_github_api_request",
         lambda path: [{"user": {"login": "alice"}, "state": "APPROVED"}],
     )
     monkeypatch.setattr(

--- a/utils/create_release.sh
+++ b/utils/create_release.sh
@@ -5,6 +5,10 @@ version="$1"
 tag="v${version}"
 
 gh release create "${tag}" ./breakfast \
+  man1/breakfast.1.gz \
+  completions/breakfast.bash \
+  completions/_breakfast \
+  completions/breakfast.fish \
   --title "${tag}" \
   --generate-notes \
   --target "$(git rev-parse HEAD)"

--- a/utils/generate_man_page.py
+++ b/utils/generate_man_page.py
@@ -1,0 +1,12 @@
+"""Generate the breakfast man page using click-man."""
+
+import importlib.metadata
+import sys
+
+from click_man.core import write_man_pages
+
+from breakfast.cli import breakfast
+
+target_dir = sys.argv[1] if len(sys.argv) > 1 else "man1"
+version = importlib.metadata.version("breakfast")
+write_man_pages("breakfast", breakfast, version=version, target_dir=target_dir)

--- a/utils/generate_man_page.py
+++ b/utils/generate_man_page.py
@@ -1,12 +1,20 @@
 """Generate the breakfast man page using click-man."""
 
 import importlib.metadata
-import sys
 
+import click
 from click_man.core import write_man_pages
 
 from breakfast.cli import breakfast
 
-target_dir = sys.argv[1] if len(sys.argv) > 1 else "man1"
-version = importlib.metadata.version("breakfast")
-write_man_pages("breakfast", breakfast, version=version, target_dir=target_dir)
+
+@click.command()
+@click.argument("target_dir", default="man1")
+def main(target_dir):
+    """Generate the breakfast man page into TARGET_DIR."""
+    version = importlib.metadata.version("breakfast")
+    write_man_pages("breakfast", breakfast, version=version, target_dir=target_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/uv.lock
+++ b/uv.lock
@@ -41,7 +41,7 @@ wheels = [
 
 [[package]]
 name = "breakfast"
-version = "0.31.0"
+version = "0.32.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },
@@ -51,10 +51,12 @@ dependencies = [
 
 [package.optional-dependencies]
 build = [
+    { name = "click-man" },
     { name = "shiv" },
 ]
 dev = [
     { name = "black" },
+    { name = "click-man" },
     { name = "pytest" },
     { name = "requests-mock" },
     { name = "ruff" },
@@ -74,6 +76,8 @@ requires-dist = [
     { name = "black", marker = "extra == 'dev'" },
     { name = "black", marker = "extra == 'lint'" },
     { name = "click" },
+    { name = "click-man", marker = "extra == 'build'" },
+    { name = "click-man", marker = "extra == 'dev'" },
     { name = "pytest", marker = "extra == 'dev'" },
     { name = "pytest", marker = "extra == 'test'" },
     { name = "requests" },
@@ -179,6 +183,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/3d/fa/656b739db8587d7b5dfa22e22ed02566950fbfbcdc20311993483657a5c0/click-8.3.1.tar.gz", hash = "sha256:12ff4785d337a1bb490bb7e9c2b1ee5da3112e94a8622f26a6c77f5d2fc6842a", size = 295065, upload-time = "2025-11-15T20:45:42.706Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/98/78/01c019cdb5d6498122777c1a43056ebb3ebfeef2076d9d026bfe15583b2b/click-8.3.1-py3-none-any.whl", hash = "sha256:981153a64e25f12d547d3426c367a4857371575ee7ad18df2a6183ab0545b2a6", size = 108274, upload-time = "2025-11-15T20:45:41.139Z" },
+]
+
+[[package]]
+name = "click-man"
+version = "0.5.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8b/1c/686c42d3a07d25d1cde107d0b92a2cf6234b92e569e61f8a294ffe6c9357/click_man-0.5.1.tar.gz", hash = "sha256:2db2163ef51a1b746d6d7781f78856430a2bcf0f10df428fe5986ecc0ef9809c", size = 21345, upload-time = "2025-04-08T14:41:11.092Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e1/37/34e03579eb583a587edba458599af6d82715a617e685dbe2ff30e4238930/click_man-0.5.1-py3-none-any.whl", hash = "sha256:ed63caf6d6bf04f2b1fb198a1a764daea9785ad29f303b2962418a417541a6ce", size = 8825, upload-time = "2025-04-08T14:41:09.345Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- `make man` generates a groff man page via `click-man` — `man breakfast` works after install
- `make completions` generates bash/zsh/fish tab-completion scripts via Click's built-in system
- `install.sh` automatically downloads and installs all artifacts at install time
- CI validates man page and completions can be generated; release job bundles them as GitHub Release assets

## Test plan
- [ ] `make man` produces `man1/breakfast.1.gz` and renders correctly
- [ ] `make completions` produces 3 non-empty scripts in `completions/`
- [ ] `make test && make lint` pass
- [ ] CI `man` and `completions` jobs pass in GitHub Actions
- [ ] After install, `man breakfast` works and tab-completion activates per shell

Closes #131
Closes #132

🤖 Generated with [Claude Code](https://claude.com/claude-code)