### PR TITLE
#63: Support glob patterns for --repo-filter

### DIFF
--- a/docs/manual/options.md
+++ b/docs/manual/options.md
@@ -12,11 +12,19 @@ breakfast -o my-org -r my-app
 
 ### `--repo-filter`, `-r`
 
-Filter repositories by name substring. Only repos whose name contains this string are included.
+Filter repositories by name. Supports both substring matching and glob patterns.
+
+- **Plain string** (no glob characters): substring match — `platform` matches `"platform-api"`, `"my-platform"`, `"happyplatform"`.
+- **Glob pattern** (contains `*`, `?`, or `[`): uses shell-style glob matching via `fnmatch`.
 
 ```bash
-breakfast -o my-org -r platform    # matches "platform-api", "my-platform", etc.
+breakfast -o my-org -r platform        # substring: matches "platform-api", "my-platform"
+breakfast -o my-org -r "platform-*"    # glob: matches "platform-api", "platform-web" but not "my-platform"
+breakfast -o my-org -r "service-?"     # glob: matches "service-a" but not "service-ab"
+breakfast -o my-org -r "app"           # substring: matches "app", "app-one", "happyapp"
 ```
+
+Glob matching is case-sensitive and uses Python's `fnmatch` semantics. To match all repos, omit `-r` entirely or pass an empty string.
 
 ## Filtering options
 

--- a/src/breakfast/api.py
+++ b/src/breakfast/api.py
@@ -1,3 +1,4 @@
+import fnmatch
 import os
 import random
 import threading
@@ -194,6 +195,23 @@ def make_github_graphql_request(query, variables={}):
                 raise
 
 
+_GLOB_CHARS = frozenset("*?[")
+
+
+def _match_repo_filter(repo_name, repo_filter):
+    """Match a repo name against a filter pattern.
+
+    If the pattern contains glob characters (``*``, ``?``, ``[``), uses
+    ``fnmatch`` for precise glob matching. Otherwise falls back to
+    substring matching for backwards compatibility.
+    """
+    if not repo_filter:
+        return True
+    if any(c in repo_filter for c in _GLOB_CHARS):
+        return fnmatch.fnmatch(repo_name, repo_filter)
+    return repo_filter in repo_name
+
+
 def get_github_prs(organization, repo_filter):
     base_query = """
     query($organization: String!, $cursor: String){
@@ -233,7 +251,7 @@ def get_github_prs(organization, repo_filter):
     prs = []
     for response in gql_responses:
         for repo in response["data"]["organization"]["repositories"]["nodes"]:
-            if repo_filter in repo["name"]:
+            if _match_repo_filter(repo["name"], repo_filter):
                 for pr in repo["pullRequests"]["nodes"]:
                     prs.append(pr["url"])
     return prs

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -802,3 +802,56 @@ def test_get_graphql_rate_limit_returns_none_on_error(monkeypatch):
 
     result = api.get_graphql_rate_limit()
     assert result is None
+
+
+# ---------------------------------------------------------------------------
+# _match_repo_filter
+# ---------------------------------------------------------------------------
+
+
+def test_match_repo_filter_empty_matches_all():
+    assert api._match_repo_filter("any-repo", "") is True
+
+
+def test_match_repo_filter_substring_backward_compat():
+    """Plain strings use substring matching for backward compatibility."""
+    assert api._match_repo_filter("platform-api", "platform") is True
+    assert api._match_repo_filter("happyapp", "app") is True
+    assert api._match_repo_filter("mapper", "app") is True
+
+
+def test_match_repo_filter_substring_no_match():
+    assert api._match_repo_filter("platform-api", "frontend") is False
+
+
+def test_match_repo_filter_glob_star_prefix():
+    """app-* matches repos starting with 'app-' only."""
+    assert api._match_repo_filter("app-one", "app-*") is True
+    assert api._match_repo_filter("app-two", "app-*") is True
+    assert api._match_repo_filter("happyapp", "app-*") is False
+    assert api._match_repo_filter("mapper", "app-*") is False
+
+
+def test_match_repo_filter_glob_question_mark():
+    """? matches exactly one character."""
+    assert api._match_repo_filter("service-a", "service-?") is True
+    assert api._match_repo_filter("service-ab", "service-?") is False
+
+
+def test_match_repo_filter_glob_bracket():
+    """[abc] matches a single character from the set."""
+    assert api._match_repo_filter("service-a", "service-[abc]") is True
+    assert api._match_repo_filter("service-z", "service-[abc]") is False
+
+
+def test_match_repo_filter_glob_exact_match():
+    """Glob without wildcards requires exact match."""
+    # fnmatch treats a bare pattern with no wildcards as exact match
+    assert api._match_repo_filter("app", "app") is True
+
+
+def test_match_repo_filter_glob_no_partial_match():
+    """Glob pattern without trailing * does not match mid-string."""
+    assert api._match_repo_filter("app-one", "app") is True  # substring fallback
+    # But if user adds glob chars, fnmatch is used (no partial match)
+    assert api._match_repo_filter("app-one", "app?") is False  # 'app-one' != 'app?'

--- a/uv.lock
+++ b/uv.lock
@@ -41,7 +41,7 @@ wheels = [
 
 [[package]]
 name = "breakfast"
-version = "0.38.0"
+version = "0.39.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

- Plain string filters (e.g. `-r platform`) continue to use substring matching for full backward compatibility
- Patterns containing glob characters (`*`, `?`, `[`) now use `fnmatch` for precise shell-style matching
- Example: `-r "platform-*"` matches `platform-api` and `platform-web` but not `my-platform` or `happyplatform`

## Changes

- `src/breakfast/api.py`: added `_match_repo_filter()` helper and wired it into `get_github_prs()`
- `tests/test_api.py`: 8 new tests covering substring fallback, glob star, `?`, bracket patterns, and edge cases
- `docs/manual/options.md`: updated `--repo-filter` docs with glob examples

Closes #63

https://claude.ai/code/session_0186amNpoEzyAee5xb18vvTh