### PR TITLE
fix: skip release job on version bump commits to prevent CI loop

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,7 +144,7 @@ jobs:
           fish -c "source completions/breakfast.fish && echo 'fish ok'"
 
   release:
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push' && !startsWith(github.event.head_commit.message, 'chore: bump version')
+    if: "github.ref == 'refs/heads/main' && github.event_name == 'push' && !startsWith(github.event.head_commit.message, 'chore: bump version')"
     runs-on: ubuntu-latest
     needs: [build, man, completions]
     permissions:
@@ -197,7 +197,7 @@ jobs:
         run: utils/create_release.sh "${{ steps.bump.outputs.version }}"
 
   verify-release:
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push' && !startsWith(github.event.head_commit.message, 'chore: bump version')
+    if: "github.ref == 'refs/heads/main' && github.event_name == 'push' && !startsWith(github.event.head_commit.message, 'chore: bump version')"
     runs-on: ubuntu-latest
     needs: release
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,7 +144,7 @@ jobs:
           fish -c "source completions/breakfast.fish && echo 'fish ok'"
 
   release:
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push' && !startsWith(github.event.head_commit.message, 'chore: bump version')
     runs-on: ubuntu-latest
     needs: [build, man, completions]
     permissions:
@@ -197,7 +197,7 @@ jobs:
         run: utils/create_release.sh "${{ steps.bump.outputs.version }}"
 
   verify-release:
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push' && !startsWith(github.event.head_commit.message, 'chore: bump version')
     runs-on: ubuntu-latest
     needs: release
     steps:


### PR DESCRIPTION
Closes #187

When using a PAT for checkout (required for branch protection bypass), git pushes trigger CI runs — unlike GITHUB_TOKEN which GitHub suppresses for loop prevention. This caused the version bump commit to re-trigger the release job, which would fail trying to bump again.

Fix: add `!startsWith(github.event.head_commit.message, 'chore: bump version')` to the `release` and `verify-release` job conditions.