### PR TITLE
#181: Add --format markdown output for pasting PR lists into docs

### DIFF
--- a/docs/manual/options.md
+++ b/docs/manual/options.md
@@ -174,9 +174,24 @@ Processing platform PRs...🍩🧇...Done
 +---------+----------------+-----------------+--------+---------+-------+---------+------------+----------+------+--------------+--------+
 ```
 
+### `--format`
+
+Choose the output format. Accepted values: `table` (default), `json`, `markdown`.
+
+```text
+breakfast -o my-org -r platform --format markdown
+breakfast -o my-org -r platform --format json
+```
+
+You can also set a persistent default in your config file:
+
+```toml
+format = "markdown"
+```
+
 ### `--json`
 
-Output results as JSON instead of a terminal table. Progress messages are sent to stderr so JSON output can be piped cleanly.
+Alias for `--format json`. Output results as JSON instead of a terminal table. Progress messages are sent to stderr so JSON output can be piped cleanly.
 
 ```text
 $ breakfast -o my-org -r platform --json 2>/dev/null
@@ -695,8 +710,12 @@ Options:
   --no-drafts                     Exclude draft PRs from results.
   --drafts-only                   Show only draft PRs.
   --age / --no-age                Include an age column showing PR age in days.
-  --json / --no-json              Output results as JSON instead of a table.
+  --json / --no-json              Alias for --format json / --format table.
                                   Progress messages go to stderr.
+  --format [table|json|markdown]  Output format. table renders a coloured
+                                  terminal table (default), json outputs
+                                  machine-readable JSON, markdown renders a
+                                  GitHub-flavoured Markdown table.
   --checks / --no-checks          Include a checks column showing CI/check
                                   status for each PR.
   --approvals / --no-approvals    Include an approvals column showing review

--- a/docs/manual/options.md
+++ b/docs/manual/options.md
@@ -189,6 +189,14 @@ You can also set a persistent default in your config file:
 format = "markdown"
 ```
 
+### `--markdown`
+
+Alias for `--format markdown`. Renders a GitHub-flavoured Markdown table. Progress messages are sent to stderr so Markdown output can be redirected cleanly.
+
+```text
+breakfast -o my-org -r platform --markdown 2>/dev/null > prs.md
+```
+
 ### `--json`
 
 Alias for `--format json`. Output results as JSON instead of a terminal table. Progress messages are sent to stderr so JSON output can be piped cleanly.
@@ -712,6 +720,8 @@ Options:
   --age / --no-age                Include an age column showing PR age in days.
   --json / --no-json              Alias for --format json / --format table.
                                   Progress messages go to stderr.
+  --markdown / --no-markdown      Alias for --format markdown / --format
+                                  table.
   --format [table|json|markdown]  Output format. table renders a coloured
                                   terminal table (default), json outputs
                                   machine-readable JSON, markdown renders a

--- a/docs/manual/output-formats.md
+++ b/docs/manual/output-formats.md
@@ -2,18 +2,19 @@
 
 ## stdout and stderr
 
-All data output — tables, JSON, and summary views — goes to **stdout**.
+All data output — tables, JSON, Markdown, and summary views — goes to **stdout**.
 All progress messages, spinner emoji, warnings, and errors go to **stderr**.
 
 This means every output format is safe to pipe or redirect independently:
 
 ```bash
-breakfast -o my-org -r platform > prs.txt          # capture table only
-breakfast -o my-org -r platform --json | jq '...'  # pipe JSON cleanly
+breakfast -o my-org -r platform > prs.txt                    # capture table only
+breakfast -o my-org -r platform --json | jq '...'            # pipe JSON cleanly
+breakfast -o my-org -r platform --format markdown > prs.md   # capture Markdown
 ```
 
-The `format` config key accepts `"table"` (default) or `"json"`. Any other value
-triggers a warning on stderr and falls back to `"table"`.
+The `format` config key accepts `"table"` (default), `"json"`, or `"markdown"`.
+Any other value triggers a warning on stderr and falls back to `"table"`.
 
 ## Table output (default)
 
@@ -64,9 +65,26 @@ Numeric columns (Files, Commits, Comments, Age) are colour-graded:
 
 The "Link" column uses [OSC 8 terminal hyperlinks](https://gist.github.com/egmontkob/eb114294efbcd5adb1944c9f3cb5feda), supported by most modern terminals (iTerm2, GNOME Terminal, Windows Terminal, etc.). Click the link to open the PR in your browser.
 
-## JSON output (`--json`)
+## Markdown output (`--format markdown`)
 
-With `--json`, output is a JSON array of objects.
+With `--format markdown`, output is a GitHub-flavoured Markdown table — ready to paste into PR descriptions, issue comments, Confluence pages, or any Markdown renderer.
+
+```text
+$ breakfast -o my-org -r platform --format markdown 2>/dev/null
+| Repo         | PR Title        | Author | State | Files | Commits | +/-       | Comments | Mergeable?  | Link                                                |
+|---|---|---|---|---|---|---|---|---|---|
+| [platform-api](https://github.com/my-org/platform-api) | Add user search | [alice](https://github.com/alice) | open  | 3     | 1       | +42/-10   | 0        | ✅ (clean)  | [PR-142](https://github.com/my-org/platform-api/pull/142) |
+| [platform-api](https://github.com/my-org/platform-api) | Fix login bug   | [bob](https://github.com/bob)   | open  | 1     | 1       | +5/-2     | 3        | ✅ (clean)  | [PR-138](https://github.com/my-org/platform-api/pull/138) |
+```
+
+- ANSI colour codes are stripped — Markdown renderers don't support them.
+- OSC 8 terminal hyperlinks are converted to `[text](url)` Markdown links.
+- Optional columns (`--age`, `--checks`, `--approvals`, `--head-branch`, `--base-branch`) are included when their flags are set.
+- Progress messages still go to stderr, so the output can be redirected cleanly.
+
+## JSON output (`--json` / `--format json`)
+
+With `--format json` (or the `--json` alias), output is a JSON array of objects.
 
 ### Schema
 

--- a/src/breakfast/cli.py
+++ b/src/breakfast/cli.py
@@ -72,11 +72,22 @@ _OSC8_FULL_RE = re.compile(
     r"\x1b]8;;(?:\x1b\\|\x07)"
     r"(?P<suffix>(?:\x1b\[[0-9;]*[a-zA-Z])*)$"
 )
+_OSC8_ANY_RE = re.compile(
+    r"\x1b]8;;(?P<url>.*?)(?:\x1b\\|\x07)(?P<text>.*?)\x1b]8;;(?:\x1b\\|\x07)"
+)
 _ANSI_RESET = "\x1b[0m"
 
 
 def _strip_ansi(s):
     return _ANSI_RE.sub("", str(s))
+
+
+def _osc8_to_markdown(s):
+    """Convert OSC 8 hyperlinks and ANSI codes in *s* to Markdown link syntax."""
+    result = _OSC8_ANY_RE.sub(
+        lambda m: f"[{m.group('text')}]({m.group('url')})", str(s)
+    )
+    return _strip_ansi(result)
 
 
 def _truncate_formatted_text(value, limit):
@@ -532,7 +543,17 @@ def _fetch_pr_bundle(url, fetch_checks, fetch_approvals):
     "--json/--no-json",
     "json_output",
     default=None,
-    help="Output results as JSON instead of a table. Progress messages go to stderr.",
+    help="Output results as JSON. Alias for --format json / --format table.",
+)
+@click.option(
+    "--format",
+    "output_format",
+    default=None,
+    type=click.Choice(["table", "json", "markdown"], case_sensitive=False),
+    help=(
+        "Output format: table (default), json, or markdown. "
+        "Overrides --json/--no-json when both are given."
+    ),
 )
 @click.option(
     "--checks/--no-checks",
@@ -726,6 +747,7 @@ def breakfast(
     drafts_only,
     age,
     json_output,
+    output_format,
     checks,
     approvals,
     head_branch,
@@ -791,19 +813,25 @@ def breakfast(
     no_drafts = no_drafts or cfg.get("no-drafts", False)
     drafts_only = drafts_only or cfg.get("drafts-only", False)
     age = age if age is not None else cfg.get("age", False)
-    if json_output is None:
+    if output_format is not None:
+        fmt = output_format.lower()
+    elif json_output is not None:
+        fmt = "json" if json_output else "table"
+    else:
         cfg_format = cfg.get("format")
-        if cfg_format is not None and cfg_format not in {"table", "json"}:
+        if cfg_format is not None and cfg_format not in {"table", "json", "markdown"}:
             click.echo(
                 click.style(
                     f"Warning: unrecognised format '{cfg_format}' in config"
-                    " — expected 'table' or 'json'. Falling back to 'table'.",
+                    " — expected 'table', 'json', or 'markdown'."
+                    " Falling back to 'table'.",
                     fg="yellow",
                 ),
                 err=True,
             )
             cfg_format = "table"
-        json_output = cfg_format == "json"
+        fmt = cfg_format or "table"
+    json_output = fmt == "json"
     checks = checks if checks is not None else cfg.get("checks", False)
     approvals = approvals if approvals is not None else cfg.get("approvals", False)
     head_branch = (
@@ -894,7 +922,7 @@ def breakfast(
             "no-drafts": no_drafts,
             "drafts-only": drafts_only,
             "age": age,
-            "json": json_output,
+            "format": fmt,
             "checks": checks,
             "approvals": approvals,
             "status-style": status_style,
@@ -921,7 +949,7 @@ def breakfast(
         "startup org=%s repo_filter=%r mine_only=%s ignore_author=%r"
         " cache_enabled=%s cache_ttl=%ss refresh=%s refresh_prs=%s"
         " checks=%s approvals=%s age=%s legendary=%s legendary_only=%s"
-        " limit=%s max_title_length=%s status_style=%s json=%s"
+        " limit=%s max_title_length=%s status_style=%s format=%s"
         " filter_state=%r filter_check=%r filter_approval=%r search=%r api_stats=%s",
         organization,
         repo_filter,
@@ -939,7 +967,7 @@ def breakfast(
         limit,
         max_title_length,
         status_style,
-        json_output,
+        fmt,
         filter_state,
         filter_check,
         filter_approval,
@@ -1240,7 +1268,7 @@ def breakfast(
 
     logger.info(
         "render format=%s row_count=%d",
-        "json" if json_output else "table",
+        fmt,
         len(pr_details),
     )
     t_render = time.monotonic()
@@ -1294,6 +1322,96 @@ def breakfast(
         if api_stats:
             _print_debug_summary(
                 t0_total, len(json_data), get_api_stats(), get_graphql_rate_limit()
+            )
+        return
+
+    if fmt == "markdown":
+        md_data = []
+        for pr_detail in pr_details:
+            repo = pr_detail["base"]["repo"]
+            repo_url = repo.get("html_url") or pr_detail["html_url"].split("/pull/")[0]
+            author = pr_detail["user"]
+            author_url = (
+                author.get("html_url") or f"https://github.com/{author['login']}"
+            )
+            state_str = pr_detail["state"]
+            if pr_detail.get("draft"):
+                state_str = "draft"
+            adds = pr_detail["additions"]
+            subs = pr_detail["deletions"]
+            row = {
+                "Repo": f"[{repo['name']}]({repo_url})",
+                "PR Title": pr_detail["title"],
+                "Author": f"[{author['login']}]({author_url})",
+                "State": state_str,
+                "Files": str(pr_detail["changed_files"]),
+                "Commits": str(pr_detail["commits"]),
+                "+/-": f"+{adds}/-{subs}",
+                "Comments": str(pr_detail["review_comments"]),
+            }
+            if age:
+                row["Age"] = str(get_pr_age_days(pr_detail))
+            if checks:
+                row["Checks"] = _osc8_to_markdown(
+                    format_check_status(
+                        check_statuses.get(pr_detail["id"], "none"),
+                        style=status_style,
+                    )
+                )
+            if approvals:
+                approval_detail = approval_details.get(pr_detail["id"], {})
+                row["Approved"] = _osc8_to_markdown(
+                    format_approval_status(
+                        approval_statuses.get(pr_detail["id"], "pending"),
+                        style=status_style,
+                        current_reviews=approval_detail.get("current"),
+                        required_reviews=approval_detail.get("required"),
+                    )
+                )
+            if head_branch:
+                _hb_name = pr_detail["head"]["ref"]
+                _hb_owner = pr_detail["base"]["repo"]["owner"]["login"]
+                _hb_repo = pr_detail["base"]["repo"]["name"]
+                _hb_url = f"https://github.com/{_hb_owner}/{_hb_repo}/tree/{_hb_name}"
+                row["Head Branch"] = f"[{_hb_name}]({_hb_url})"
+            if base_branch:
+                _bb_name = pr_detail["base"]["ref"]
+                _bb_owner = pr_detail["base"]["repo"]["owner"]["login"]
+                _bb_repo = pr_detail["base"]["repo"]["name"]
+                _bb_url = f"https://github.com/{_bb_owner}/{_bb_repo}/tree/{_bb_name}"
+                row["Base Branch"] = f"[{_bb_name}]({_bb_url})"
+            row["Mergeable?"] = _osc8_to_markdown(
+                format_mergeable_status(
+                    pr_detail["mergeable"],
+                    pr_detail["mergeable_state"],
+                    style=status_style,
+                )
+            )
+            row["Link"] = f"[PR-{pr_detail['number']}]({pr_detail['html_url']})"
+            md_data.append(row)
+        click.echo(
+            tabulate(
+                md_data,
+                headers="keys",
+                tablefmt="github",
+                disable_numparse=True,
+            )
+        )
+        logger.info(
+            "render_complete elapsed_ms=%d", int((time.monotonic() - t_render) * 1000)
+        )
+        if not no_update_check:
+            update_msg = check_for_update()
+            if update_msg:
+                logger.info("update_available msg=%r", update_msg)
+                click.echo(
+                    click.style(update_msg, fg="cyan", bold=True),
+                    err=True,
+                    color=colour,
+                )
+        if api_stats:
+            _print_debug_summary(
+                t0_total, len(md_data), get_api_stats(), get_graphql_rate_limit()
             )
         return
 

--- a/src/breakfast/cli.py
+++ b/src/breakfast/cli.py
@@ -546,13 +546,19 @@ def _fetch_pr_bundle(url, fetch_checks, fetch_approvals):
     help="Output results as JSON. Alias for --format json / --format table.",
 )
 @click.option(
+    "--markdown/--no-markdown",
+    "markdown_flag",
+    default=None,
+    help="Output results as a Markdown table. Alias for --format markdown.",
+)
+@click.option(
     "--format",
     "output_format",
     default=None,
     type=click.Choice(["table", "json", "markdown"], case_sensitive=False),
     help=(
         "Output format: table (default), json, or markdown. "
-        "Overrides --json/--no-json when both are given."
+        "Overrides --json/--no-json/--markdown when both are given."
     ),
 )
 @click.option(
@@ -747,6 +753,7 @@ def breakfast(
     drafts_only,
     age,
     json_output,
+    markdown_flag,
     output_format,
     checks,
     approvals,
@@ -817,6 +824,8 @@ def breakfast(
         fmt = output_format.lower()
     elif json_output is not None:
         fmt = "json" if json_output else "table"
+    elif markdown_flag is not None:
+        fmt = "markdown" if markdown_flag else "table"
     else:
         cfg_format = cfg.get("format")
         if cfg_format is not None and cfg_format not in {"table", "json", "markdown"}:

--- a/src/breakfast/config.py
+++ b/src/breakfast/config.py
@@ -104,7 +104,8 @@ _DEFAULT_CONFIG_CONTENT = """\
 
 # Output format. "table" renders a coloured terminal table (default).
 # "json" outputs machine-readable JSON — useful for scripting or piping.
-# Equivalent to: --json
+# "markdown" renders a GitHub-flavoured Markdown table — great for pasting into docs.
+# Equivalent to: --format table|json|markdown
 # format = "table"
 
 # How status columns (Checks, Approved, Mergeable?) are rendered.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2766,3 +2766,129 @@ def test_cli_no_json_flag_overrides_config_format_json(monkeypatch, tmp_path):
     assert "PR-1" in result.stdout
     with pytest.raises(json.JSONDecodeError):
         json.loads(result.stdout)
+
+
+# ---------------------------------------------------------------------------
+# --format markdown
+# ---------------------------------------------------------------------------
+
+
+def test_format_markdown_produces_gfm_table(monkeypatch):
+    monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
+    monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
+    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(
+        cli, "get_github_prs", lambda *_: ["https://github.com/org/repo/pull/1"]
+    )
+    monkeypatch.setattr(api, "make_github_api_request", _fake_pr_detail)
+
+    result = CliRunner().invoke(
+        cli.breakfast, ["-o", "org", "-r", "repo", "--format", "markdown"]
+    )
+
+    assert result.exit_code == 0
+    assert "| Repo" in result.stdout
+    assert "|---" in result.stdout
+    assert "[repo](https://github.com/org/repo)" in result.stdout
+    assert "[PR-1](https://github.com/org/repo/pull/1)" in result.stdout
+
+
+def test_format_markdown_strips_ansi_codes(monkeypatch):
+    monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
+    monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
+    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(
+        cli, "get_github_prs", lambda *_: ["https://github.com/org/repo/pull/1"]
+    )
+    monkeypatch.setattr(api, "make_github_api_request", _fake_pr_detail)
+
+    result = CliRunner().invoke(
+        cli.breakfast, ["-o", "org", "-r", "repo", "--format", "markdown"]
+    )
+
+    assert result.exit_code == 0
+    assert "\x1b[" not in result.stdout
+    assert "\x1b]8;;" not in result.stdout
+
+
+def test_format_markdown_output_goes_to_stdout(monkeypatch):
+    monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
+    monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
+    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(
+        cli, "get_github_prs", lambda *_: ["https://github.com/org/repo/pull/1"]
+    )
+    monkeypatch.setattr(api, "make_github_api_request", _fake_pr_detail)
+
+    result = CliRunner().invoke(
+        cli.breakfast, ["-o", "org", "-r", "repo", "--format", "markdown"]
+    )
+
+    assert result.exit_code == 0
+    assert "Processing" in result.stderr
+    assert "Processing" not in result.stdout
+    assert "[repo]" in result.stdout
+
+
+def test_config_format_markdown_produces_markdown_output(monkeypatch, tmp_path):
+    cfg_file = tmp_path / "config.toml"
+    cfg_file.write_text('format = "markdown"\norganization = "org"\n')
+    monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
+    monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
+    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(
+        cli, "get_github_prs", lambda *_: ["https://github.com/org/repo/pull/1"]
+    )
+    monkeypatch.setattr(api, "make_github_api_request", _fake_pr_detail)
+
+    result = CliRunner().invoke(cli.breakfast, ["--config", str(cfg_file)])
+
+    assert result.exit_code == 0
+    assert "| Repo" in result.stdout
+    assert "[PR-1]" in result.stdout
+
+
+def test_format_markdown_includes_optional_columns(monkeypatch):
+    monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
+    monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
+    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+
+    def fake_api_request(path):
+        if "check-runs" in path:
+            return {"check_runs": [{"status": "completed", "conclusion": "success"}]}
+        return _fake_pr_detail(path)
+
+    monkeypatch.setattr(
+        cli, "get_github_prs", lambda *_: ["https://github.com/org/repo/pull/1"]
+    )
+    monkeypatch.setattr(api, "make_github_api_request", fake_api_request)
+
+    result = CliRunner().invoke(
+        cli.breakfast,
+        ["-o", "org", "-r", "repo", "--format", "markdown", "--checks", "--age"],
+    )
+
+    assert result.exit_code == 0
+    assert "| Checks" in result.stdout
+    assert "| Age" in result.stdout
+
+
+def test_format_flag_overrides_json_flag(monkeypatch):
+    """--format markdown takes precedence over --json."""
+    monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
+    monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
+    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(
+        cli, "get_github_prs", lambda *_: ["https://github.com/org/repo/pull/1"]
+    )
+    monkeypatch.setattr(api, "make_github_api_request", _fake_pr_detail)
+
+    result = CliRunner().invoke(
+        cli.breakfast,
+        ["-o", "org", "-r", "repo", "--json", "--format", "markdown"],
+    )
+
+    assert result.exit_code == 0
+    assert "| Repo" in result.stdout
+    with pytest.raises(json.JSONDecodeError):
+        json.loads(result.stdout)


### PR DESCRIPTION
## Summary

- Adds a new `--format markdown` output mode that renders the PR table as a GitHub-flavoured Markdown table
- Introduces a `--format [table|json|markdown]` CLI option; `--json/--no-json` is kept as an alias for `--format json` / `--format table`
- ANSI colour codes are stripped and OSC 8 terminal hyperlinks are converted to `[text](url)` Markdown links
- Optional columns (`--age`, `--checks`, `--approvals`, `--head-branch`, `--base-branch`) are included when their flags are active
- `format = "markdown"` in config works as a persistent default
- Manual pages updated (`options.md`, `output-formats.md`)

## Test plan

- [ ] `--format markdown` renders a GFM table to stdout
- [ ] ANSI codes and OSC 8 hyperlinks are stripped
- [ ] Optional columns included when flags active
- [ ] `format = "markdown"` in config works
- [ ] `--format` overrides `--json` when both given
- [ ] Progress messages go to stderr, table to stdout
- [ ] All 274 unit tests pass (`make test`)
- [ ] Lint clean (`make lint`)

Closes #181

🤖 Generated with [Claude Code](https://claude.com/claude-code)