### PR TITLE
Fix hyperlink truncation in auto-fit tables

### DIFF
--- a/src/breakfast/cli.py
+++ b/src/breakfast/cli.py
@@ -56,11 +56,46 @@ _DROPPABLE_COLUMNS = [
 
 _ANSI_RE = re.compile(r"\x1b(?:\[[0-9;]*[a-zA-Z]|\]8;;.*?\x1b\\|\]8;;.*?\x07)")
 _ANSI_LEADING_RE = re.compile(r"^(?:\x1b\[[0-9;]*[a-zA-Z])*")
+_OSC8_FULL_RE = re.compile(
+    r"^(?P<prefix>(?:\x1b\[[0-9;]*[a-zA-Z])*)"
+    r"\x1b]8;;(?P<url>.*?)(?:\x1b\\|\x07)"
+    r"(?P<text>.*?)"
+    r"\x1b]8;;(?:\x1b\\|\x07)"
+    r"(?P<suffix>(?:\x1b\[[0-9;]*[a-zA-Z])*)$"
+)
 _ANSI_RESET = "\x1b[0m"
 
 
 def _strip_ansi(s):
     return _ANSI_RE.sub("", str(s))
+
+
+def _truncate_formatted_text(value, limit):
+    """Truncate visible text while preserving ANSI and OSC 8 wrappers.
+
+    Args:
+        value: Cell value that may contain ANSI styling or OSC 8 hyperlinks.
+        limit: Maximum visible character count, including the ellipsis.
+
+    Returns:
+        The truncated value with any existing formatting preserved.
+    """
+    plain = _strip_ansi(value)
+    if len(plain) <= limit:
+        return value
+
+    truncated = plain[: limit - 1] + "…"
+    osc_match = _OSC8_FULL_RE.match(str(value))
+    if osc_match:
+        return (
+            osc_match.group("prefix")
+            + generate_terminal_url_anchor(osc_match.group("url"), truncated)
+            + osc_match.group("suffix")
+        )
+
+    if plain != value:
+        return str(value).replace(plain, truncated, 1)
+    return truncated
 
 
 def _styled_hyperlink(url, styled_text):
@@ -117,11 +152,7 @@ def _truncate_col(pr_data, key, terminal_width, min_len=8):
     return [
         {
             **row,
-            key: (
-                row[key][: limit - 1] + "…"
-                if len(_strip_ansi(row[key])) > limit
-                else row[key]
-            ),
+            key: _truncate_formatted_text(row[key], limit),
         }
         for row in pr_data
     ]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1226,9 +1226,11 @@ def test_auto_fit_truncates_repo_and_author_before_dropping(monkeypatch):
         result = runner.invoke(cli.breakfast, ["-o", "org", "-r", "repo"])
 
     assert result.exit_code == 0
+    visible_output = cli._strip_ansi(result.output)
     # Full long names should have been truncated
-    assert "a-very-long-repository-name" not in result.output
-    assert "a-very-long-author-name" not in result.output
+    assert "a-very-long-repository-name" not in visible_output
+    assert "a-very-long-author-name" not in visible_output
+    assert "a-very-…" in visible_output
 
 
 def test_auto_fit_compresses_mergeable_before_dropping(monkeypatch):
@@ -1897,6 +1899,57 @@ def test_compress_styled_preserves_approval_fraction():
     compressed = cli._compress_styled(styled)
 
     assert cli._strip_ansi(compressed) == "✅ 1/2"
+
+
+def test_truncate_formatted_text_preserves_osc8_anchor():
+    linked_repo = cli.generate_terminal_url_anchor(
+        "https://github.com/myorg/really-long-repo-name",
+        "really-long-repo-name",
+    )
+
+    truncated = cli._truncate_formatted_text(linked_repo, 8)
+
+    assert cli._strip_ansi(truncated) == "really-…"
+    assert "\x1b]8;;https://github.com/myorg/really-long-repo-name\x1b\\" in truncated
+    assert truncated.endswith("\x1b]8;;\x1b\\")
+    assert "]8;;ht…" not in truncated
+
+
+def test_truncate_col_preserves_repo_and_author_hyperlinks():
+    rows = [
+        {
+            "Repo": cli.generate_terminal_url_anchor(
+                "https://github.com/myorg/really-long-repo-name",
+                "really-long-repo-name",
+            ),
+            "PR Title": "Short title",
+            "Author": cli.generate_terminal_url_anchor(
+                "https://github.com/some-very-long-author-name",
+                "some-very-long-author-name",
+            ),
+            "State": "open",
+            "Files": "1",
+            "Commits": "1",
+            "+/-": "+1/-0",
+            "Comments": "0",
+            "Mergeable?": "✅ (clean)",
+            "Link": "PR-1",
+        }
+    ]
+
+    truncated = cli._truncate_col(rows, "Repo", terminal_width=40, min_len=8)
+    truncated = cli._truncate_col(truncated, "Author", terminal_width=40, min_len=8)
+
+    assert (
+        "\x1b]8;;https://github.com/myorg/really-long-repo-name\x1b\\"
+        in truncated[0]["Repo"]
+    )
+    assert (
+        "\x1b]8;;https://github.com/some-very-long-author-name\x1b\\"
+        in truncated[0]["Author"]
+    )
+    assert "]8;;ht…" not in truncated[0]["Repo"]
+    assert "]8;;ht…" not in truncated[0]["Author"]
 
 
 def test_auto_fit_preserves_checks_colour(monkeypatch):


### PR DESCRIPTION
## Issue

Closes #163

## Description

Preserve OSC-8 hyperlink wrappers when auto-fitting table output so truncating `Repo` and `Author` cells does not corrupt row rendering.

## Changes

- add `_truncate_formatted_text()` to truncate visible text while preserving ANSI and OSC-8 wrappers
- update `_truncate_col()` to use the formatting-aware truncation path
- add regression coverage for hyperlink truncation and adjust the existing truncation assertion to validate rendered text

## Testing

- [x] `make test` passes
- [x] `make lint` passes

## Notes

No unrelated workspace changes were included in the commit; the existing `uv.lock` modification was left out of this PR.
