### PR TITLE
#130: Add --no-colour / --no-color flag and NO_COLOR env var support

### DIFF
--- a/docs/manual/options.md
+++ b/docs/manual/options.md
@@ -509,6 +509,29 @@ breakfast -o my-org -r my-app --no-update-check
 export BREAKFAST_NO_UPDATE_CHECK=1
 ```
 
+## Colour control
+
+### `--no-colour` / `--no-color`
+
+Disable all ANSI colour codes and formatting in output. Useful when piping output to a file, logging system, or tool that does not interpret escape codes.
+
+```bash
+breakfast -o my-org -r my-app --no-colour
+breakfast -o my-org -r my-app --no-color    # US spelling alias
+```
+
+The `NO_COLOR` environment variable is also honoured (see [no-color.org](https://no-color.org/)):
+
+```bash
+NO_COLOR=1 breakfast -o my-org -r my-app
+```
+
+Can also be set persistently in config:
+
+```toml
+no-colour = true
+```
+
 ## Diagnostics
 
 ### `--api-stats`

--- a/src/breakfast/cli.py
+++ b/src/breakfast/cli.py
@@ -545,6 +545,18 @@ def _fetch_pr_bundle(url, fetch_checks, fetch_approvals):
         " rate-limit remaining, and total elapsed time."
     ),
 )
+@click.option(
+    "--no-colour",
+    "--no-color",
+    "no_colour",
+    is_flag=True,
+    default=False,
+    envvar="NO_COLOR",
+    help=(
+        "Disable ANSI colour in all output."
+        " Also honoured via the NO_COLOR environment variable (no-color.org)."
+    ),
+)
 @click.version_option(package_name="breakfast")
 def breakfast(
     config,
@@ -577,6 +589,7 @@ def breakfast(
     legendary_only,
     search,
     api_stats,
+    no_colour,
 ):
     t0_total = time.monotonic()
     configure_logging()
@@ -590,7 +603,8 @@ def breakfast(
                     f"Error: --search pattern is not valid regex: {exc}",
                     fg="red",
                     bold=True,
-                )
+                ),
+                color=not no_colour,
             )
             sys.exit(1)
 
@@ -632,6 +646,8 @@ def breakfast(
     if legendary_only:
         legendary = True  # --legendary-only implies marking
     api_stats = api_stats or cfg.get("api-stats", False)
+    no_colour = no_colour or cfg.get("no-colour", False)
+    colour = not no_colour
 
     # Cache is opt-in: CLI flag > config > default off.
     cache_enabled = cache if cache is not None else cfg.get("cache", False)
@@ -643,7 +659,8 @@ def breakfast(
                 " Pass --cache or set cache = true in config.",
                 fg="red",
                 bold=True,
-            )
+            ),
+            color=colour,
         )
         sys.exit(1)
     if refresh_prs and not cache_enabled:
@@ -653,7 +670,8 @@ def breakfast(
                 " Pass --cache or set cache = true in config.",
                 fg="red",
                 bold=True,
-            )
+            ),
+            color=colour,
         )
         sys.exit(1)
 
@@ -664,7 +682,7 @@ def breakfast(
     except ValueError as exc:
         logger.error("invalid_cache_ttl value=%r error=%s", raw_ttl, exc)
         msg = f"Error: invalid --cache-ttl value: {exc}"
-        click.echo(click.style(msg, fg="red", bold=True))
+        click.echo(click.style(msg, fg="red", bold=True), color=colour)
         sys.exit(1)
 
     if show_config:
@@ -694,6 +712,7 @@ def breakfast(
             "legendary-only": legendary_only,
             "search": search,
             "api-stats": api_stats,
+            "no-colour": no_colour,
         }
         for k, v in resolved.items():
             click.echo(f"  {k}: {v}")
@@ -735,7 +754,8 @@ def breakfast(
                 "Error: --no-drafts and --drafts-only are mutually exclusive.",
                 fg="red",
                 bold=True,
-            )
+            ),
+            color=colour,
         )
         sys.exit(1)
 
@@ -744,12 +764,12 @@ def breakfast(
             "Organization must be provided via CLI (-o) "
             "or config file (organization)."
         )
-        click.echo(click.style(message, fg="red", bold=True))
+        click.echo(click.style(message, fg="red", bold=True), color=colour)
         sys.exit(1)
 
     if SECRET_GITHUB_TOKEN is None:
         message = "GITHUB_TOKEN not set in environment - exiting..."
-        click.echo(click.style(message, fg="red", bold=True))
+        click.echo(click.style(message, fg="red", bold=True), color=colour)
         sys.exit(1)
     current_user_login = None
     if mine_only:
@@ -808,7 +828,9 @@ def breakfast(
                     "check your network connection and try again.\n"
                     f"  ({type(exc).__name__}: {exc})"
                 )
-                click.echo(click.style(msg, fg="red", bold=True), err=True)
+                click.echo(
+                    click.style(msg, fg="red", bold=True), err=True, color=colour
+                )
                 sys.exit(1)
             if cache_enabled:
                 write_graphql_cache(organization, repo_filter, prs)
@@ -856,7 +878,7 @@ def breakfast(
                 f"Warning: {len(failed_urls)} PR(s) could not be fetched"
                 f" after retries: {examples}{suffix}"
             )
-            click.echo(click.style(msg, fg="yellow"), err=True)
+            click.echo(click.style(msg, fg="yellow"), err=True, color=colour)
         if cache_enabled:
             needs_cache_write = True
     else:
@@ -971,7 +993,8 @@ def breakfast(
             click.style(
                 f"🔍 No PRs matched '{search}'",
                 fg="yellow",
-            )
+            ),
+            color=colour,
         )
     pr_details.sort(key=lambda pr: pr["base"]["repo"]["name"])
     if legendary_only:
@@ -1027,7 +1050,11 @@ def breakfast(
             update_msg = check_for_update()
             if update_msg:
                 logger.info("update_available msg=%r", update_msg)
-                click.echo(click.style(update_msg, fg="cyan", bold=True), err=True)
+                click.echo(
+                    click.style(update_msg, fg="cyan", bold=True),
+                    err=True,
+                    color=colour,
+                )
         if api_stats:
             _print_debug_summary(
                 t0_total, len(json_data), get_api_stats(), get_graphql_rate_limit()
@@ -1111,7 +1138,7 @@ def breakfast(
             tablefmt="outline",
             disable_numparse=True,
         ),
-        color=_stdout_is_tty(),
+        color=_stdout_is_tty() and colour,
     )
 
     logger.info(
@@ -1122,7 +1149,9 @@ def breakfast(
         update_msg = check_for_update()
         if update_msg:
             logger.info("update_available msg=%r", update_msg)
-            click.echo(click.style(update_msg, fg="cyan", bold=True), err=True)
+            click.echo(
+                click.style(update_msg, fg="cyan", bold=True), err=True, color=colour
+            )
 
     if api_stats:
         _print_debug_summary(

--- a/src/breakfast/config.py
+++ b/src/breakfast/config.py
@@ -203,6 +203,11 @@ def generate_default_config():
 # REST and GraphQL calls made, and rate-limit remaining/reset info.
 # Equivalent to: --api-stats
 # api-stats = false
+
+# Disable all ANSI colour codes in output. Equivalent to setting the
+# NO_COLOR environment variable (https://no-color.org/).
+# Equivalent to: --no-colour
+# no-colour = false
 """
     config_path.write_text(default_content)
     click.echo(click.style(f"Created default config at {config_path}", fg="green"))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2108,3 +2108,59 @@ def test_debug_flag_prints_summary_to_stderr(monkeypatch):
     assert "4998 points remaining" in result.output
     # Normal table output is still present
     assert "PR-1" in result.output
+
+
+def _plain_pr():
+    return {
+        "base": {"repo": {"name": "repo", "html_url": "https://github.com/org/repo"}},
+        "mergeable": True,
+        "mergeable_state": "clean",
+        "additions": 5,
+        "deletions": 2,
+        "title": "Test PR",
+        "user": {"login": "alice", "html_url": "https://github.com/alice"},
+        "state": "open",
+        "draft": False,
+        "changed_files": 1,
+        "commits": 1,
+        "review_comments": 0,
+        "created_at": "2026-01-10T00:00:00Z",
+        "html_url": "https://github.com/org/repo/pull/1",
+        "number": 1,
+        "id": 1,
+    }
+
+
+def test_no_colour_strips_ansi_from_table(monkeypatch):
+    """--no-colour produces output with no ANSI escape sequences."""
+    monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
+    monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
+    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(
+        cli, "get_github_prs", lambda *_: ["https://github.com/org/repo/pull/1"]
+    )
+    monkeypatch.setattr(api, "make_github_api_request", lambda _: _plain_pr())
+
+    runner = CliRunner()
+    result = runner.invoke(cli.breakfast, ["-o", "org", "-r", "repo", "--no-colour"])
+
+    assert result.exit_code == 0
+    assert "\x1b[" not in result.output
+    assert "PR-1" in result.output
+
+
+def test_no_color_alias_works(monkeypatch):
+    """--no-color (US spelling) is accepted and strips ANSI."""
+    monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
+    monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
+    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(
+        cli, "get_github_prs", lambda *_: ["https://github.com/org/repo/pull/1"]
+    )
+    monkeypatch.setattr(api, "make_github_api_request", lambda _: _plain_pr())
+
+    runner = CliRunner()
+    result = runner.invoke(cli.breakfast, ["-o", "org", "-r", "repo", "--no-color"])
+
+    assert result.exit_code == 0
+    assert "\x1b[" not in result.output


### PR DESCRIPTION
## Summary

- Adds `--no-colour` flag (with `--no-color` US-spelling alias) that strips all ANSI escape codes from output
- The `NO_COLOR` environment variable ([no-color.org](https://no-color.org/)) is also honoured via Click's `envvar` mechanism
- Can be set persistently in config: `no-colour = true`

When active, `color=False` is passed to all `click.echo` calls that carry styled text, causing Click to strip escape sequences before writing. Covers: the table, all error/warning messages, update notifications, and the search no-results message.

## Usage

```bash
breakfast -o my-org --no-colour
breakfast -o my-org --no-color       # US spelling alias
NO_COLOR=1 breakfast -o my-org       # environment variable
```

## Test plan

- [ ] `test_no_colour_strips_ansi_from_table` — verifies no `\x1b[` sequences in output
- [ ] `test_no_color_alias_works` — verifies US-spelling alias works identically
- [ ] All 194 tests pass
- [ ] `make lint` clean
- [ ] `docs/manual/options.md` updated with new section and examples

Closes #130

https://claude.ai/code/session_0186amNpoEzyAee5xb18vvTh