### PR TITLE
#189: Add --colour-diagnostics flag to preview all UI colours and gradients

### DIFF
--- a/docs/manual/options.md
+++ b/docs/manual/options.md
@@ -613,6 +613,29 @@ Can also be set persistently in config:
 no-colour = true
 ```
 
+### `--colour-diagnostics` / `--color-diagnostics`
+
+Print a colour swatch page showing every colour and gradient used in the breakfast UI, then exit. No GitHub token or organisation is required.
+
+```bash
+breakfast --colour-diagnostics
+breakfast --color-diagnostics    # US spelling alias
+```
+
+The swatch page covers:
+
+- **Seasonal palettes** — all five (January purple, Easter yellow, October orange, December red/green) with all four shades each
+- **PR state** — open (green), draft (grey), closed (red)
+- **Check status** — pass, fail, pending, none
+- **Approval status** — approved, changes requested, pending
+- **Mergeable status** — yes / no
+- **Number gradient** — the colour scale used for files, commits, comments, and age columns
+- **Summary bar gradient** — the bar colours used in `--summarise-*-prs` views
+- **UI / system colours** — cyan (update notifications), yellow (warnings), red (errors), green (success)
+- **+/- column** — additions (green) and deletions (red)
+
+Each row shows filled blocks rendered in the actual colour alongside the ANSI code or name, so you can see exactly what each one looks like in your terminal.
+
 ## Diagnostics
 
 ### `--api-stats`

--- a/src/breakfast/cli.py
+++ b/src/breakfast/cli.py
@@ -45,6 +45,7 @@ from .ui import (
     format_mergeable_status,
     format_pr_state,
     generate_terminal_url_anchor,
+    render_colour_diagnostics,
     render_pr_summary,
 )
 from .updater import check_for_update
@@ -717,6 +718,18 @@ def _fetch_pr_bundle(url, fetch_checks, fetch_approvals):
     ),
 )
 @click.option(
+    "--colour-diagnostics",
+    "--color-diagnostics",
+    "colour_diagnostics",
+    is_flag=True,
+    default=False,
+    help=(
+        "Print a colour swatch page showing every colour and gradient used in"
+        " the breakfast UI, then exit. Useful for tuning palette choices in"
+        " your terminal."
+    ),
+)
+@click.option(
     "--summarise-user-prs",
     "--summarize-user-prs",
     "summarise_user_prs",
@@ -776,11 +789,16 @@ def breakfast(
     search,
     api_stats,
     no_colour,
+    colour_diagnostics,
     summarise_user_prs,
     summarise_repo_prs,
 ):
     t0_total = time.monotonic()
     configure_logging()
+
+    if colour_diagnostics:
+        click.echo(render_colour_diagnostics(), color=True)
+        sys.exit(0)
 
     if search is not None:
         try:

--- a/src/breakfast/ui.py
+++ b/src/breakfast/ui.py
@@ -237,6 +237,138 @@ def generate_terminal_url_anchor(url, url_text="Link"):
     return f"\033]8;;{url}\033\\{url_text}\033]8;;\033\\"
 
 
+def render_colour_diagnostics() -> str:
+    """Render a swatch page showing every colour used in the breakfast UI.
+
+    Returns a multi-line string ready to pass to ``click.echo()``.
+    Useful for tuning palette choices in a specific terminal.
+    """
+
+    def _ansi256(code: int, text: str) -> str:
+        return f"\033[38;5;{code}m{text}\033[0m"
+
+    def _named(name: str, text: str) -> str:
+        return click.style(text, fg=name, bold=True)
+
+    def _named_dim(name, text: str) -> str:
+        return click.style(text, fg=name, bold=False)
+
+    BLOCK = "████"
+
+    lines = [click.style("🎨 breakfast colour diagnostics", fg="cyan", bold=True), ""]
+
+    # ------------------------------------------------------------------
+    # Seasonal palettes (author / PR title gradient)
+    # ------------------------------------------------------------------
+    lines.append(click.style("Seasonal palettes  (author & PR title)", bold=True))
+    palette_rows = [
+        ("January 🗓️", "purple"),
+        ("Easter 🐣", "yellow"),
+        ("October 🎃", "orange"),
+        ("December 🎄 (red)", "red"),
+        ("December 🎄 (green)", "green"),
+    ]
+    for label, key in palette_rows:
+
+        def _swatch(code: str) -> str:
+            n = code.split(";")[2].rstrip("m")
+            return f"{_ansi256(int(n), BLOCK)} {n}"
+
+        swatches = "  ".join(_swatch(c) for c in SEASONAL_PALETTES[key])
+        lines.append(f"  {label:<22}  {swatches}")
+    lines.append("")
+
+    # ------------------------------------------------------------------
+    # PR state
+    # ------------------------------------------------------------------
+    lines.append(click.style("PR state", bold=True))
+    lines.append(
+        f"  {_named('green', BLOCK)} open        "
+        f"  {_named_dim(246, BLOCK)} draft (246)  "
+        f"  {_named('red', BLOCK)} closed"
+    )
+    lines.append("")
+
+    # ------------------------------------------------------------------
+    # Check status
+    # ------------------------------------------------------------------
+    lines.append(click.style("Check status", bold=True))
+    lines.append(
+        f"  {_named('green', BLOCK)} pass    "
+        f"  {_named('red', BLOCK)} fail    "
+        f"  {_named('yellow', BLOCK)} pending  "
+        f"  {_named('white', BLOCK)} none"
+    )
+    lines.append("")
+
+    # ------------------------------------------------------------------
+    # Approval status
+    # ------------------------------------------------------------------
+    lines.append(click.style("Approval status", bold=True))
+    lines.append(
+        f"  {_named('green', BLOCK)} approved  "
+        f"  {_named('red', BLOCK)} changes   "
+        f"  {_named('yellow', BLOCK)} pending"
+    )
+    lines.append("")
+
+    # ------------------------------------------------------------------
+    # Mergeable status
+    # ------------------------------------------------------------------
+    lines.append(click.style("Mergeable status", bold=True))
+    lines.append(f"  {_named('green', BLOCK)} yes  " f"  {_named('red', BLOCK)} no")
+    lines.append("")
+
+    # ------------------------------------------------------------------
+    # Number gradient (files, commits, comments, age)
+    # ------------------------------------------------------------------
+    lines.append(
+        click.style("Number gradient  (files / commits / comments / age)", bold=True)
+    )
+    lines.append(
+        f"  {_named('green', BLOCK)} <10      "
+        f"  {_named('yellow', BLOCK)} 10–19    "
+        f"  {_ansi256(208, BLOCK)} 20–49 (208)  "
+        f"  {_named('red', BLOCK)} 50+"
+    )
+    lines.append("")
+
+    # ------------------------------------------------------------------
+    # Summary bar gradient (--summarise-user-prs / --summarise-repo-prs)
+    # ------------------------------------------------------------------
+    lines.append(click.style("Summary bar gradient  (--summarise-*-prs)", bold=True))
+    lines.append(
+        f"  {_named('green', BLOCK)} ≤25%     "
+        f"  {_named('yellow', BLOCK)} ≤50%     "
+        f"  {_ansi256(208, BLOCK)} ≤75% (208)   "
+        f"  {_named('red', BLOCK)} >75%"
+    )
+    lines.append(f"  {_ansi256(245, BLOCK)} draft blocks (245)")
+    lines.append("")
+
+    # ------------------------------------------------------------------
+    # UI / system colours
+    # ------------------------------------------------------------------
+    lines.append(click.style("UI / system colours", bold=True))
+    lines.append(
+        f"  {_named('cyan', BLOCK)} update notifications  "
+        f"  {_named('yellow', BLOCK)} warnings  "
+        f"  {_named('red', BLOCK)} errors  "
+        f"  {_named('green', BLOCK)} success"
+    )
+    lines.append("")
+
+    # ------------------------------------------------------------------
+    # Additions / deletions (+/- column)
+    # ------------------------------------------------------------------
+    lines.append(click.style("+/- column", bold=True))
+    lines.append(
+        f"  {_named('green', BLOCK)} additions  " f"  {_named('red', BLOCK)} deletions"
+    )
+
+    return "\n".join(lines)
+
+
 def render_pr_summary(groups, title, label_header, colour, seasonal_colours):
     """Render a compact PR summary table as a string.
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2369,6 +2369,29 @@ def test_no_color_alias_works(monkeypatch):
 
 
 # ---------------------------------------------------------------------------
+# Colour diagnostics (#189)
+# ---------------------------------------------------------------------------
+
+
+def test_colour_diagnostics_flag_exits_zero_and_outputs_swatches():
+    """--colour-diagnostics prints swatch output and exits 0 without needing a token."""
+    runner = CliRunner()
+    result = runner.invoke(cli.breakfast, ["--colour-diagnostics"])
+    assert result.exit_code == 0
+    assert "Seasonal palettes" in result.output
+    assert "Check status" in result.output
+    assert "Number gradient" in result.output
+
+
+def test_color_diagnostics_alias_works():
+    """--color-diagnostics (US spelling) is accepted."""
+    runner = CliRunner()
+    result = runner.invoke(cli.breakfast, ["--color-diagnostics"])
+    assert result.exit_code == 0
+    assert "Seasonal palettes" in result.output
+
+
+# ---------------------------------------------------------------------------
 # Seasonal colours (#168)
 # ---------------------------------------------------------------------------
 

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -152,6 +152,35 @@ def test_apply_seasonal_colour_wraps_and_resets():
 
 
 # ---------------------------------------------------------------------------
+# render_colour_diagnostics (#189)
+# ---------------------------------------------------------------------------
+
+
+def test_render_colour_diagnostics_contains_section_headings():
+    result = ui.render_colour_diagnostics()
+    assert "Seasonal palettes" in result
+    assert "PR state" in result
+    assert "Check status" in result
+    assert "Approval status" in result
+    assert "Mergeable status" in result
+    assert "Number gradient" in result
+    assert "Summary bar gradient" in result
+    assert "UI / system colours" in result
+    assert "+/- column" in result
+
+
+def test_render_colour_diagnostics_contains_ansi_codes():
+    result = ui.render_colour_diagnostics()
+    assert "\033[" in result
+
+
+def test_render_colour_diagnostics_is_string():
+    result = ui.render_colour_diagnostics()
+    assert isinstance(result, str)
+    assert len(result) > 0
+
+
+# ---------------------------------------------------------------------------
 # render_pr_summary (#177)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- Adds `--colour-diagnostics` / `--color-diagnostics` flag that prints a swatch page and exits immediately (no GitHub token or org required)
- Covers every colour used in the UI: seasonal palettes (January/Easter/October/December), PR state, check status, approval status, mergeable status, number gradient, summary bar gradient, named UI colours (cyan/yellow/red/green), and the +/- column
- Each swatch row shows filled blocks rendered in the actual colour alongside its label and ANSI code/name, so you can see exactly what it looks like in your terminal
- `render_colour_diagnostics()` added to `ui.py`; flag wired into `cli.py` before org/token checks

## Test plan

- [ ] `make test` passes (279 tests)
- [ ] `make lint` passes
- [ ] Run `breakfast --colour-diagnostics` — swatch page renders with coloured blocks and labels
- [ ] Run `breakfast --color-diagnostics` — US spelling alias works
- [ ] Confirm all 9 sections are present: Seasonal palettes, PR state, Check status, Approval status, Mergeable status, Number gradient, Summary bar gradient, UI/system colours, +/- column

Closes #189

🤖 Generated with [Claude Code](https://claude.com/claude-code)