### PR TITLE
#44: Add --api-stats flag for API diagnostics

### DIFF
--- a/docs/manual/options.md
+++ b/docs/manual/options.md
@@ -501,6 +501,35 @@ breakfast -o my-org -r my-app --no-update-check
 export BREAKFAST_NO_UPDATE_CHECK=1
 ```
 
+## Diagnostics
+
+### `--debug`
+
+Print API diagnostics to stderr after the normal output. Useful for understanding slow runs or diagnosing rate-limit issues.
+
+```bash
+breakfast -o my-org -r my-app --debug
+```
+
+Output is written to **stderr** so it does not interfere with `--json` piping. Example:
+
+```
+🐛 Debug summary
+  Total elapsed:    3.41s
+  PRs processed:    42
+  API calls:        87 (85 REST + 2 GraphQL)
+  REST rate limit:  4913 requests remaining
+  REST rate resets: 10:30:00 UTC
+  GQL rate limit:   4998 points remaining
+  GQL rate resets:  2026-04-11T10:30:00Z
+```
+
+Can also be enabled persistently via config:
+
+```toml
+debug = true
+```
+
 ## Other options
 
 ### `--version`

--- a/docs/manual/options.md
+++ b/docs/manual/options.md
@@ -503,12 +503,12 @@ export BREAKFAST_NO_UPDATE_CHECK=1
 
 ## Diagnostics
 
-### `--debug`
+### `--api-stats`
 
 Print API diagnostics to stderr after the normal output. Useful for understanding slow runs or diagnosing rate-limit issues.
 
 ```bash
-breakfast -o my-org -r my-app --debug
+breakfast -o my-org -r my-app --api-stats
 ```
 
 Output is written to **stderr** so it does not interfere with `--json` piping. Example:
@@ -527,7 +527,7 @@ Output is written to **stderr** so it does not interfere with `--json` piping. E
 Can also be enabled persistently via config:
 
 ```toml
-debug = true
+api-stats = true
 ```
 
 ## Other options

--- a/src/breakfast/api.py
+++ b/src/breakfast/api.py
@@ -1,5 +1,6 @@
 import os
 import random
+import threading
 import time
 from functools import lru_cache
 from urllib.parse import quote
@@ -16,6 +17,39 @@ SECRET_GITHUB_TOKEN = os.getenv("GITHUB_TOKEN", None)
 
 _MAX_RETRIES = 3
 _RETRY_STATUSES = {502, 503, 504}
+
+_api_stats_lock = threading.Lock()
+_api_stats = {
+    "rest_calls": 0,
+    "graphql_calls": 0,
+    "rest_rate_limit_remaining": None,
+    "rest_rate_limit_reset": None,
+}
+
+
+def get_api_stats():
+    """Return a snapshot of the current API call statistics."""
+    with _api_stats_lock:
+        return dict(_api_stats)
+
+
+def get_graphql_rate_limit():
+    """Query the current GraphQL API rate limit status."""
+    query = """
+    query {
+      rateLimit {
+        cost
+        remaining
+        resetAt
+        used
+      }
+    }
+    """
+    try:
+        response = make_github_graphql_request(query)
+        return response.get("data", {}).get("rateLimit")
+    except (ValueError, requests.exceptions.RequestException):
+        return None
 
 
 def make_github_api_request(query_string):
@@ -48,7 +82,17 @@ def make_github_api_request(query_string):
                 req.status_code,
                 elapsed_ms,
             )
-            return req.json()
+            result = req.json()
+            with _api_stats_lock:
+                _api_stats["rest_calls"] += 1
+                headers = getattr(req, "headers", {})
+                remaining = headers.get("X-RateLimit-Remaining")
+                reset_ts = headers.get("X-RateLimit-Reset")
+                if remaining is not None:
+                    _api_stats["rest_rate_limit_remaining"] = int(remaining)
+                if reset_ts is not None:
+                    _api_stats["rest_rate_limit_reset"] = int(reset_ts)
+            return result
         except (
             requests.exceptions.ConnectionError,
             requests.exceptions.Timeout,
@@ -131,7 +175,9 @@ def make_github_graphql_request(query, variables={}):
                 response.status_code,
                 elapsed_ms,
             )
-            return response.json()
+            with _api_stats_lock:
+                _api_stats["graphql_calls"] += 1
+            return resp_json
         except (
             requests.exceptions.ConnectionError,
             requests.exceptions.Timeout,

--- a/src/breakfast/cli.py
+++ b/src/breakfast/cli.py
@@ -13,10 +13,12 @@ from tabulate import tabulate
 from .api import (
     SECRET_GITHUB_TOKEN,
     _fetch_pr_detail,
+    get_api_stats,
     get_approval_summary,
     get_authenticated_user_login,
     get_check_status,
     get_github_prs,
+    get_graphql_rate_limit,
 )
 from .cache import (
     parse_ttl,
@@ -234,6 +236,35 @@ def _auto_fit(pr_data, terminal_width, explicit_max_title_length):
 
 def _stdout_is_tty():
     return sys.stdout.isatty()
+
+
+def _print_debug_summary(t0, pr_count, api_stats, graphql_rate_limit):
+    from datetime import datetime, timezone
+
+    elapsed = time.monotonic() - t0
+    total_calls = api_stats["rest_calls"] + api_stats["graphql_calls"]
+    lines = [
+        click.style("🐛 Debug summary", fg="cyan", bold=True),
+        f"  Total elapsed:    {elapsed:.2f}s",
+        f"  PRs processed:    {pr_count}",
+        f"  API calls:        {total_calls}"
+        f" ({api_stats['rest_calls']} REST + {api_stats['graphql_calls']} GraphQL)",
+    ]
+    remaining = api_stats.get("rest_rate_limit_remaining")
+    reset_ts = api_stats.get("rest_rate_limit_reset")
+    if remaining is not None:
+        lines.append(f"  REST rate limit:  {remaining} requests remaining")
+    if reset_ts is not None:
+        reset_dt = datetime.fromtimestamp(reset_ts, tz=timezone.utc)
+        lines.append(f"  REST rate resets: {reset_dt.strftime('%H:%M:%S UTC')}")
+    if graphql_rate_limit:
+        gql_remaining = graphql_rate_limit.get("remaining")
+        gql_reset = graphql_rate_limit.get("resetAt")
+        if gql_remaining is not None:
+            lines.append(f"  GQL rate limit:   {gql_remaining} points remaining")
+        if gql_reset:
+            lines.append(f"  GQL rate resets:  {gql_reset}")
+    click.echo("\n".join(lines), err=True)
 
 
 def get_pr_age_days(pr_detail, now=None):
@@ -505,6 +536,15 @@ def _fetch_pr_bundle(url, fetch_checks, fetch_approvals):
         " matching is case-insensitive."
     ),
 )
+@click.option(
+    "--debug",
+    is_flag=True,
+    default=False,
+    help=(
+        "Print API diagnostics to stderr after output: call counts,"
+        " rate-limit remaining, and total elapsed time."
+    ),
+)
 @click.version_option(package_name="breakfast")
 def breakfast(
     config,
@@ -536,7 +576,9 @@ def breakfast(
     legendary,
     legendary_only,
     search,
+    debug,
 ):
+    t0_total = time.monotonic()
     configure_logging()
 
     if search is not None:
@@ -589,6 +631,7 @@ def breakfast(
     legendary_only = legendary_only or cfg.get("legendary-only", False)
     if legendary_only:
         legendary = True  # --legendary-only implies marking
+    debug = debug or cfg.get("debug", False)
 
     # Cache is opt-in: CLI flag > config > default off.
     cache_enabled = cache if cache is not None else cfg.get("cache", False)
@@ -650,6 +693,7 @@ def breakfast(
             "legendary": legendary,
             "legendary-only": legendary_only,
             "search": search,
+            "debug": debug,
         }
         for k, v in resolved.items():
             click.echo(f"  {k}: {v}")
@@ -660,7 +704,7 @@ def breakfast(
         " cache_enabled=%s cache_ttl=%ss refresh=%s refresh_prs=%s"
         " checks=%s approvals=%s age=%s legendary=%s legendary_only=%s"
         " limit=%s max_title_length=%s status_style=%s json=%s"
-        " filter_state=%r filter_check=%r filter_approval=%r search=%r",
+        " filter_state=%r filter_check=%r filter_approval=%r search=%r debug=%s",
         organization,
         repo_filter,
         mine_only,
@@ -682,6 +726,7 @@ def breakfast(
         filter_check,
         filter_approval,
         search,
+        debug,
     )
 
     if no_drafts and drafts_only:
@@ -983,6 +1028,10 @@ def breakfast(
             if update_msg:
                 logger.info("update_available msg=%r", update_msg)
                 click.echo(click.style(update_msg, fg="cyan", bold=True), err=True)
+        if debug:
+            _print_debug_summary(
+                t0_total, len(json_data), get_api_stats(), get_graphql_rate_limit()
+            )
         return
 
     for pr_detail in pr_details:
@@ -1074,6 +1123,11 @@ def breakfast(
         if update_msg:
             logger.info("update_available msg=%r", update_msg)
             click.echo(click.style(update_msg, fg="cyan", bold=True), err=True)
+
+    if debug:
+        _print_debug_summary(
+            t0_total, len(pr_data), get_api_stats(), get_graphql_rate_limit()
+        )
 
 
 if __name__ == "__main__":

--- a/src/breakfast/cli.py
+++ b/src/breakfast/cli.py
@@ -537,7 +537,7 @@ def _fetch_pr_bundle(url, fetch_checks, fetch_approvals):
     ),
 )
 @click.option(
-    "--debug",
+    "--api-stats",
     is_flag=True,
     default=False,
     help=(
@@ -576,7 +576,7 @@ def breakfast(
     legendary,
     legendary_only,
     search,
-    debug,
+    api_stats,
 ):
     t0_total = time.monotonic()
     configure_logging()
@@ -631,7 +631,7 @@ def breakfast(
     legendary_only = legendary_only or cfg.get("legendary-only", False)
     if legendary_only:
         legendary = True  # --legendary-only implies marking
-    debug = debug or cfg.get("debug", False)
+    api_stats = api_stats or cfg.get("api-stats", False)
 
     # Cache is opt-in: CLI flag > config > default off.
     cache_enabled = cache if cache is not None else cfg.get("cache", False)
@@ -693,7 +693,7 @@ def breakfast(
             "legendary": legendary,
             "legendary-only": legendary_only,
             "search": search,
-            "debug": debug,
+            "api-stats": api_stats,
         }
         for k, v in resolved.items():
             click.echo(f"  {k}: {v}")
@@ -704,7 +704,7 @@ def breakfast(
         " cache_enabled=%s cache_ttl=%ss refresh=%s refresh_prs=%s"
         " checks=%s approvals=%s age=%s legendary=%s legendary_only=%s"
         " limit=%s max_title_length=%s status_style=%s json=%s"
-        " filter_state=%r filter_check=%r filter_approval=%r search=%r debug=%s",
+        " filter_state=%r filter_check=%r filter_approval=%r search=%r api_stats=%s",
         organization,
         repo_filter,
         mine_only,
@@ -726,7 +726,7 @@ def breakfast(
         filter_check,
         filter_approval,
         search,
-        debug,
+        api_stats,
     )
 
     if no_drafts and drafts_only:
@@ -1028,7 +1028,7 @@ def breakfast(
             if update_msg:
                 logger.info("update_available msg=%r", update_msg)
                 click.echo(click.style(update_msg, fg="cyan", bold=True), err=True)
-        if debug:
+        if api_stats:
             _print_debug_summary(
                 t0_total, len(json_data), get_api_stats(), get_graphql_rate_limit()
             )
@@ -1124,7 +1124,7 @@ def breakfast(
             logger.info("update_available msg=%r", update_msg)
             click.echo(click.style(update_msg, fg="cyan", bold=True), err=True)
 
-    if debug:
+    if api_stats:
         _print_debug_summary(
             t0_total, len(pr_data), get_api_stats(), get_graphql_rate_limit()
         )

--- a/src/breakfast/config.py
+++ b/src/breakfast/config.py
@@ -192,6 +192,17 @@ def generate_default_config():
 # approval statuses. Higher values fetch faster but consume more API rate limit.
 # Equivalent to: --workers <n>
 # workers = 64
+
+
+# -----------------------------------------------------------------------------
+# Diagnostics
+# Tools for understanding what breakfast is doing under the hood.
+# -----------------------------------------------------------------------------
+
+# Print API diagnostics to stderr after output: total elapsed time, number of
+# REST and GraphQL calls made, and rate-limit remaining/reset info.
+# Equivalent to: --debug
+# debug = false
 """
     config_path.write_text(default_content)
     click.echo(click.style(f"Created default config at {config_path}", fg="green"))

--- a/src/breakfast/config.py
+++ b/src/breakfast/config.py
@@ -201,8 +201,8 @@ def generate_default_config():
 
 # Print API diagnostics to stderr after output: total elapsed time, number of
 # REST and GraphQL calls made, and rate-limit remaining/reset info.
-# Equivalent to: --debug
-# debug = false
+# Equivalent to: --api-stats
+# api-stats = false
 """
     config_path.write_text(default_content)
     click.echo(click.style(f"Created default config at {config_path}", fg="green"))

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -639,3 +639,106 @@ def test_make_github_graphql_request_raises_on_persistent_timeout(monkeypatch):
 
     with pytest.raises(requests.exceptions.Timeout):
         api.make_github_graphql_request("{ viewer { login } }")
+
+
+def test_get_api_stats_tracks_rest_calls(monkeypatch):
+    """REST calls increment the rest_calls counter."""
+    monkeypatch.setattr(api, "SECRET_GITHUB_TOKEN", "token-123")
+    monkeypatch.setattr(api.time, "sleep", lambda _: None)
+    # Reset stats for this test
+    with api._api_stats_lock:
+        api._api_stats.update(
+            {
+                "rest_calls": 0,
+                "graphql_calls": 0,
+                "rest_rate_limit_remaining": None,
+                "rest_rate_limit_reset": None,
+            }
+        )
+
+    class OkResponse:
+        status_code = 200
+        headers = {"X-RateLimit-Remaining": "4999", "X-RateLimit-Reset": "1700000000"}
+
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return {"ok": True}
+
+    monkeypatch.setattr(api.requests, "get", lambda url, headers: OkResponse())
+
+    api.make_github_api_request("/repos/org/repo")
+    api.make_github_api_request("/repos/org/repo")
+
+    stats = api.get_api_stats()
+    assert stats["rest_calls"] == 2
+    assert stats["rest_rate_limit_remaining"] == 4999
+    assert stats["rest_rate_limit_reset"] == 1700000000
+
+
+def test_get_api_stats_tracks_graphql_calls(monkeypatch):
+    """GraphQL calls increment the graphql_calls counter."""
+    monkeypatch.setattr(api, "SECRET_GITHUB_TOKEN", "token-123")
+    monkeypatch.setattr(api.time, "sleep", lambda _: None)
+    monkeypatch.setattr(api.random, "uniform", lambda _a, _b: 0)
+    with api._api_stats_lock:
+        api._api_stats.update(
+            {
+                "rest_calls": 0,
+                "graphql_calls": 0,
+                "rest_rate_limit_remaining": None,
+                "rest_rate_limit_reset": None,
+            }
+        )
+
+    class GoodGraphqlResponse:
+        status_code = 200
+
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return {"data": {"viewer": {"login": "alice"}}}
+
+    monkeypatch.setattr(
+        api.requests, "post", lambda url, json, headers: GoodGraphqlResponse()
+    )
+
+    api.make_github_graphql_request("{ viewer { login } }")
+    api.make_github_graphql_request("{ viewer { login } }")
+
+    stats = api.get_api_stats()
+    assert stats["graphql_calls"] == 2
+
+
+def test_get_graphql_rate_limit_returns_rate_limit_data(monkeypatch):
+    """get_graphql_rate_limit returns the rateLimit node from the response."""
+    rate_limit = {
+        "cost": 1,
+        "remaining": 4998,
+        "resetAt": "2026-04-11T10:30:00Z",
+        "used": 2,
+    }
+    monkeypatch.setattr(
+        api,
+        "make_github_graphql_request",
+        lambda query, variables={}: {"data": {"rateLimit": rate_limit}},
+    )
+
+    result = api.get_graphql_rate_limit()
+    assert result == rate_limit
+
+
+def test_get_graphql_rate_limit_returns_none_on_error(monkeypatch):
+    """get_graphql_rate_limit returns None if the request fails."""
+    monkeypatch.setattr(
+        api,
+        "make_github_graphql_request",
+        lambda query, variables={}: (_ for _ in ()).throw(
+            requests.exceptions.ConnectionError("network error")
+        ),
+    )
+
+    result = api.get_graphql_rate_limit()
+    assert result is None

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2099,7 +2099,7 @@ def test_debug_flag_prints_summary_to_stderr(monkeypatch):
     monkeypatch.setattr(api, "make_github_api_request", fake_api_request)
 
     runner = CliRunner()
-    result = runner.invoke(cli.breakfast, ["-o", "org", "-r", "repo", "--debug"])
+    result = runner.invoke(cli.breakfast, ["-o", "org", "-r", "repo", "--api-stats"])
 
     assert result.exit_code == 0
     assert "Debug summary" in result.output

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2048,3 +2048,63 @@ def test_progress_emoji_emitted_after_check_status_fetch(monkeypatch):
     # bundle_complete appears exactly once — no second bulk-fetch phase
     assert call_log.count("bundle_complete") == 1
     assert call_log.count("check_status_fetched") == 1
+
+
+def test_debug_flag_prints_summary_to_stderr(monkeypatch):
+    """--debug emits a summary block to stderr without disrupting stdout output."""
+    monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
+    monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
+    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(
+        cli,
+        "get_api_stats",
+        lambda: {
+            "rest_calls": 10,
+            "graphql_calls": 2,
+            "rest_rate_limit_remaining": 4990,
+            "rest_rate_limit_reset": 1700000000,
+        },
+    )
+    monkeypatch.setattr(
+        cli,
+        "get_graphql_rate_limit",
+        lambda: {
+            "remaining": 4998,
+            "resetAt": "2026-04-11T10:30:00Z",
+        },
+    )
+
+    def fake_get_prs(_org, _repo_filter):
+        return ["https://github.com/org/repo/pull/1"]
+
+    def fake_api_request(_path):
+        return {
+            "base": {"repo": {"name": "repo"}},
+            "mergeable": True,
+            "mergeable_state": "clean",
+            "additions": 5,
+            "deletions": 2,
+            "title": "Test PR",
+            "user": {"login": "alice"},
+            "state": "open",
+            "changed_files": 1,
+            "commits": 1,
+            "review_comments": 0,
+            "created_at": "2026-01-10T00:00:00Z",
+            "html_url": "https://github.com/org/repo/pull/1",
+            "number": 1,
+        }
+
+    monkeypatch.setattr(cli, "get_github_prs", fake_get_prs)
+    monkeypatch.setattr(api, "make_github_api_request", fake_api_request)
+
+    runner = CliRunner()
+    result = runner.invoke(cli.breakfast, ["-o", "org", "-r", "repo", "--debug"])
+
+    assert result.exit_code == 0
+    assert "Debug summary" in result.output
+    assert "12 (10 REST + 2 GraphQL)" in result.output
+    assert "4990 requests remaining" in result.output
+    assert "4998 points remaining" in result.output
+    # Normal table output is still present
+    assert "PR-1" in result.output

--- a/uv.lock
+++ b/uv.lock
@@ -41,7 +41,7 @@ wheels = [
 
 [[package]]
 name = "breakfast"
-version = "0.35.0"
+version = "0.37.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

- Adds `--api-stats` flag (and `api-stats = true` config key) that prints API diagnostics to stderr after normal output
- Tracks REST + GraphQL call counts in a thread-safe module-level stats dict in `api.py`
- Captures `X-RateLimit-Remaining` / `X-RateLimit-Reset` headers from REST responses
- Adds `get_graphql_rate_limit()` which queries the GraphQL `rateLimit` node on demand when `--api-stats` is active
- Updates `docs/manual/options.md` with an `--api-stats` section and example output
- Adds `api-stats` key to the generated config template

## Example output

```
🐛 Debug summary
  Total elapsed:    3.41s
  PRs processed:    42
  API calls:        87 (85 REST + 2 GraphQL)
  REST rate limit:  4913 requests remaining
  REST rate resets: 10:30:00 UTC
  GQL rate limit:   4998 points remaining
  GQL rate resets:  2026-04-11T10:30:00Z
```

## Test plan

- [ ] 5 new tests added covering stats tracking, `get_graphql_rate_limit()`, and the `--api-stats` CLI flag
- [ ] All 190 tests pass
- [ ] `make lint` clean
- [ ] Manual: run `breakfast -o <org> --api-stats` and verify summary appears on stderr without disrupting table output
- [ ] Manual: run `breakfast -o <org> --json --api-stats` and verify JSON is clean on stdout, debug on stderr

Closes #44

https://claude.ai/code/session_0186amNpoEzyAee5xb18vvTh