### PR TITLE
#190: Use default terminal colour for author/title in non-special months

### DIFF
--- a/src/breakfast/ui.py
+++ b/src/breakfast/ui.py
@@ -69,8 +69,12 @@ def _easter_month(year: int) -> int:
     return (h + ll - 7 * m + 114) // 31
 
 
-def _seasonal_palette() -> list[str]:
-    """Return the 4-shade ANSI palette for the current calendar month."""
+def _seasonal_palette() -> list[str] | None:
+    """Return the 4-shade ANSI palette for the current calendar month, or None.
+
+    Returns None for months with no seasonal theme, so callers can skip
+    colouring and fall back to the default terminal colour.
+    """
     today = datetime.date.today()
     month = today.month
     if month == 1:
@@ -81,16 +85,17 @@ def _seasonal_palette() -> list[str]:
         return SEASONAL_PALETTES["orange"]
     if month == 12:
         return SEASONAL_PALETTES["red"]
-    return SEASONAL_PALETTES["green"]
+    return None
 
 
 def apply_seasonal_colour(text: str, pr_number: int) -> str:
     """Wrap *text* in a seasonal ANSI 256-colour based on the current month.
 
     December 🎄 alternates rows between red and green (candy-cane style).
-    All other months use a 4-shade gradient keyed by ``pr_number % 4``.
-    Returns the original text unchanged if called when no colour is needed —
-    callers are expected to guard with the ``no-colour`` setting.
+    Special months (Jan, Easter, Oct, Dec) use a 4-shade gradient keyed by
+    ``pr_number % 4``. Non-special months return text unstyled so it renders
+    in the default terminal colour, consistent with all other table columns.
+    Callers are expected to guard with the ``no-colour`` setting.
     """
     today = datetime.date.today()
     if today.month == 12:
@@ -99,9 +104,11 @@ def apply_seasonal_colour(text: str, pr_number: int) -> str:
             if pr_number % 2 == 0
             else SEASONAL_PALETTES["green"][2]
         )
-    else:
-        palette = _seasonal_palette()
-        colour = palette[pr_number % 4]
+        return f"{colour}{text}\033[0m"
+    palette = _seasonal_palette()
+    if palette is None:
+        return text
+    colour = palette[pr_number % 4]
     return f"{colour}{text}\033[0m"
 
 

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -111,26 +111,40 @@ def test_easter_month_known_years():
         (4, "yellow"),  # 2026 Easter is in April
         (10, "orange"),
         (12, "red"),
-        (6, "green"),
-        (8, "green"),
     ],
 )
-def test_seasonal_palette_by_month(month, expected_key):
+def test_seasonal_palette_by_special_month(month, expected_key):
     with patch("breakfast.ui.datetime") as mock_dt:
         mock_dt.date.today.return_value = _today(month)
         palette = ui._seasonal_palette()
     assert palette == ui.SEASONAL_PALETTES[expected_key]
 
 
+@pytest.mark.parametrize("month", [2, 3, 5, 6, 7, 8, 9, 11])
+def test_seasonal_palette_non_special_months_return_none(month):
+    with patch("breakfast.ui.datetime") as mock_dt:
+        mock_dt.date.today.return_value = _today(month)
+        palette = ui._seasonal_palette()
+    assert palette is None
+
+
 def test_apply_seasonal_colour_shade_from_pr_number():
     with patch("breakfast.ui.datetime") as mock_dt:
-        mock_dt.date.today.return_value = _today(6)  # June → green
+        mock_dt.date.today.return_value = _today(1)  # January → purple
         for pr_num in range(8):
             result = ui.apply_seasonal_colour("alice", pr_num)
-            expected_colour = ui.SEASONAL_PALETTES["green"][pr_num % 4]
+            expected_colour = ui.SEASONAL_PALETTES["purple"][pr_num % 4]
             assert result.startswith(expected_colour)
             assert result.endswith("\033[0m")
             assert "alice" in result
+
+
+def test_apply_seasonal_colour_non_special_month_returns_plain():
+    with patch("breakfast.ui.datetime") as mock_dt:
+        mock_dt.date.today.return_value = _today(6)  # June → no seasonal theme
+        for pr_num in range(4):
+            result = ui.apply_seasonal_colour("alice", pr_num)
+            assert result == "alice"
 
 
 def test_apply_seasonal_colour_christmas_alternates():


### PR DESCRIPTION
## Summary

- `_seasonal_palette()` now returns `None` for months with no seasonal theme (anything outside January, Easter, October, December)
- `apply_seasonal_colour` returns text unstyled when there is no palette, so author and PR title render in the default terminal colour rather than always green
- Tests updated: removed the green-for-non-special-months assertions, added a parametrised check that all non-special months return `None` from `_seasonal_palette`, and added a test that `apply_seasonal_colour` returns plain text in a non-special month

## Test plan

- [ ] `make test` passes (281 tests)
- [ ] `make lint` passes
- [ ] Run `breakfast` in a non-special month (e.g. May) — author and PR title should render in default terminal colour with no ANSI green
- [ ] Run `breakfast` in a mocked special month (or wait until January/October) — seasonal colours should still apply

Closes #190

🤖 Generated with [Claude Code](https://claude.com/claude-code)