### PR TITLE
#147: Add 'draft' as a valid --filter-state value

### DIFF
--- a/docs/manual/options.md
+++ b/docs/manual/options.md
@@ -63,11 +63,14 @@ With `--ignore-author dependabot[bot]`, the bot PR is excluded:
 
 ### `--filter-state`
 
-Only show PRs with a specific state. Accepted values: `open`, `closed`. Repeat the flag to match multiple states.
+Only show PRs with a specific state. Accepted values: `open`, `closed`, `draft`. Repeat the flag to match multiple states.
+
+`draft` matches PRs where `draft=true`. It can be combined with other states:
 
 ```bash
-breakfast -o my-org -r my-app --filter-state open                          # open PRs only
-breakfast -o my-org -r my-app --filter-state open --filter-state closed    # both states
+breakfast -o my-org -r my-app --filter-state open            # open PRs only (includes drafts)
+breakfast -o my-org -r my-app --filter-state draft           # only draft PRs
+breakfast -o my-org -r my-app --filter-state closed --filter-state draft   # closed or draft
 ```
 
 ### `--filter-check`

--- a/docs/manual/options.md
+++ b/docs/manual/options.md
@@ -68,9 +68,9 @@ Only show PRs with a specific state. Accepted values: `open`, `closed`, `draft`.
 `draft` matches PRs where `draft=true`. It can be combined with other states:
 
 ```bash
-breakfast -o my-org -r my-app --filter-state open            # open PRs only (includes drafts)
-breakfast -o my-org -r my-app --filter-state draft           # only draft PRs
-breakfast -o my-org -r my-app --filter-state closed --filter-state draft   # closed or draft
+breakfast -o my-org -r my-app --filter-state open                        # open PRs only (includes drafts)
+breakfast -o my-org -r my-app --filter-state draft                       # only draft PRs
+breakfast -o my-org -r my-app --filter-state closed --filter-state draft # closed or draft
 ```
 
 ### `--filter-check`

--- a/src/breakfast/cli.py
+++ b/src/breakfast/cli.py
@@ -494,9 +494,12 @@ def _fetch_pr_bundle(url, fetch_checks, fetch_approvals):
 )
 @click.option(
     "--filter-state",
-    type=click.Choice(["open", "closed"], case_sensitive=False),
+    type=click.Choice(["open", "closed", "draft"], case_sensitive=False),
     multiple=True,
-    help="Only show PRs with this state. Repeat for multiple values.",
+    help=(
+        "Only show PRs with this state. Repeat for multiple values."
+        " 'draft' matches PRs where draft=true."
+    ),
 )
 @click.option(
     "--filter-check",

--- a/src/breakfast/config.py
+++ b/src/breakfast/config.py
@@ -259,10 +259,16 @@ def filter_pr_details(
             continue
         if drafts_only and not is_draft:
             continue
-        if filter_state and pr_detail.get("state", "").lower() not in {
-            s.lower() for s in filter_state
-        }:
-            continue
+        if filter_state:
+            filter_state_lower = {s.lower() for s in filter_state}
+            regular_states = filter_state_lower - {"draft"}
+            include_drafts = "draft" in filter_state_lower
+            is_draft = pr_detail.get("draft", False)
+            pr_state = pr_detail.get("state", "").lower()
+            state_match = bool(regular_states) and pr_state in regular_states
+            draft_match = include_drafts and is_draft
+            if not (state_match or draft_match):
+                continue
         if filter_check and check_statuses is not None:
             pr_check = check_statuses.get(pr_detail["id"], "none")
             if pr_check not in filter_check:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -134,6 +134,25 @@ def test_filter_pr_details_filter_state():
     assert result[0]["id"] == 2
 
 
+def test_filter_pr_details_filter_state_draft():
+    draft_pr = {**_make_pr(state="open", pr_id=1), "draft": True}
+    open_pr = {**_make_pr(state="open", pr_id=2), "draft": False}
+    closed_pr = {**_make_pr(state="closed", pr_id=3), "draft": False}
+    pr_details = [draft_pr, open_pr, closed_pr]
+
+    # draft only
+    result = config.filter_pr_details(pr_details, [], filter_state=("draft",))
+    assert [r["id"] for r in result] == [1]
+
+    # closed + draft
+    result = config.filter_pr_details(pr_details, [], filter_state=("closed", "draft"))
+    assert sorted(r["id"] for r in result) == [1, 3]
+
+    # open alone still includes draft PRs (state=open)
+    result = config.filter_pr_details(pr_details, [], filter_state=("open",))
+    assert sorted(r["id"] for r in result) == [1, 2]
+
+
 def test_filter_pr_details_filter_check():
     pr_details = [_make_pr(pr_id=1), _make_pr(pr_id=2), _make_pr(pr_id=3)]
     check_statuses = {1: "pass", 2: "fail", 3: "pending"}


### PR DESCRIPTION
## Summary

- Adds `draft` to the accepted values for `--filter-state` alongside `open` and `closed`
- `draft` matches PRs where `draft=true`, independently of the `state` field (GitHub always reports drafts as `state=open`)
- Existing `--no-drafts` and `--drafts-only` behaviour is unaffected

## Behaviour

```bash
--filter-state draft           # only draft PRs
--filter-state closed draft    # closed PRs or draft PRs
--filter-state open            # all open PRs (unchanged — still includes drafts)
```

## Test plan

- [ ] 3 new assertions in `test_filter_pr_details_filter_state_draft` covering draft-only, combined, and open-includes-drafts cases
- [ ] All 193 tests pass
- [ ] `make lint` clean
- [ ] `docs/manual/options.md` updated with new accepted value and examples

Closes #147

https://claude.ai/code/session_0186amNpoEzyAee5xb18vvTh