### PR TITLE
#167: Add --head-branch and --base-branch columns

### DIFF
--- a/docs/manual/options.md
+++ b/docs/manual/options.md
@@ -307,6 +307,58 @@ When approval counts are available, `"approval_current"` and
 }
 ```
 
+### `--head-branch`
+
+Add a "Head Branch" column showing the source branch the PR was raised from. Rendered as a clickable hyperlink to the branch on GitHub. Off by default.
+
+```text
+$ breakfast -o my-org -r platform --head-branch
+Fetching my-org PRs...🥐...Done
+Processing platform PRs...🍩🧇...Done
++---------+----------------+-----------------+--------+---------+-------+---------+------------+----------+-----------------------+--------------+--------+
+|         | Repo           | PR Title        | Author | State   | Files | Commits |    +/-     | Comments | Head Branch           | Mergeable?   | Link   |
++---------+----------------+-----------------+--------+---------+-------+---------+------------+----------+-----------------------+--------------+--------+
+|       0 | platform-api   | Add user search | alice  | open    |   3   |    1    |  +42/-10   |    0     | feature/user-search   | ✅ (clean)   | PR-142 |
+|       1 | platform-api   | Fix login bug   | bob    | open    |   1   |    1    |  +5/-2     |    3     | fix/login-bug         | ✅ (clean)   | PR-138 |
+|       2 | platform-ui    | Update nav bar  | carol  | open    |  12   |    4    |  +280/-95  |    1     | feat/nav-redesign     | ❌ (dirty)   | PR-87  |
++---------+----------------+-----------------+--------+---------+-------+---------+------------+----------+-----------------------+--------------+--------+
+```
+
+Enable in config:
+
+```toml
+head-branch = true
+```
+
+### `--base-branch`
+
+Add a "Base Branch" column showing the target branch the PR merges into. Rendered as a clickable hyperlink to the branch on GitHub. Off by default. Particularly useful when working with stacked PRs.
+
+```text
+$ breakfast -o my-org -r platform --base-branch
+Fetching my-org PRs...🥐...Done
+Processing platform PRs...🍩🧇...Done
++---------+----------------+-----------------+--------+---------+-------+---------+------------+----------+-------------+--------------+--------+
+|         | Repo           | PR Title        | Author | State   | Files | Commits |    +/-     | Comments | Base Branch | Mergeable?   | Link   |
++---------+----------------+-----------------+--------+---------+-------+---------+------------+----------+-------------+--------------+--------+
+|       0 | platform-api   | Add user search | alice  | open    |   3   |    1    |  +42/-10   |    0     | main        | ✅ (clean)   | PR-142 |
+|       1 | platform-api   | Fix login bug   | bob    | open    |   1   |    1    |  +5/-2     |    3     | main        | ✅ (clean)   | PR-138 |
+|       2 | platform-ui    | Update nav bar  | carol  | open    |  12   |    4    |  +280/-95  |    1     | develop     | ❌ (dirty)   | PR-87  |
++---------+----------------+-----------------+--------+---------+-------+---------+------------+----------+-------------+--------------+--------+
+```
+
+Enable in config:
+
+```toml
+base-branch = true
+```
+
+Both flags can be combined to show the full branch path at a glance:
+
+```bash
+breakfast -o my-org -r platform --head-branch --base-branch
+```
+
 ### `--status-style`
 
 Choose how the `Checks`, `Approved`, and `Mergeable?` columns are rendered in table output.

--- a/docs/manual/output-formats.md
+++ b/docs/manual/output-formats.md
@@ -29,6 +29,8 @@ The default output is a colour-coded terminal table with the following columns:
 | Comments | Number of review comments |
 | Age | Days since PR creation (only with `--age`) |
 | Checks | CI/check run status: pass, fail, pending, none (only with `--checks`) — clickable link to the PR's checks tab |
+| Head Branch | Source branch the PR was raised from (only with `--head-branch`) — clickable link to the branch on GitHub |
+| Base Branch | Target branch the PR merges into (only with `--base-branch`) — clickable link to the branch on GitHub |
 | Mergeable? | Whether the PR can be merged cleanly |
 | Link | Clickable link to the PR |
 

--- a/docs/manual/usage.md
+++ b/docs/manual/usage.md
@@ -73,6 +73,29 @@ Processing platform PRs...🍩🧇...Done
 +---------+----------------------------------+-----------------+--------+---------+-----------+-----------+------------+-----------+------+-----------------------+--------+
 ```
 
+### Navigate stacked PRs
+
+When working with stacked (chained) PRs, use `--base-branch` to see which branch each PR targets — quickly spotting PRs that merge into a feature branch rather than `main`:
+
+```text
+$ breakfast -o my-org -r platform --base-branch
+Fetching my-org PRs...🧇...Done
+Processing platform PRs...🍳🥐...Done
++---------+----------------+---------------------------+--------+---------+-------+---------+------------+----------+------------------------+--------------+--------+
+|         | Repo           | PR Title                  | Author | State   | Files | Commits |    +/-     | Comments | Base Branch            | Mergeable?   | Link   |
++---------+----------------+---------------------------+--------+---------+-------+---------+------------+----------+------------------------+--------------+--------+
+|       0 | platform-api   | Stack: Add user model     | alice  | open    |   5   |    2    |  +120/-0   |    0     | main                   | ✅ (clean)   | PR-145 |
+|       1 | platform-api   | Stack: Add user endpoints | alice  | open    |   4   |    1    |  +80/-5    |    0     | feature/user-model     | ✅ (clean)   | PR-146 |
+|       2 | platform-api   | Stack: Add user UI        | alice  | open    |   8   |    3    |  +200/-10  |    2     | feature/user-endpoints | ❌ (dirty)   | PR-147 |
++---------+----------------+---------------------------+--------+---------+-------+---------+------------+----------+------------------------+--------------+--------+
+```
+
+Combine with `--head-branch` for the full picture:
+
+```bash
+breakfast -o my-org -r platform --head-branch --base-branch
+```
+
 ### Get machine-readable output
 
 Progress messages go to stderr, so JSON can be piped cleanly:

--- a/src/breakfast/cli.py
+++ b/src/breakfast/cli.py
@@ -58,6 +58,8 @@ _DROPPABLE_COLUMNS = [
     "Age",
     "Checks",
     "Apr",
+    "Head Branch",
+    "Base Branch",
 ]
 
 _ANSI_RE = re.compile(r"\x1b(?:\[[0-9;]*[a-zA-Z]|\]8;;.*?\x1b\\|\]8;;.*?\x07)")
@@ -199,6 +201,14 @@ def _auto_fit(pr_data, terminal_width, explicit_max_title_length):
 
     # 3. Truncate Author
     pr_data = _truncate_col(pr_data, "Author", terminal_width, min_len=8)
+    if fits():
+        return pr_data
+
+    # 3b. Truncate Head Branch / Base Branch
+    pr_data = _truncate_col(pr_data, "Head Branch", terminal_width, min_len=8)
+    if fits():
+        return pr_data
+    pr_data = _truncate_col(pr_data, "Base Branch", terminal_width, min_len=8)
     if fits():
         return pr_data
 
@@ -482,6 +492,16 @@ def _fetch_pr_bundle(url, fetch_checks, fetch_approvals):
     help="Include an approvals column showing review approval status for each PR.",
 )
 @click.option(
+    "--head-branch/--no-head-branch",
+    default=None,
+    help="Include a column showing the source branch the PR was raised from.",
+)
+@click.option(
+    "--base-branch/--no-base-branch",
+    default=None,
+    help="Include a column showing the target branch the PR merges into.",
+)
+@click.option(
     "--status-style",
     type=click.Choice(["emoji", "ascii"], case_sensitive=False),
     default=None,
@@ -633,6 +653,8 @@ def breakfast(
     json_output,
     checks,
     approvals,
+    head_branch,
+    base_branch,
     status_style,
     limit,
     workers,
@@ -695,6 +717,12 @@ def breakfast(
         json_output = cfg.get("format") == "json"
     checks = checks if checks is not None else cfg.get("checks", False)
     approvals = approvals if approvals is not None else cfg.get("approvals", False)
+    head_branch = (
+        head_branch if head_branch is not None else cfg.get("head-branch", False)
+    )
+    base_branch = (
+        base_branch if base_branch is not None else cfg.get("base-branch", False)
+    )
     if status_style is None:
         status_style = str(cfg.get("status-style", "emoji")).lower()
     max_title_length = (
@@ -1184,6 +1212,18 @@ def breakfast(
                 current_reviews=approval_detail.get("current"),
                 required_reviews=approval_detail.get("required"),
             )
+        if head_branch:
+            _hb_name = pr_detail["head"]["ref"]
+            _hb_owner = pr_detail["base"]["repo"]["owner"]["login"]
+            _hb_repo = pr_detail["base"]["repo"]["name"]
+            _hb_url = f"https://github.com/{_hb_owner}/{_hb_repo}/tree/{_hb_name}"
+            row["Head Branch"] = generate_terminal_url_anchor(_hb_url, _hb_name)
+        if base_branch:
+            _bb_name = pr_detail["base"]["ref"]
+            _bb_owner = pr_detail["base"]["repo"]["owner"]["login"]
+            _bb_repo = pr_detail["base"]["repo"]["name"]
+            _bb_url = f"https://github.com/{_bb_owner}/{_bb_repo}/tree/{_bb_name}"
+            row["Base Branch"] = generate_terminal_url_anchor(_bb_url, _bb_name)
         row["Mergeable?"] = format_mergeable_status(
             pr_detail["mergeable"],
             pr_detail["mergeable_state"],

--- a/src/breakfast/config.py
+++ b/src/breakfast/config.py
@@ -81,6 +81,16 @@ _DEFAULT_CONFIG_CONTENT = """\
 # Equivalent to: --approvals
 # approvals = false
 
+# Show a column with the source branch the PR was raised from (e.g. feature/my-thing).
+# Rendered as a clickable hyperlink to the branch on GitHub.
+# Equivalent to: --head-branch
+# head-branch = false
+
+# Show a column with the target branch the PR merges into (e.g. main).
+# Rendered as a clickable hyperlink to the branch on GitHub.
+# Equivalent to: --base-branch
+# base-branch = false
+
 # Truncate PR titles to this many characters (appends … when truncated).
 # Useful on narrow terminals. Unset means no truncation.
 # Equivalent to: --max-title-length <n>

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -137,6 +137,98 @@ def test_cli_outputs_age_column_when_enabled(monkeypatch):
     assert "7" in result.output
 
 
+def _fake_pr_detail_with_branches():
+    return {
+        "base": {
+            "ref": "main",
+            "repo": {"name": "repo", "owner": {"login": "org"}},
+        },
+        "head": {"ref": "feature/my-branch", "sha": "abc123"},
+        "mergeable": True,
+        "mergeable_state": "clean",
+        "additions": 5,
+        "deletions": 2,
+        "title": "Test PR",
+        "user": {"login": "alice"},
+        "state": "open",
+        "changed_files": 1,
+        "commits": 1,
+        "review_comments": 0,
+        "created_at": "2026-01-10T00:00:00Z",
+        "html_url": "https://github.com/org/repo/pull/1",
+        "number": 1,
+    }
+
+
+def test_cli_outputs_head_branch_column_when_enabled(monkeypatch):
+    monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
+    monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
+    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(
+        cli,
+        "get_github_prs",
+        lambda _org, _repo_filter: ["https://github.com/org/repo/pull/1"],
+    )
+    monkeypatch.setattr(
+        api,
+        "make_github_api_request",
+        lambda _path: _fake_pr_detail_with_branches(),
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(cli.breakfast, ["-o", "org", "-r", "repo", "--head-branch"])
+
+    assert result.exit_code == 0
+    assert "Head Branch" in result.output
+    assert "feature/my-branch" in result.output
+
+
+def test_cli_outputs_base_branch_column_when_enabled(monkeypatch):
+    monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
+    monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
+    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(
+        cli,
+        "get_github_prs",
+        lambda _org, _repo_filter: ["https://github.com/org/repo/pull/1"],
+    )
+    monkeypatch.setattr(
+        api,
+        "make_github_api_request",
+        lambda _path: _fake_pr_detail_with_branches(),
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(cli.breakfast, ["-o", "org", "-r", "repo", "--base-branch"])
+
+    assert result.exit_code == 0
+    assert "Base Branch" in result.output
+    assert "main" in result.output
+
+
+def test_cli_head_and_base_branch_hidden_by_default(monkeypatch):
+    monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
+    monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
+    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(
+        cli,
+        "get_github_prs",
+        lambda _org, _repo_filter: ["https://github.com/org/repo/pull/1"],
+    )
+    monkeypatch.setattr(
+        api,
+        "make_github_api_request",
+        lambda _path: _fake_pr_detail_with_branches(),
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(cli.breakfast, ["-o", "org", "-r", "repo"])
+
+    assert result.exit_code == 0
+    assert "Head Branch" not in result.output
+    assert "Base Branch" not in result.output
+
+
 def test_cli_outputs_json(monkeypatch):
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])

--- a/uv.lock
+++ b/uv.lock
@@ -41,7 +41,7 @@ wheels = [
 
 [[package]]
 name = "breakfast"
-version = "0.46.0"
+version = "0.47.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

- Adds `--head-branch/--no-head-branch` — shows the source branch a PR was raised from as a clickable OSC 8 hyperlink
- Adds `--base-branch/--no-base-branch` — shows the target branch a PR merges into as a clickable OSC 8 hyperlink
- Both default to off; CLI flags override config file values (`head-branch`, `base-branch` keys)
- Long branch names are truncated by `_auto_fit` before columns are dropped as last resort
- Both columns added to the low-priority drop list in `_DROPPABLE_COLUMNS`

## Test plan

- [ ] `make test` passes (238 tests, 3 new: head branch shown, base branch shown, both hidden by default)
- [ ] `make lint` passes
- [ ] Manual test with `--head-branch`, `--base-branch`, and both combined
- [ ] Verify branch names render as clickable hyperlinks in a terminal that supports OSC 8
- [ ] Verify stacked PR workflow: `--base-branch` clearly shows which PRs target feature branches vs `main`
- [ ] Test with cache enabled and disabled

Closes #167

https://claude.ai/code/session_01C1cpV6R7aDCnheigVGFVsH