### PR TITLE
#102: Retry on ChunkedEncodingError in REST and GraphQL request paths

### DIFF
--- a/src/breakfast/api.py
+++ b/src/breakfast/api.py
@@ -94,6 +94,7 @@ def make_github_api_request(query_string):
                     _api_stats["rest_rate_limit_reset"] = int(reset_ts)
             return result
         except (
+            requests.exceptions.ChunkedEncodingError,
             requests.exceptions.ConnectionError,
             requests.exceptions.Timeout,
         ) as exc:
@@ -179,6 +180,7 @@ def make_github_graphql_request(query, variables={}):
                 _api_stats["graphql_calls"] += 1
             return resp_json
         except (
+            requests.exceptions.ChunkedEncodingError,
             requests.exceptions.ConnectionError,
             requests.exceptions.Timeout,
         ) as exc:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -641,6 +641,66 @@ def test_make_github_graphql_request_raises_on_persistent_timeout(monkeypatch):
         api.make_github_graphql_request("{ viewer { login } }")
 
 
+def test_make_github_graphql_request_retries_on_chunked_encoding_error(monkeypatch):
+    """Premature chunked response is retried and eventually succeeds."""
+    attempts = []
+    monkeypatch.setattr(api, "SECRET_GITHUB_TOKEN", "token-123")
+    monkeypatch.setattr(api.time, "sleep", lambda _: None)
+    monkeypatch.setattr(api.random, "uniform", lambda _a, _b: 0)
+
+    class GoodResponse:
+        status_code = 200
+
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return {"data": {"ok": True}}
+
+    def fake_post(url, json, headers):
+        attempts.append(1)
+        if len(attempts) < 3:
+            raise requests.exceptions.ChunkedEncodingError("Response ended prematurely")
+        return GoodResponse()
+
+    monkeypatch.setattr(api.requests, "post", fake_post)
+
+    result = api.make_github_graphql_request("{ viewer { login } }")
+
+    assert result == {"data": {"ok": True}}
+    assert len(attempts) == 3
+
+
+def test_make_github_api_request_retries_on_chunked_encoding_error(monkeypatch):
+    """Premature chunked REST response is retried and eventually succeeds."""
+    attempts = []
+    monkeypatch.setattr(api, "SECRET_GITHUB_TOKEN", "token-123")
+    monkeypatch.setattr(api.time, "sleep", lambda _: None)
+
+    class GoodResponse:
+        status_code = 200
+        headers = {}
+
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return {"ok": True}
+
+    def fake_get(url, headers):
+        attempts.append(1)
+        if len(attempts) < 2:
+            raise requests.exceptions.ChunkedEncodingError("Response ended prematurely")
+        return GoodResponse()
+
+    monkeypatch.setattr(api.requests, "get", fake_get)
+
+    result = api.make_github_api_request("/repos/org/repo")
+
+    assert result == {"ok": True}
+    assert len(attempts) == 2
+
+
 def test_get_api_stats_tracks_rest_calls(monkeypatch):
     """REST calls increment the rest_calls counter."""
     monkeypatch.setattr(api, "SECRET_GITHUB_TOKEN", "token-123")

--- a/uv.lock
+++ b/uv.lock
@@ -41,7 +41,7 @@ wheels = [
 
 [[package]]
 name = "breakfast"
-version = "0.37.0"
+version = "0.38.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

- `ChunkedEncodingError` (premature chunked response — `Response ended prematurely`) is not a subclass of `ConnectionError`, so it previously escaped the retry handler and crashed the CLI with a raw traceback
- Added it to the `except` tuple in both `make_github_api_request` and `make_github_graphql_request`, giving it the same bounded exponential backoff + jitter treatment as `ConnectionError` and `Timeout`

## Test plan

- [ ] Two new tests: retry-then-succeed for `ChunkedEncodingError` in both the REST and GraphQL paths
- [ ] All 192 tests pass
- [ ] `make lint` clean

Closes #102

https://claude.ai/code/session_0186amNpoEzyAee5xb18vvTh