### PR TITLE
#149: Respect required review decisions in approval status

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ breakfast -o my-org -r my-app --legendary-only
 - `--repo-filter`, `-r`: Filter repos by name substring.
 - `--age`: Add an age column (days since creation).
 - `--checks`: Add a checks column showing CI status (✅ pass / ❌ fail / ⚠️ pending).
-- `--approvals`: Add an approvals column showing review status (✅ approved / ❌ changes / ⏳ pending).
+- `--approvals`: Add an approvals column showing review status (✅ approved / ❌ changes / ⏳ review required).
 - `--status-style`: Render status cells with `emoji` (default) or `ascii` labels.
 - `--json`: Output as JSON instead of a table.
 - `--limit`: Cap the number of PRs shown.

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ breakfast -o my-org -r my-app --legendary-only
 - `--repo-filter`, `-r`: Filter repos by name substring.
 - `--age`: Add an age column (days since creation).
 - `--checks`: Add a checks column showing CI status (✅ pass / ❌ fail / ⚠️ pending).
-- `--approvals`: Add an approvals column showing review status (✅ approved / ❌ changes / ⏳ review required).
+- `--approvals`: Add an approvals column showing review status (✅ approved / ✅ 1/2 approvals / ❌ changes / ⏳ pending).
 - `--status-style`: Render status cells with `emoji` (default) or `ascii` labels.
 - `--json`: Output as JSON instead of a table.
 - `--limit`: Cap the number of PRs shown.

--- a/docs/design/pr-caching.md
+++ b/docs/design/pr-caching.md
@@ -21,7 +21,7 @@ breakfast --no-cache  # always fetches fresh
 any in-memory filtering. This means `--ignore-author` and `--mine-only` can vary
 between runs without re-fetching the underlying data.
 
-**Also cache: CI check statuses and review approval statuses.**
+**Also cache: CI check statuses and review approval statuses/details.**
 _(Added in [#113 — filter options](https://github.com/mrsixw/breakfast/issues/113))_
 When `--checks`, `--approvals`, or the corresponding filter flags are used, the
 fetched statuses are stored in the same cache file alongside the PR details.
@@ -69,14 +69,19 @@ file as optional top-level keys:
   "pr_count": 42,
   "prs": [{}, {}],
   "check_statuses": {"101": "pass", "102": "fail"},
-  "approval_statuses": {"101": "approved", "102": "pending"}
+  "approval_statuses": {"101": "approved", "102": "pending"},
+  "approval_details": {
+    "101": {"status": "approved", "current": 2, "required": 2},
+    "102": {"status": "pending", "current": 1, "required": 2}
+  }
 }
 ```
 
-`check_statuses` and `approval_statuses` are omitted when `--checks`/`--approvals`
-were not used in the run that wrote the cache. Older cache files without these
-fields are handled gracefully — the statuses are treated as uncached and fetched
-on demand. JSON requires string keys; they are converted back to `int` on read.
+`check_statuses`, `approval_statuses`, and `approval_details` are omitted when
+`--checks`/`--approvals` were not used in the run that wrote the cache. Older
+cache files without these fields are handled gracefully — the statuses/details
+are treated as uncached and fetched on demand. JSON requires string keys; they
+are converted back to `int` on read.
 
 ## Cache Location
 

--- a/docs/manual/options.md
+++ b/docs/manual/options.md
@@ -256,19 +256,22 @@ Processing platform PRs...🍩🧇...Done
 +---------+----------------+-----------------+--------+---------+-------+---------+------------+----------+--------------+--------------+--------+
 |         | Repo           | PR Title        | Author | State   | Files | Commits |    +/-     | Comments | Approved     | Mergeable?   | Link   |
 +---------+----------------+-----------------+--------+---------+-------+---------+------------+----------+--------------+--------------+--------+
-|       0 | platform-api   | Add user search | alice  | open    |   3   |    1    |  +42/-10   |    0     | ✅ approved  | ✅ (clean)   | PR-142 |
+|       0 | platform-api   | Add user search | alice  | open    |   3   |    1    |  +42/-10   |    0     | ✅ 2/2 approvals | ✅ (clean)   | PR-142 |
 |       1 | platform-api   | Fix login bug   | bob    | open    |   1   |    1    |  +5/-2     |    3     | ❌ changes   | ✅ (clean)   | PR-138 |
-|       2 | platform-ui    | Update nav bar  | carol  | open    |  12   |    4    |  +280/-95  |    1     | ⏳ review required | ❌ (dirty)   | PR-87  |
+|       2 | platform-ui    | Update nav bar  | carol  | open    |  12   |    4    |  +280/-95  |    1     | ✅ 1/2 approvals | ❌ (dirty)   | PR-87  |
 +---------+----------------+-----------------+--------+---------+-------+---------+------------+----------+--------------+--------------+--------+
 ```
 
 Approval values:
-- **✅ approved** (green) — GitHub reports the PR as approved for merge
+- **✅ approved** (green) — GitHub reports the PR as approved for merge when no multi-review count is available
+- **✅ 1/2 approvals** (green) — the PR has some effective approvals, but still needs more to satisfy a multi-review branch rule
 - **❌ changes** (red) — at least one reviewer has requested changes
-- **⏳ review required** (yellow) — GitHub still requires more review before merge
+- **⏳ pending** (yellow) — no effective approvals yet
 
 GitHub's review decision is used when available so repos that require multiple
-approvals do not show a misleading green approval after only one review.
+approvals do not show a misleading final `approved` state after only one review.
+When branch protection exposes a required approval count, breakfast also shows
+the current/required approval total.
 
 Can also be set in the config file:
 
@@ -276,13 +279,17 @@ Can also be set in the config file:
 approvals = true
 ```
 
-With `--json --approvals`, an `"approval"` field is included in each PR object:
+With `--json --approvals`, an `"approval"` field is included in each PR object.
+When approval counts are available, `"approval_current"` and
+`"approval_required"` are included as well:
 
 ```json
 {
   "repo": "platform-api",
   "title": "Add user search",
   "approval": "approved",
+  "approval_current": 2,
+  "approval_required": 2,
   ...
 }
 ```
@@ -296,8 +303,8 @@ breakfast -o my-org -r platform --checks --status-style ascii
 ```
 
 Supported values:
-- `emoji` - default whimsical output, such as `✅ pass`, `✅ approved`, and `❌ (dirty)`
-- `ascii` - terminal-safe fallback, such as `pass`, `approved`, and `no (dirty)`
+- `emoji` - default whimsical output, such as `✅ pass`, `✅ 1/2 approvals`, and `❌ (dirty)`
+- `ascii` - terminal-safe fallback, such as `pass`, `1/2 approvals`, and `no (dirty)`
 
 This is also available in config:
 
@@ -361,7 +368,7 @@ The table is compressed progressively, in order of least impact:
 4. **Mergeable?** reason is dropped (`"✅ (clean)"` → `"✅"`)
 4b. **Mergeable?** header is shortened to `"Mrg"`
 5. **Checks** label is dropped (`"✅ pass"` → `"✅"`)
-5b. **Approved** label is dropped (`"✅ approved"` → `"✅"`)
+5b. **Approved** label is shortened (`"✅ approved"` → `"✅"`, `"✅ 1/2 approvals"` → `"✅ 1/2"`)
 6. **Comments** header is shortened to `"Cmt"`
 6b. **Approved** header is shortened to `"Apr"`
 7. Low-priority columns are dropped entirely: State, Commits, Files, +/-, Cmt, Age, Checks, Approved/Apr

--- a/docs/manual/options.md
+++ b/docs/manual/options.md
@@ -258,16 +258,17 @@ Processing platform PRs...🍩🧇...Done
 +---------+----------------+-----------------+--------+---------+-------+---------+------------+----------+--------------+--------------+--------+
 |       0 | platform-api   | Add user search | alice  | open    |   3   |    1    |  +42/-10   |    0     | ✅ approved  | ✅ (clean)   | PR-142 |
 |       1 | platform-api   | Fix login bug   | bob    | open    |   1   |    1    |  +5/-2     |    3     | ❌ changes   | ✅ (clean)   | PR-138 |
-|       2 | platform-ui    | Update nav bar  | carol  | open    |  12   |    4    |  +280/-95  |    1     | ⏳ pending   | ❌ (dirty)   | PR-87  |
+|       2 | platform-ui    | Update nav bar  | carol  | open    |  12   |    4    |  +280/-95  |    1     | ⏳ review required | ❌ (dirty)   | PR-87  |
 +---------+----------------+-----------------+--------+---------+-------+---------+------------+----------+--------------+--------------+--------+
 ```
 
 Approval values:
-- **✅ approved** (green) — at least one reviewer has approved and no changes are requested
+- **✅ approved** (green) — GitHub reports the PR as approved for merge
 - **❌ changes** (red) — at least one reviewer has requested changes
-- **⏳ pending** (yellow) — no qualifying reviews yet
+- **⏳ review required** (yellow) — GitHub still requires more review before merge
 
-The most recent review per reviewer is used, mirroring GitHub's own UI logic.
+GitHub's review decision is used when available so repos that require multiple
+approvals do not show a misleading green approval after only one review.
 
 Can also be set in the config file:
 

--- a/src/breakfast/api.py
+++ b/src/breakfast/api.py
@@ -197,13 +197,16 @@ def get_authenticated_user_login():
     return login
 
 
-def get_approval_status(owner, repo, pr_number):
-    """Get the aggregate approval status for a PR.
+def _review_status_from_latest_reviews(owner, repo, pr_number):
+    """Aggregate approval state from the latest REST review events.
 
-    Uses the most recent review per reviewer, mirroring GitHub's UI logic:
-    - ``approved``  — at least one APPROVED review, no CHANGES_REQUESTED
-    - ``changes``   — at least one reviewer has requested changes
-    - ``pending``   — no qualifying reviews yet
+    Args:
+        owner: Repository owner login.
+        repo: Repository name.
+        pr_number: Pull request number.
+
+    Returns:
+        str: One of ``approved``, ``changes``, or ``pending``.
     """
     reviews = make_paginated_github_api_requst(
         f"/repos/{owner}/{repo}/pulls/{pr_number}/reviews"
@@ -212,7 +215,6 @@ def get_approval_status(owner, repo, pr_number):
     if not reviews:
         return "pending"
 
-    # Keep only the most recent qualifying review state per reviewer
     latest_by_reviewer = {}
     for review in reviews:
         reviewer = review.get("user", {}).get("login")
@@ -226,6 +228,56 @@ def get_approval_status(owner, repo, pr_number):
     if "APPROVED" in states:
         return "approved"
     return "pending"
+
+
+def get_approval_status(owner, repo, pr_number):
+    """Get GitHub's current review decision for a pull request.
+
+    Args:
+        owner: Repository owner login.
+        repo: Repository name.
+        pr_number: Pull request number.
+
+    Returns:
+        str: One of ``approved``, ``changes``, or ``pending``.
+
+    Notes:
+        This prefers GitHub's ``reviewDecision`` so multi-review branch rules do
+        not get flattened into a misleading single-approval green state. If the
+        GraphQL signal is unavailable, it falls back to the latest REST review
+        events.
+    """
+    query = """
+    query($owner: String!, $repo: String!, $prNumber: Int!) {
+      repository(owner: $owner, name: $repo) {
+        pullRequest(number: $prNumber) {
+          reviewDecision
+        }
+      }
+    }
+    """
+    variables = {"owner": owner, "repo": repo, "prNumber": pr_number}
+
+    try:
+        response = make_github_graphql_request(query, variables)
+        review_decision = (
+            response.get("data", {})
+            .get("repository", {})
+            .get("pullRequest", {})
+            .get("reviewDecision")
+        )
+    except (ValueError, requests.exceptions.RequestException):
+        review_decision = None
+
+    decision_map = {
+        "APPROVED": "approved",
+        "CHANGES_REQUESTED": "changes",
+        "REVIEW_REQUIRED": "pending",
+    }
+    if review_decision in decision_map:
+        return decision_map[review_decision]
+
+    return _review_status_from_latest_reviews(owner, repo, pr_number)
 
 
 def get_check_status(owner, repo, sha):

--- a/src/breakfast/api.py
+++ b/src/breakfast/api.py
@@ -1,6 +1,8 @@
 import os
 import random
 import time
+from functools import lru_cache
+from urllib.parse import quote
 
 import click
 import requests
@@ -213,30 +215,135 @@ def _review_status_from_latest_reviews(owner, repo, pr_number):
     )
 
     if not reviews:
-        return "pending"
+        return {"status": "pending", "current": 0}
 
     latest_by_reviewer = {}
     for review in reviews:
         reviewer = review.get("user", {}).get("login")
         state = review.get("state")
-        if reviewer and state in ("APPROVED", "CHANGES_REQUESTED"):
+        if reviewer and state in ("APPROVED", "CHANGES_REQUESTED", "DISMISSED"):
             latest_by_reviewer[reviewer] = state
 
     states = set(latest_by_reviewer.values())
+    approval_count = sum(
+        1 for state in latest_by_reviewer.values() if state == "APPROVED"
+    )
     if "CHANGES_REQUESTED" in states:
-        return "changes"
-    if "APPROVED" in states:
-        return "approved"
-    return "pending"
+        status = "changes"
+    elif approval_count:
+        status = "approved"
+    else:
+        status = "pending"
+    return {"status": status, "current": approval_count}
 
 
-def get_approval_status(owner, repo, pr_number):
+@lru_cache(maxsize=None)
+def get_required_approving_review_count(owner, repo, branch):
+    """Return the required approval count for a protected branch.
+
+    Args:
+        owner: Repository owner login.
+        repo: Repository name.
+        branch: Base branch name.
+
+    Returns:
+        int | None: Required approval count, or ``None`` when it cannot be
+        determined from branch protection data.
+    """
+    encoded_branch = quote(branch, safe="")
+    query_string = (
+        f"/repos/{owner}/{repo}/branches/{encoded_branch}"
+        "/protection/required_pull_request_reviews"
+    )
+    try:
+        data = make_github_api_request(query_string)
+    except requests.exceptions.HTTPError as exc:
+        status_code = exc.response.status_code if exc.response is not None else None
+        if status_code in (403, 404):
+            return None
+        raise
+
+    required_count = data.get("required_approving_review_count")
+    if isinstance(required_count, int) and required_count > 0:
+        return required_count
+    return None
+
+
+def get_approval_summary(owner, repo, pr_number, base_branch=None):
+    """Return approval status plus optional obtained/required review counts.
+
+    Args:
+        owner: Repository owner login.
+        repo: Repository name.
+        pr_number: Pull request number.
+        base_branch: Base branch name for branch protection lookup.
+
+    Returns:
+        dict: Summary with ``status`` and optional ``current`` / ``required``
+        review counts.
+    """
+    review_summary = _review_status_from_latest_reviews(owner, repo, pr_number)
+    current_reviews = review_summary["current"]
+    required_reviews = None
+
+    if base_branch:
+        try:
+            required_reviews = get_required_approving_review_count(
+                owner, repo, base_branch
+            )
+        except requests.exceptions.RequestException:
+            required_reviews = None
+
+    query = """
+    query($owner: String!, $repo: String!, $prNumber: Int!) {
+      repository(owner: $owner, name: $repo) {
+        pullRequest(number: $prNumber) {
+          reviewDecision
+        }
+      }
+    }
+    """
+    variables = {"owner": owner, "repo": repo, "prNumber": pr_number}
+
+    try:
+        response = make_github_graphql_request(query, variables)
+        review_decision = (
+            response.get("data", {})
+            .get("repository", {})
+            .get("pullRequest", {})
+            .get("reviewDecision")
+        )
+    except (ValueError, requests.exceptions.RequestException):
+        review_decision = None
+
+    decision_map = {
+        "APPROVED": "approved",
+        "CHANGES_REQUESTED": "changes",
+        "REVIEW_REQUIRED": "pending",
+    }
+    status = decision_map.get(review_decision, review_summary["status"])
+
+    if required_reviews is not None and review_decision is None and status != "changes":
+        status = "approved" if current_reviews >= required_reviews else "pending"
+
+    if required_reviews is not None and status == "approved":
+        current_reviews = max(current_reviews, required_reviews)
+
+    return {
+        "status": status,
+        "current": current_reviews,
+        "required": required_reviews,
+    }
+
+
+def get_approval_status(owner, repo, pr_number, base_branch=None):
     """Get GitHub's current review decision for a pull request.
 
     Args:
         owner: Repository owner login.
         repo: Repository name.
         pr_number: Pull request number.
+        base_branch: Base branch name for branch protection lookup.
 
     Returns:
         str: One of ``approved``, ``changes``, or ``pending``.
@@ -277,7 +384,7 @@ def get_approval_status(owner, repo, pr_number):
     if review_decision in decision_map:
         return decision_map[review_decision]
 
-    return _review_status_from_latest_reviews(owner, repo, pr_number)
+    return get_approval_summary(owner, repo, pr_number, base_branch)["status"]
 
 
 def get_check_status(owner, repo, sha):

--- a/src/breakfast/cache.py
+++ b/src/breakfast/cache.py
@@ -125,6 +125,7 @@ def read_pr_cache(org: str, repo_filter: str, ttl: int) -> dict | None:
       "prs"              – list of PR detail dicts
       "check_statuses"   – dict[int, str] or None (absent from older caches)
       "approval_statuses"– dict[int, str] or None (absent from older caches)
+      "approval_details" – dict[int, dict] or None (absent from older caches)
     """
     path = cache_path(org, repo_filter)
     try:
@@ -147,6 +148,7 @@ def read_pr_cache(org: str, repo_filter: str, ttl: int) -> dict | None:
         # JSON keys are always strings; convert back to int for PR IDs.
         raw_checks = data.get("check_statuses")
         raw_approvals = data.get("approval_statuses")
+        raw_approval_details = data.get("approval_details")
         pr_count = len(data["prs"])
         logger.debug(
             "cache_hit layer=pr_detail path=%s age=%.0fs pr_count=%d",
@@ -166,6 +168,11 @@ def read_pr_cache(org: str, repo_filter: str, ttl: int) -> dict | None:
                 if raw_approvals is not None
                 else None
             ),
+            "approval_details": (
+                {int(k): v for k, v in raw_approval_details.items()}
+                if raw_approval_details is not None
+                else None
+            ),
         }
     except (OSError, json.JSONDecodeError, KeyError, ValueError) as exc:
         logger.warning(
@@ -181,6 +188,7 @@ def write_pr_cache(
     pr_details: list,
     check_statuses: dict | None = None,
     approval_statuses: dict | None = None,
+    approval_details: dict | None = None,
 ) -> None:
     """Write pr_details (and optional statuses) to disk cache."""
     try:
@@ -199,6 +207,10 @@ def write_pr_cache(
         if approval_statuses is not None:
             payload["approval_statuses"] = {
                 str(k): v for k, v in approval_statuses.items()
+            }
+        if approval_details is not None:
+            payload["approval_details"] = {
+                str(k): v for k, v in approval_details.items()
             }
         path.write_text(json.dumps(payload))
         logger.debug(

--- a/src/breakfast/cli.py
+++ b/src/breakfast/cli.py
@@ -13,7 +13,7 @@ from tabulate import tabulate
 from .api import (
     SECRET_GITHUB_TOKEN,
     _fetch_pr_detail,
-    get_approval_status,
+    get_approval_summary,
     get_authenticated_user_login,
     get_check_status,
     get_github_prs,
@@ -130,8 +130,11 @@ def _compress_styled(styled_text):
     words = plain.split()
     if len(words) <= 1:
         return styled_text
-    first_word = words[0]
-    return styled_text.replace(plain, first_word, 1)
+    if len(words) >= 2 and re.fullmatch(r"\d+/\d+", words[1]):
+        compressed = " ".join(words[:2])
+    else:
+        compressed = words[0]
+    return styled_text.replace(plain, compressed, 1)
 
 
 def _auto_fit(pr_data, terminal_width, explicit_max_title_length):
@@ -193,7 +196,7 @@ def _auto_fit(pr_data, terminal_width, explicit_max_title_length):
     if fits():
         return pr_data
 
-    # 5b. Compress Approved: "✅ approved" → "✅" (preserving colour)
+    # 5b. Compress Approved: "✅ approved" → "✅", "✅ 1/2 approvals" → "✅ 1/2"
     if "Approved" in pr_data[0]:
         pr_data = [
             {**row, "Approved": _compress_styled(row["Approved"])} for row in pr_data
@@ -297,25 +300,39 @@ def _fetch_pr_bundle(url, fetch_checks, fetch_approvals):
         else:
             check_status = "none"
 
-    approval_status = None
+    approval_detail = None
     if fetch_approvals:
         owner = pr_detail.get("base", {}).get("repo", {}).get("owner", {}).get("login")
         repo_name = pr_detail.get("base", {}).get("repo", {}).get("name")
         pr_number = pr_detail.get("number")
+        base_branch = pr_detail.get("base", {}).get("ref")
         if owner and repo_name and pr_number is not None:
             try:
-                approval_status = get_approval_status(owner, repo_name, pr_number)
+                approval_detail = get_approval_summary(
+                    owner,
+                    repo_name,
+                    pr_number,
+                    base_branch=base_branch,
+                )
             except (ValueError, requests.exceptions.RequestException) as exc:
                 logger.warning(
                     "approval_status_fetch_failed pr_id=%s error=%r",
                     pr_detail.get("id"),
                     str(exc),
                 )
-                approval_status = "pending"
+                approval_detail = {
+                    "status": "pending",
+                    "current": 0,
+                    "required": None,
+                }
         else:
-            approval_status = "pending"
+            approval_detail = {
+                "status": "pending",
+                "current": 0,
+                "required": None,
+            }
 
-    return pr_detail, check_status, approval_status
+    return pr_detail, check_status, approval_detail
 
 
 @click.command()
@@ -701,6 +718,7 @@ def breakfast(
     pr_details = None
     cached_check_statuses = None
     cached_approval_statuses = None
+    cached_approval_details = None
     needs_cache_write = False
     if cache_enabled and not refresh and not refresh_prs:
         cache_result = read_pr_cache(organization, repo_filter, cache_ttl_seconds)
@@ -708,6 +726,7 @@ def breakfast(
             pr_details = cache_result["prs"]
             cached_check_statuses = cache_result["check_statuses"]
             cached_approval_statuses = cache_result["approval_statuses"]
+            cached_approval_details = cache_result.get("approval_details")
 
     # Resolve implied flags before fetch so bundle knows what to fetch per PR.
     if filter_check:
@@ -717,6 +736,7 @@ def breakfast(
 
     check_statuses = {}
     approval_statuses = {}
+    approval_details = {}
     statuses_from_bundle = False
 
     if pr_details is None:
@@ -763,12 +783,15 @@ def breakfast(
                 for future in as_completed(future_to_url):
                     url = future_to_url[future]
                     try:
-                        pr_detail, check_status, approval_status = future.result()
+                        pr_detail, check_status, approval_detail = future.result()
                         pr_details.append(pr_detail)
                         if check_status is not None:
                             check_statuses[pr_detail["id"]] = check_status
-                        if approval_status is not None:
-                            approval_statuses[pr_detail["id"]] = approval_status
+                        if approval_detail is not None:
+                            approval_statuses[pr_detail["id"]] = approval_detail[
+                                "status"
+                            ]
+                            approval_details[pr_detail["id"]] = approval_detail
                         click.echo(
                             random.choices(BREAKFAST_ITEMS)[0],
                             nl=False,
@@ -824,8 +847,9 @@ def breakfast(
     # Fetch approval statuses for cache-hit paths where statuses are absent.
     # In the live-fetch path statuses are already populated by _fetch_pr_bundle.
     if approvals and pr_details and not statuses_from_bundle:
-        if cached_approval_statuses is not None:
+        if cached_approval_statuses is not None and cached_approval_details is not None:
             approval_statuses = cached_approval_statuses
+            approval_details = cached_approval_details
         else:
             max_workers = min(workers, len(pr_details))
             with ThreadPoolExecutor(max_workers=max_workers) as executor:
@@ -834,20 +858,28 @@ def breakfast(
                     owner = pr_detail["base"]["repo"]["owner"]["login"]
                     repo_name = pr_detail["base"]["repo"]["name"]
                     pr_number = pr_detail["number"]
+                    base_branch = pr_detail.get("base", {}).get("ref")
                     future = executor.submit(
-                        get_approval_status, owner, repo_name, pr_number
+                        get_approval_summary, owner, repo_name, pr_number, base_branch
                     )
                     approval_futures.append((pr_detail["id"], future))
             for pr_id, future in approval_futures:
                 try:
-                    approval_statuses[pr_id] = future.result()
-                except requests.exceptions.RequestException as exc:
+                    approval_detail = future.result()
+                    approval_statuses[pr_id] = approval_detail["status"]
+                    approval_details[pr_id] = approval_detail
+                except (ValueError, requests.exceptions.RequestException) as exc:
                     logger.warning(
                         "approval_status_fetch_failed pr_id=%s error=%r",
                         pr_id,
                         str(exc),
                     )
                     approval_statuses[pr_id] = "pending"
+                    approval_details[pr_id] = {
+                        "status": "pending",
+                        "current": 0,
+                        "required": None,
+                    }
             needs_cache_write = True
 
     logger.info(
@@ -863,6 +895,7 @@ def breakfast(
             pr_details,
             check_statuses=check_statuses or None,
             approval_statuses=approval_statuses or None,
+            approval_details=approval_details or None,
         )
         if refresh or refresh_prs:
             click.echo("🔄 Cache refreshed.", err=json_output)
@@ -935,6 +968,11 @@ def breakfast(
                 entry["checks"] = check_statuses.get(pr_detail["id"], "none")
             if approvals:
                 entry["approval"] = approval_statuses.get(pr_detail["id"], "pending")
+                approval_detail = approval_details.get(pr_detail["id"], {})
+                if approval_detail.get("current") is not None:
+                    entry["approval_current"] = approval_detail["current"]
+                if approval_detail.get("required") is not None:
+                    entry["approval_required"] = approval_detail["required"]
             json_data.append(entry)
         click.echo(json.dumps(json_data, indent=2))
         logger.info(
@@ -981,9 +1019,12 @@ def breakfast(
                 ),
             )
         if approvals:
+            approval_detail = approval_details.get(pr_detail["id"], {})
             row["Approved"] = format_approval_status(
                 approval_statuses.get(pr_detail["id"], "pending"),
                 style=status_style,
+                current_reviews=approval_detail.get("current"),
+                required_reviews=approval_detail.get("required"),
             )
         row["Mergeable?"] = format_mergeable_status(
             pr_detail["mergeable"],

--- a/src/breakfast/cli.py
+++ b/src/breakfast/cli.py
@@ -281,28 +281,38 @@ def _fetch_pr_bundle(url, fetch_checks, fetch_approvals):
 
     check_status = None
     if fetch_checks:
-        owner = pr_detail["base"]["repo"]["owner"]["login"]
-        repo_name = pr_detail["base"]["repo"]["name"]
-        try:
-            check_status = get_check_status(owner, repo_name, pr_detail["head"]["sha"])
-        except requests.exceptions.RequestException as exc:
-            logger.warning(
-                "check_status_fetch_failed pr_id=%s error=%r", pr_detail["id"], str(exc)
-            )
+        owner = pr_detail.get("base", {}).get("repo", {}).get("owner", {}).get("login")
+        repo_name = pr_detail.get("base", {}).get("repo", {}).get("name")
+        head_sha = pr_detail.get("head", {}).get("sha")
+        if owner and repo_name and head_sha:
+            try:
+                check_status = get_check_status(owner, repo_name, head_sha)
+            except requests.exceptions.RequestException as exc:
+                logger.warning(
+                    "check_status_fetch_failed pr_id=%s error=%r",
+                    pr_detail.get("id"),
+                    str(exc),
+                )
+                check_status = "none"
+        else:
             check_status = "none"
 
     approval_status = None
     if fetch_approvals:
-        owner = pr_detail["base"]["repo"]["owner"]["login"]
-        repo_name = pr_detail["base"]["repo"]["name"]
-        try:
-            approval_status = get_approval_status(owner, repo_name, pr_detail["number"])
-        except requests.exceptions.RequestException as exc:
-            logger.warning(
-                "approval_status_fetch_failed pr_id=%s error=%r",
-                pr_detail["id"],
-                str(exc),
-            )
+        owner = pr_detail.get("base", {}).get("repo", {}).get("owner", {}).get("login")
+        repo_name = pr_detail.get("base", {}).get("repo", {}).get("name")
+        pr_number = pr_detail.get("number")
+        if owner and repo_name and pr_number is not None:
+            try:
+                approval_status = get_approval_status(owner, repo_name, pr_number)
+            except (ValueError, requests.exceptions.RequestException) as exc:
+                logger.warning(
+                    "approval_status_fetch_failed pr_id=%s error=%r",
+                    pr_detail.get("id"),
+                    str(exc),
+                )
+                approval_status = "pending"
+        else:
             approval_status = "pending"
 
     return pr_detail, check_status, approval_status

--- a/src/breakfast/ui.py
+++ b/src/breakfast/ui.py
@@ -96,26 +96,47 @@ def format_check_status(status, style="emoji"):
     return click.style(text, fg=colour, bold=True)
 
 
-def format_approval_status(status, style="emoji"):
+def format_approval_status(
+    status,
+    style="emoji",
+    current_reviews=None,
+    required_reviews=None,
+):
     """Return a colour-coded approval status label for table output.
 
     Args:
         status: Canonical approval status — ``approved``, ``changes``, or ``pending``.
         style: Rendering style, either ``emoji`` or ``ascii``.
+        current_reviews: Number of effective approvals currently present.
+        required_reviews: Number of approvals required by branch protection.
 
     Returns:
         A styled label in the requested style.
     """
+    if (
+        required_reviews is not None
+        and required_reviews > 1
+        and current_reviews is not None
+        and status != "changes"
+    ):
+        colour = "green" if current_reviews > 0 else "yellow"
+        if style == "ascii":
+            text = f"{current_reviews}/{required_reviews} approvals"
+        else:
+            prefix = "✅" if current_reviews > 0 else "⏳"
+            text = f"{prefix} {current_reviews}/{required_reviews} approvals"
+        return click.style(text, fg=colour, bold=True)
+
     styles = {
         "emoji": {
             "approved": ("green", "✅ approved"),
             "changes": ("red", "❌ changes"),
-            "pending": ("yellow", "⏳ review required"),
+            "pending": ("yellow", "⏳ pending"),
         },
         "ascii": {
             "approved": ("green", "approved"),
             "changes": ("red", "changes"),
-            "pending": ("yellow", "review required"),
+            "pending": ("yellow", "pending"),
         },
     }
     style_map = styles.get(style, styles["emoji"])

--- a/src/breakfast/ui.py
+++ b/src/breakfast/ui.py
@@ -110,12 +110,12 @@ def format_approval_status(status, style="emoji"):
         "emoji": {
             "approved": ("green", "✅ approved"),
             "changes": ("red", "❌ changes"),
-            "pending": ("yellow", "⏳ pending"),
+            "pending": ("yellow", "⏳ review required"),
         },
         "ascii": {
             "approved": ("green", "approved"),
             "changes": ("red", "changes"),
-            "pending": ("yellow", "pending"),
+            "pending": ("yellow", "review required"),
         },
     }
     style_map = styles.get(style, styles["emoji"])

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,10 @@
 import pytest
 
-from breakfast import cache
+from breakfast import api, cache
 
 
 @pytest.fixture(autouse=True)
 def isolate_cache(tmp_path, monkeypatch):
     """Redirect the PR cache to a per-test temp dir so tests don't share cache state."""
     monkeypatch.setattr(cache, "_CACHE_DIR", tmp_path / "breakfast_cache")
+    api.get_required_approving_review_count.cache_clear()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -469,6 +469,68 @@ def test_get_approval_status_falls_back_to_rest_reviews_on_graphql_error(monkeyp
     assert api.get_approval_status("org", "repo", 1) == "approved"
 
 
+def test_get_required_approving_review_count(monkeypatch):
+    monkeypatch.setattr(
+        api,
+        "make_github_api_request",
+        lambda path: {"required_approving_review_count": 2},
+    )
+
+    assert api.get_required_approving_review_count("org", "repo", "main") == 2
+
+
+def test_get_approval_summary_includes_counts_for_multi_review_branch(monkeypatch):
+    monkeypatch.setattr(
+        api,
+        "make_github_graphql_request",
+        lambda query, variables: {
+            "data": {
+                "repository": {"pullRequest": {"reviewDecision": "REVIEW_REQUIRED"}}
+            }
+        },
+    )
+    monkeypatch.setattr(
+        api,
+        "make_paginated_github_api_requst",
+        lambda path: [{"user": {"login": "alice"}, "state": "APPROVED"}],
+    )
+    monkeypatch.setattr(
+        api,
+        "get_required_approving_review_count",
+        lambda owner, repo, branch: 2,
+    )
+
+    summary = api.get_approval_summary("org", "repo", 1, base_branch="main")
+
+    assert summary == {"status": "pending", "current": 1, "required": 2}
+
+
+def test_get_approval_summary_preserves_approved_when_github_reports_approved(
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        api,
+        "make_github_graphql_request",
+        lambda query, variables: {
+            "data": {"repository": {"pullRequest": {"reviewDecision": "APPROVED"}}}
+        },
+    )
+    monkeypatch.setattr(
+        api,
+        "make_paginated_github_api_requst",
+        lambda path: [{"user": {"login": "alice"}, "state": "APPROVED"}],
+    )
+    monkeypatch.setattr(
+        api,
+        "get_required_approving_review_count",
+        lambda owner, repo, branch: 2,
+    )
+
+    summary = api.get_approval_summary("org", "repo", 1, base_branch="main")
+
+    assert summary == {"status": "approved", "current": 2, "required": 2}
+
+
 def test_get_check_status_mixed_sources(monkeypatch):
     """Check runs pass but commit statuses fail — overall should be fail."""
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -337,71 +337,41 @@ def test_get_check_status_commit_status_all_success(monkeypatch):
 
 def test_get_approval_status_approved(monkeypatch):
     monkeypatch.setattr(api, "SECRET_GITHUB_TOKEN", "token-123")
-    monkeypatch.setattr(api.time, "sleep", lambda _: None)
-
-    reviews = [
-        {"user": {"login": "alice"}, "state": "APPROVED"},
-        {"user": {"login": "bob"}, "state": "COMMENTED"},
-    ]
-
-    def fake_get(url, headers):
-        class Resp:
-            status_code = 200
-
-            def raise_for_status(self):
-                pass
-
-            def json(self):
-                return reviews
-
-        return Resp()
-
-    monkeypatch.setattr(api.requests, "get", fake_get)
+    monkeypatch.setattr(
+        api,
+        "make_github_graphql_request",
+        lambda query, variables: {
+            "data": {"repository": {"pullRequest": {"reviewDecision": "APPROVED"}}}
+        },
+    )
     assert api.get_approval_status("org", "repo", 1) == "approved"
 
 
 def test_get_approval_status_changes_requested(monkeypatch):
     monkeypatch.setattr(api, "SECRET_GITHUB_TOKEN", "token-123")
-    monkeypatch.setattr(api.time, "sleep", lambda _: None)
-
-    reviews = [
-        {"user": {"login": "alice"}, "state": "APPROVED"},
-        {"user": {"login": "bob"}, "state": "CHANGES_REQUESTED"},
-    ]
-
-    def fake_get(url, headers):
-        class Resp:
-            status_code = 200
-
-            def raise_for_status(self):
-                pass
-
-            def json(self):
-                return reviews
-
-        return Resp()
-
-    monkeypatch.setattr(api.requests, "get", fake_get)
+    monkeypatch.setattr(
+        api,
+        "make_github_graphql_request",
+        lambda query, variables: {
+            "data": {
+                "repository": {"pullRequest": {"reviewDecision": "CHANGES_REQUESTED"}}
+            }
+        },
+    )
     assert api.get_approval_status("org", "repo", 1) == "changes"
 
 
 def test_get_approval_status_pending_no_reviews(monkeypatch):
     monkeypatch.setattr(api, "SECRET_GITHUB_TOKEN", "token-123")
-    monkeypatch.setattr(api.time, "sleep", lambda _: None)
-
-    def fake_get(url, headers):
-        class Resp:
-            status_code = 200
-
-            def raise_for_status(self):
-                pass
-
-            def json(self):
-                return []
-
-        return Resp()
-
-    monkeypatch.setattr(api.requests, "get", fake_get)
+    monkeypatch.setattr(
+        api,
+        "make_github_graphql_request",
+        lambda query, variables: {
+            "data": {
+                "repository": {"pullRequest": {"reviewDecision": "REVIEW_REQUIRED"}}
+            }
+        },
+    )
     assert api.get_approval_status("org", "repo", 1) == "pending"
 
 
@@ -427,6 +397,13 @@ def test_get_approval_status_latest_review_per_reviewer_wins(monkeypatch):
 
         return Resp()
 
+    monkeypatch.setattr(
+        api,
+        "make_github_graphql_request",
+        lambda query, variables: {
+            "data": {"repository": {"pullRequest": {"reviewDecision": None}}}
+        },
+    )
     monkeypatch.setattr(api.requests, "get", fake_get)
     assert api.get_approval_status("org", "repo", 1) == "changes"
 
@@ -451,8 +428,45 @@ def test_get_approval_status_pending_only_comments(monkeypatch):
 
         return Resp()
 
+    monkeypatch.setattr(
+        api,
+        "make_github_graphql_request",
+        lambda query, variables: {
+            "data": {"repository": {"pullRequest": {"reviewDecision": None}}}
+        },
+    )
     monkeypatch.setattr(api.requests, "get", fake_get)
     assert api.get_approval_status("org", "repo", 1) == "pending"
+
+
+def test_get_approval_status_falls_back_to_rest_reviews_on_graphql_error(monkeypatch):
+    monkeypatch.setattr(api, "SECRET_GITHUB_TOKEN", "token-123")
+    monkeypatch.setattr(api.time, "sleep", lambda _: None)
+
+    reviews = [
+        {"user": {"login": "alice"}, "state": "APPROVED"},
+    ]
+
+    def fake_get(url, headers):
+        class Resp:
+            status_code = 200
+
+            def raise_for_status(self):
+                pass
+
+            def json(self):
+                return reviews
+
+        return Resp()
+
+    monkeypatch.setattr(
+        api,
+        "make_github_graphql_request",
+        lambda query, variables: (_ for _ in ()).throw(ValueError("graphql failed")),
+    )
+    monkeypatch.setattr(api.requests, "get", fake_get)
+
+    assert api.get_approval_status("org", "repo", 1) == "approved"
 
 
 def test_get_check_status_mixed_sources(monkeypatch):

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -108,6 +108,7 @@ def test_write_then_read_roundtrip(monkeypatch, tmp_path):
     assert result["prs"] == pr_details
     assert result["check_statuses"] is None
     assert result["approval_statuses"] is None
+    assert result["approval_details"] is None
 
 
 def test_write_then_read_roundtrip_with_statuses(monkeypatch, tmp_path):
@@ -115,17 +116,20 @@ def test_write_then_read_roundtrip_with_statuses(monkeypatch, tmp_path):
     pr_details = [{"number": 1, "id": 101}]
     check_statuses = {101: "pass"}
     approval_statuses = {101: "approved"}
+    approval_details = {101: {"status": "approved", "current": 2, "required": 2}}
     cache.write_pr_cache(
         "org",
         "filter",
         pr_details,
         check_statuses=check_statuses,
         approval_statuses=approval_statuses,
+        approval_details=approval_details,
     )
     result = cache.read_pr_cache("org", "filter", 300)
     assert result["prs"] == pr_details
     assert result["check_statuses"] == check_statuses
     assert result["approval_statuses"] == approval_statuses
+    assert result["approval_details"] == approval_details
 
 
 def test_read_pr_cache_expired(monkeypatch, tmp_path):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -584,7 +584,8 @@ def _make_pr_detail(number=1, owner="org", repo="repo", pr_id=1001):
             "repo": {
                 "name": repo,
                 "owner": {"login": owner},
-            }
+            },
+            "ref": "main",
         },
         "head": {"sha": "abc123"},
         "mergeable": True,
@@ -618,8 +619,13 @@ def test_cli_outputs_approvals_column(monkeypatch):
     def fake_get_prs(_org, _repo_filter):
         return ["https://github.com/org/repo/pull/1"]
 
+    def fake_api_request(path):
+        if "/reviews" in path:
+            return [{"user": {"login": "bob"}, "state": "APPROVED"}]
+        return pr_detail
+
     monkeypatch.setattr(cli, "get_github_prs", fake_get_prs)
-    monkeypatch.setattr(api, "make_github_api_request", lambda path: pr_detail)
+    monkeypatch.setattr(api, "make_github_api_request", fake_api_request)
     monkeypatch.setattr(
         api,
         "make_github_graphql_request",
@@ -648,7 +654,13 @@ def test_cli_renders_review_required_for_incomplete_reviews(monkeypatch):
         "get_github_prs",
         lambda _org, _repo_filter: ["https://github.com/org/repo/pull/1"],
     )
-    monkeypatch.setattr(api, "make_github_api_request", lambda path: pr_detail)
+
+    def fake_api_request(path):
+        if "/reviews" in path:
+            return []
+        return pr_detail
+
+    monkeypatch.setattr(api, "make_github_api_request", fake_api_request)
     monkeypatch.setattr(
         api,
         "make_github_graphql_request",
@@ -663,7 +675,44 @@ def test_cli_renders_review_required_for_incomplete_reviews(monkeypatch):
     result = runner.invoke(cli.breakfast, ["-o", "org", "-r", "repo", "--approvals"])
 
     assert result.exit_code == 0
-    assert "⏳ review required" in result.output
+    assert "⏳ pending" in result.output
+
+
+def test_cli_renders_approval_counts_for_multi_review_branch(monkeypatch):
+    monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
+    monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
+    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+
+    pr_detail = _make_pr_detail()
+
+    def fake_api_request(path):
+        if "/reviews" in path:
+            return [{"user": {"login": "bob"}, "state": "APPROVED"}]
+        if path.endswith("/branches/main/protection/required_pull_request_reviews"):
+            return {"required_approving_review_count": 2}
+        return pr_detail
+
+    monkeypatch.setattr(
+        cli,
+        "get_github_prs",
+        lambda _org, _repo_filter: ["https://github.com/org/repo/pull/1"],
+    )
+    monkeypatch.setattr(api, "make_github_api_request", fake_api_request)
+    monkeypatch.setattr(
+        api,
+        "make_github_graphql_request",
+        lambda query, variables: {
+            "data": {
+                "repository": {"pullRequest": {"reviewDecision": "REVIEW_REQUIRED"}}
+            }
+        },
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(cli.breakfast, ["-o", "org", "-r", "repo", "--approvals"])
+
+    assert result.exit_code == 0
+    assert "✅ 1/2 approvals" in result.output
 
 
 def test_cli_approvals_not_shown_by_default(monkeypatch):
@@ -719,6 +768,46 @@ def test_cli_json_includes_approval_when_enabled(monkeypatch):
     assert result.exit_code == 0
     data = json.loads(result.output[result.output.index("[") :])
     assert data[0]["approval"] == "changes"
+
+
+def test_cli_json_includes_approval_counts_when_available(monkeypatch):
+    monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
+    monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
+    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+
+    pr_detail = _make_pr_detail()
+
+    def fake_api_request(path):
+        if "/reviews" in path:
+            return [{"user": {"login": "bob"}, "state": "APPROVED"}]
+        if path.endswith("/branches/main/protection/required_pull_request_reviews"):
+            return {"required_approving_review_count": 2}
+        return pr_detail
+
+    monkeypatch.setattr(
+        cli, "get_github_prs", lambda _o, _r: ["https://github.com/org/repo/pull/1"]
+    )
+    monkeypatch.setattr(api, "make_github_api_request", fake_api_request)
+    monkeypatch.setattr(
+        api,
+        "make_github_graphql_request",
+        lambda query, variables: {
+            "data": {
+                "repository": {"pullRequest": {"reviewDecision": "REVIEW_REQUIRED"}}
+            }
+        },
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli.breakfast, ["-o", "org", "-r", "repo", "--json", "--approvals"]
+    )
+
+    assert result.exit_code == 0
+    data = json.loads(result.output[result.output.index("[") :])
+    assert data[0]["approval"] == "pending"
+    assert data[0]["approval_current"] == 1
+    assert data[0]["approval_required"] == 2
 
 
 def test_cli_json_excludes_approval_by_default(monkeypatch):
@@ -1240,7 +1329,10 @@ def test_cli_init_config(monkeypatch):
 
 def _make_pr_detail(number=1):
     return {
-        "base": {"repo": {"name": "repo", "owner": {"login": "org"}}},
+        "base": {
+            "repo": {"name": "repo", "owner": {"login": "org"}},
+            "ref": "main",
+        },
         "head": {"sha": "abc123"},
         "mergeable": True,
         "mergeable_state": "clean",
@@ -1773,6 +1865,18 @@ def test_compress_styled_noop_for_single_word():
 def test_compress_styled_plain_text():
     assert cli._compress_styled("hello world") == "hello"
     assert cli._compress_styled("single") == "single"
+
+
+def test_compress_styled_preserves_approval_fraction():
+    styled = cli.format_approval_status(
+        "pending",
+        current_reviews=1,
+        required_reviews=2,
+    )
+
+    compressed = cli._compress_styled(styled)
+
+    assert cli._strip_ansi(compressed) == "✅ 1/2"
 
 
 def test_auto_fit_preserves_checks_colour(monkeypatch):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,11 +3,31 @@ from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timezone
 from unittest.mock import patch
 
+import pytest
 import requests
 from click.testing import CliRunner
 from tabulate import tabulate
 
 from breakfast import api, cache, cli
+
+
+@pytest.fixture(autouse=True)
+def stub_review_decision(monkeypatch):
+    monkeypatch.setattr(
+        api,
+        "make_github_graphql_request",
+        lambda query, variables: {
+            "data": {
+                "repository": {"pullRequest": {"reviewDecision": "REVIEW_REQUIRED"}}
+            }
+        },
+    )
+
+
+@pytest.fixture(autouse=True)
+def isolate_config_home(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "xdg_config"))
 
 
 def test_get_pr_age_days():
@@ -598,13 +618,15 @@ def test_cli_outputs_approvals_column(monkeypatch):
     def fake_get_prs(_org, _repo_filter):
         return ["https://github.com/org/repo/pull/1"]
 
-    def fake_api_request(path):
-        if "/reviews" in path:
-            return [{"user": {"login": "bob"}, "state": "APPROVED"}]
-        return pr_detail
-
     monkeypatch.setattr(cli, "get_github_prs", fake_get_prs)
-    monkeypatch.setattr(api, "make_github_api_request", fake_api_request)
+    monkeypatch.setattr(api, "make_github_api_request", lambda path: pr_detail)
+    monkeypatch.setattr(
+        api,
+        "make_github_graphql_request",
+        lambda query, variables: {
+            "data": {"repository": {"pullRequest": {"reviewDecision": "APPROVED"}}}
+        },
+    )
 
     runner = CliRunner()
     result = runner.invoke(cli.breakfast, ["-o", "org", "-r", "repo", "--approvals"])
@@ -612,6 +634,36 @@ def test_cli_outputs_approvals_column(monkeypatch):
     assert result.exit_code == 0
     assert "Approved" in result.output
     assert "✅ approved" in result.output
+
+
+def test_cli_renders_review_required_for_incomplete_reviews(monkeypatch):
+    monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
+    monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
+    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+
+    pr_detail = _make_pr_detail()
+
+    monkeypatch.setattr(
+        cli,
+        "get_github_prs",
+        lambda _org, _repo_filter: ["https://github.com/org/repo/pull/1"],
+    )
+    monkeypatch.setattr(api, "make_github_api_request", lambda path: pr_detail)
+    monkeypatch.setattr(
+        api,
+        "make_github_graphql_request",
+        lambda query, variables: {
+            "data": {
+                "repository": {"pullRequest": {"reviewDecision": "REVIEW_REQUIRED"}}
+            }
+        },
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(cli.breakfast, ["-o", "org", "-r", "repo", "--approvals"])
+
+    assert result.exit_code == 0
+    assert "⏳ review required" in result.output
 
 
 def test_cli_approvals_not_shown_by_default(monkeypatch):
@@ -649,6 +701,15 @@ def test_cli_json_includes_approval_when_enabled(monkeypatch):
         cli, "get_github_prs", lambda _o, _r: ["https://github.com/org/repo/pull/1"]
     )
     monkeypatch.setattr(api, "make_github_api_request", fake_api_request)
+    monkeypatch.setattr(
+        api,
+        "make_github_graphql_request",
+        lambda query, variables: {
+            "data": {
+                "repository": {"pullRequest": {"reviewDecision": "CHANGES_REQUESTED"}}
+            }
+        },
+    )
 
     runner = CliRunner()
     result = runner.invoke(

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -43,6 +43,31 @@ def test_format_mergeable_status():
     assert "yes (clean)" in ui.format_mergeable_status(True, "clean", style="ascii")
 
 
+def test_format_approval_status():
+    result = ui.format_approval_status("approved")
+    assert "✅ approved" in result
+
+    result = ui.format_approval_status("pending")
+    assert "⏳ pending" in result
+
+
+def test_format_approval_status_with_counts():
+    result = ui.format_approval_status(
+        "pending",
+        current_reviews=1,
+        required_reviews=2,
+    )
+    assert "✅ 1/2 approvals" in result
+
+    result = ui.format_approval_status(
+        "pending",
+        style="ascii",
+        current_reviews=0,
+        required_reviews=2,
+    )
+    assert "0/2 approvals" in result
+
+
 def test_format_pr_state_open():
     result = ui.format_pr_state("open", is_draft=False)
     assert "open" in result


### PR DESCRIPTION
## Summary
- use GitHub's pull request `reviewDecision` when computing approval status so repos that require multiple approvals do not show a false green `approved` state after a single approval
- keep the existing `approved` / `changes` / `pending` API surface, but render the pending state as `review required` in table output
- harden optional status fetching for partial mocked payloads and extend API/CLI coverage for GraphQL review decisions and REST fallback behaviour

## Testing
- `make lint`
- `make test`

## Issue
Closes #149