### PR TITLE
#161: handle GitHub REST rate-limit 403 with a friendly message

### DIFF
--- a/src/breakfast/api.py
+++ b/src/breakfast/api.py
@@ -1,3 +1,4 @@
+import datetime
 import fnmatch
 import os
 import random
@@ -15,6 +16,24 @@ from .ui import BREAKFAST_ITEMS
 GITHUB_API_URL = "https://api.github.com"
 GITHUB_GRAPHQL_URL = "https://api.github.com/graphql"
 SECRET_GITHUB_TOKEN = os.getenv("GITHUB_TOKEN", None)
+
+
+class GitHubRateLimitError(Exception):
+    """Raised when the GitHub REST API rate limit is exhausted.
+
+    Attributes:
+        reset_time: UTC datetime when the rate limit resets, or None if unknown.
+    """
+
+    def __init__(self, reset_time=None):
+        self.reset_time = reset_time
+        if reset_time:
+            super().__init__(
+                f"GitHub API rate limit exceeded. Try again after {reset_time} UTC."
+            )
+        else:
+            super().__init__("GitHub API rate limit exceeded.")
+
 
 _MAX_RETRIES = 3
 _RETRY_STATUSES = {502, 503, 504}
@@ -76,6 +95,22 @@ def make_github_api_request(query_string):
                     attempt + 1,
                 )
                 continue
+            if (
+                req.status_code == 403
+                and req.headers.get("X-RateLimit-Remaining") == "0"
+            ):
+                reset_ts = req.headers.get("X-RateLimit-Reset")
+                reset_time = None
+                if reset_ts:
+                    reset_time = datetime.datetime.fromtimestamp(
+                        int(reset_ts), tz=datetime.timezone.utc
+                    ).strftime("%Y-%m-%d %H:%M:%S")
+                logger.warning(
+                    "api_call type=rest url=%s rate_limit_exceeded reset=%s",
+                    url,
+                    reset_time,
+                )
+                raise GitHubRateLimitError(reset_time)
             req.raise_for_status()
             logger.debug(
                 "api_call type=rest url=%s status=%d elapsed_ms=%d",

--- a/src/breakfast/cli.py
+++ b/src/breakfast/cli.py
@@ -12,6 +12,7 @@ from tabulate import tabulate
 
 from .api import (
     SECRET_GITHUB_TOKEN,
+    GitHubRateLimitError,
     _fetch_pr_detail,
     get_api_stats,
     get_approval_summary,
@@ -236,6 +237,15 @@ def _auto_fit(pr_data, terminal_width, explicit_max_title_length):
 
 def _stdout_is_tty():
     return sys.stdout.isatty()
+
+
+def _handle_rate_limit(exc, json_output=False):
+    """Print a friendly rate-limit message and exit non-zero."""
+    click.echo(
+        click.style(f"🥞 {exc}", fg="red", bold=True),
+        err=json_output,
+    )
+    sys.exit(1)
 
 
 def _print_debug_summary(t0, pr_count, api_stats, graphql_rate_limit):
@@ -776,7 +786,10 @@ def breakfast(
         sys.exit(1)
     current_user_login = None
     if mine_only:
-        current_user_login = get_authenticated_user_login()
+        try:
+            current_user_login = get_authenticated_user_login()
+        except GitHubRateLimitError as exc:
+            _handle_rate_limit(exc, json_output)
 
     # grab all the pull requests we are interested in
     pr_data = []
@@ -867,6 +880,9 @@ def breakfast(
                             nl=False,
                             err=json_output,
                         )
+                    except GitHubRateLimitError as exc:
+                        click.echo("", err=json_output)  # end the progress line
+                        _handle_rate_limit(exc, json_output)
                     except requests.exceptions.RequestException as exc:
                         logger.warning(
                             "pr_detail_fetch_failed url=%s error=%r", url, str(exc)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -855,3 +855,66 @@ def test_match_repo_filter_glob_no_partial_match():
     assert api._match_repo_filter("app-one", "app") is True  # substring fallback
     # But if user adds glob chars, fnmatch is used (no partial match)
     assert api._match_repo_filter("app-one", "app?") is False  # 'app-one' != 'app?'
+
+
+# ---------------------------------------------------------------------------
+# Rate limit error tests
+# ---------------------------------------------------------------------------
+
+
+def _make_rate_limit_response(reset_ts="1712000000"):
+    """Return a fake requests.Response that looks like a GitHub rate-limit 403."""
+
+    class FakeResponse:
+        status_code = 403
+        headers = {
+            "X-RateLimit-Remaining": "0",
+            "X-RateLimit-Reset": reset_ts,
+        }
+
+        def raise_for_status(self):
+            raise requests.exceptions.HTTPError(response=self)
+
+    return FakeResponse()
+
+
+def test_make_github_api_request_raises_rate_limit_error(monkeypatch):
+    monkeypatch.setattr(api, "SECRET_GITHUB_TOKEN", "token-123")
+    monkeypatch.setattr(
+        api.requests, "get", lambda *_a, **_kw: _make_rate_limit_response()
+    )
+
+    with pytest.raises(api.GitHubRateLimitError):
+        api.make_github_api_request("/user")
+
+
+def test_make_github_api_request_rate_limit_error_contains_reset_time(monkeypatch):
+    monkeypatch.setattr(api, "SECRET_GITHUB_TOKEN", "token-123")
+    monkeypatch.setattr(
+        api.requests, "get", lambda *_a, **_kw: _make_rate_limit_response("1712000000")
+    )
+
+    with pytest.raises(api.GitHubRateLimitError) as exc_info:
+        api.make_github_api_request("/user")
+
+    assert exc_info.value.reset_time is not None
+    assert "2024" in exc_info.value.reset_time  # timestamp 1712000000 is in 2024
+
+
+def test_make_github_api_request_403_without_rate_limit_header_raises_http_error(
+    monkeypatch,
+):
+    """A plain 403 (auth failure) should raise HTTPError, not GitHubRateLimitError."""
+
+    class FakeForbidden:
+        status_code = 403
+        headers = {}  # no X-RateLimit-Remaining header
+
+        def raise_for_status(self):
+            raise requests.exceptions.HTTPError(response=self)
+
+    monkeypatch.setattr(api, "SECRET_GITHUB_TOKEN", "token-123")
+    monkeypatch.setattr(api.requests, "get", lambda *_a, **_kw: FakeForbidden())
+
+    with pytest.raises(requests.exceptions.HTTPError):
+        api.make_github_api_request("/user")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -301,6 +301,26 @@ def test_cli_mine_only_filters_to_authenticated_user(monkeypatch):
     assert "Bob PR" not in result.output
 
 
+def test_cli_mine_only_exits_cleanly_on_rate_limit(monkeypatch):
+    from breakfast.api import GitHubRateLimitError
+
+    monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
+    monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
+    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(
+        cli,
+        "get_authenticated_user_login",
+        lambda: (_ for _ in ()).throw(GitHubRateLimitError("2026-04-10 16:04:48")),
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(cli.breakfast, ["-o", "org", "-r", "repo", "--mine-only"])
+
+    assert result.exit_code == 1
+    assert "rate limit" in result.output.lower()
+    assert "2026-04-10 16:04:48" in result.output
+
+
 def test_cli_outputs_checks_column(monkeypatch):
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])


### PR DESCRIPTION
## Summary

- Adds `GitHubRateLimitError` to `api.py` — raised whenever `make_github_api_request()` receives a 403 with `X-RateLimit-Remaining: 0`
- Includes the reset time from `X-RateLimit-Reset` in the message when present
- Adds `_handle_rate_limit()` helper in `cli.py` and catches `GitHubRateLimitError` in two places:
  - Before the main fetch loop (`GET /user` for `--mine-only`)
  - Inside the per-PR fetch loop (covers all users hitting rate limits during PR/check/approval fetching)
- A plain 403 (auth failure) still raises `HTTPError` as before — only rate-limit 403s with `X-RateLimit-Remaining: 0` trigger the new path

**Example output:**
```
🥞 GitHub API rate limit exceeded. Try again after 2026-04-10 16:04:48 UTC.
```

## Test plan

- [ ] `make test` — 207 tests pass
- [ ] `make lint` — clean
- [ ] Rate-limit 403 on `GET /user` exits cleanly with friendly message (not a traceback)
- [ ] Rate-limit 403 during PR detail fetch also exits cleanly
- [ ] Plain 403 (auth failure, no rate-limit header) still raises `HTTPError`

Closes #161

🤖 Generated with [Claude Code](https://claude.com/claude-code)