### PR TITLE
fix: use GH_TOKEN PAT in release checkout to bypass branch protection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,6 +154,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ secrets.GH_TOKEN }}
 
       - name: Set up Python
         uses: actions/setup-python@v5


### PR DESCRIPTION
The release job pushes a version bump directly to main, but the branch protection ruleset now requires PRs. `GITHUB_TOKEN` is a GitHub App integration and cannot be granted bypass rights on personal accounts.

Fix: pass `token: ${{ secrets.GH_TOKEN }}` to the `actions/checkout` step in the release job. The PAT from the repo owner has admin-level access, which satisfies the `RepositoryRole` bypass configured on the ruleset.

**Before merging:** add a `GH_TOKEN` secret to this repo containing a PAT with `repo` scope from mrsixw.