### PR TITLE
#193: Tune seasonal colours — single hue per month, all plain columns coloured

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -70,7 +70,11 @@ When updating project rules, update **all four files** to keep them consistent.
 
 ## Code Quality
 - Use `ruff` (lint + import sorting) and `black` (formatting).
-- Before committing and pushing changes, run `make test`, `make lint`, and `make format` locally.
+- **Before every commit and push, you MUST run all three of these in order — no exceptions:**
+  1. `make format` — auto-fix formatting
+  2. `make lint` — must exit clean
+  3. `make test` — all tests must pass
+  Skipping any of these steps is not acceptable, even for small or documentation-only changes.
 
 ## Documentation
 - If CLI options, features, or user-visible behaviors change, you MUST update the relevant manual pages in `docs/manual/` (`options.md`, `usage.md`, etc.).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,7 +79,11 @@ When updating project rules, update **all four files** to keep them consistent.
 ## Code Quality
 - Use `ruff` (lint + import sorting) and `black` (formatting).
 - Prefer running checks via CI and pre-commit hooks where possible.
-- Before committing and pushing changes, run `make test`, `make lint`, and `make format` locally.
+- **Before every commit and push, you MUST run all three of these in order — no exceptions:**
+  1. `make format` — auto-fix formatting
+  2. `make lint` — must exit clean
+  3. `make test` — all tests must pass
+  Skipping any of these steps is not acceptable, even for small or documentation-only changes.
 - **Never use bare `except Exception`.** Always catch the most specific exception type(s) possible (e.g. `requests.exceptions.RequestException`, `OSError`, `json.JSONDecodeError`, `KeyError`, `ValueError`, `PackageNotFoundError`). Bare `except Exception` hides bugs and swallows unexpected errors silently.
 - **stdout/stderr discipline:** All data output (table, JSON, summary views) must go to **stdout**. All progress messages, spinner emoji, warnings, and errors must go to **stderr** (`err=True` in Click). This keeps every output format safe to pipe or redirect independently. Tests must assert data on `result.stdout` and status/error messages on `result.stderr`.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,7 +79,11 @@ When updating project rules, update **all four files** to keep them consistent.
 ## Code Quality
 - Use `ruff` (lint + import sorting) and `black` (formatting).
 - Prefer running checks via CI and pre-commit hooks where possible.
-- Before committing and pushing changes, run `make test`, `make lint`, and `make format` locally.
+- **Before every commit and push, you MUST run all three of these in order — no exceptions:**
+  1. `make format` — auto-fix formatting
+  2. `make lint` — must exit clean
+  3. `make test` — all tests must pass
+  Skipping any of these steps is not acceptable, even for small or documentation-only changes.
 - **Never use bare `except Exception`.** Always catch the most specific exception type(s) possible (e.g. `requests.exceptions.RequestException`, `OSError`, `json.JSONDecodeError`, `KeyError`, `ValueError`, `PackageNotFoundError`). Bare `except Exception` hides bugs and swallows unexpected errors silently.
 - **stdout/stderr discipline:** All data output (table, JSON, summary views) must go to **stdout**. All progress messages, spinner emoji, warnings, and errors must go to **stderr** (`err=True` in Click). This keeps every output format safe to pipe or redirect independently. Tests must assert data on `result.stdout` and status/error messages on `result.stderr`.
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -35,7 +35,11 @@ When updating project rules, update **all four files** to keep them consistent.
 
 ## Technical Integrity & Validation
 - **Project Structure:** Logic is decomposed into modules within `src/breakfast/`; tests are module-specific in `tests/`.
-- **Pre-commit Checks:** Always run `make test`, `make lint`, and `make format` before committing.
+- **Pre-commit Checks:** Before every commit and push, you MUST run all three in order — no exceptions:
+  1. `make format` — auto-fix formatting
+  2. `make lint` — must exit clean
+  3. `make test` — all tests must pass
+  Skipping any of these is not acceptable, even for small or documentation-only changes.
 - **No bare `except Exception`:** Always catch the most specific exception type(s) (e.g. `requests.exceptions.RequestException`, `OSError`, `json.JSONDecodeError`, `KeyError`, `ValueError`, `PackageNotFoundError`). Bare `except Exception` hides bugs and swallows unexpected errors silently.
 - **stdout/stderr discipline:** All data output (table, JSON, summary views) must go to **stdout**. All progress messages, spinner emoji, warnings, and errors must go to **stderr** (`err=True` in Click). This keeps every output format safe to pipe or redirect independently. Tests must assert data on `result.stdout` and status/error messages on `result.stderr`.
 - **Testing with Cache:** Since caching is implemented, all manual testing must be performed both *with* the cache enabled and *without* the cache (e.g., clearing the cache or disabling it).

--- a/src/breakfast/cli.py
+++ b/src/breakfast/cli.py
@@ -1456,26 +1456,26 @@ def breakfast(
         author_url = author.get("html_url") or f"https://github.com/{author['login']}"
         pr_num = pr_detail["number"]
 
-        def _sc(text: str) -> str:
+        def _seasonal_colour(text: str) -> str:
             """Apply seasonal colour to plain text when seasonal colouring is active."""
             if seasonal_colours and colour:
                 return apply_seasonal_colour(text, pr_num)
             return text
 
-        def _sc_link(url: str, text: str) -> str:
+        def _seasonal_colour_link(url: str, text: str) -> str:
             """Apply seasonal colour to a hyperlinked label when active."""
             if seasonal_colours and colour:
                 return _styled_hyperlink(url, apply_seasonal_colour(text, pr_num))
             return generate_terminal_url_anchor(url, text)
 
         row = {
-            "Repo": _sc_link(repo_url, repo["name"]),
-            "PR Title": _sc(pr_detail["title"]),
-            "Author": _sc_link(author_url, author["login"]),
+            "Repo": _seasonal_colour_link(repo_url, repo["name"]),
+            "PR Title": _seasonal_colour(pr_detail["title"]),
+            "Author": _seasonal_colour_link(author_url, author["login"]),
             "State": state_label,
             "Files": click_colour_grade_number(pr_detail["changed_files"]),
             "Commits": click_colour_grade_number(pr_detail["commits"]),
-            "+/-": _sc(f"{adds}/{subs}"),
+            "+/-": _seasonal_colour(f"{adds}/{subs}"),
             "Comments": click_colour_grade_number(pr_detail["review_comments"]),
         }
         if age:
@@ -1501,19 +1501,21 @@ def breakfast(
             _hb_owner = pr_detail["base"]["repo"]["owner"]["login"]
             _hb_repo = pr_detail["base"]["repo"]["name"]
             _hb_url = f"https://github.com/{_hb_owner}/{_hb_repo}/tree/{_hb_name}"
-            row["Head Branch"] = _sc_link(_hb_url, _hb_name)
+            row["Head Branch"] = _seasonal_colour_link(_hb_url, _hb_name)
         if base_branch:
             _bb_name = pr_detail["base"]["ref"]
             _bb_owner = pr_detail["base"]["repo"]["owner"]["login"]
             _bb_repo = pr_detail["base"]["repo"]["name"]
             _bb_url = f"https://github.com/{_bb_owner}/{_bb_repo}/tree/{_bb_name}"
-            row["Base Branch"] = _sc_link(_bb_url, _bb_name)
+            row["Base Branch"] = _seasonal_colour_link(_bb_url, _bb_name)
         row["Mergeable?"] = format_mergeable_status(
             pr_detail["mergeable"],
             pr_detail["mergeable_state"],
             style=status_style,
         )
-        row["Link"] = _sc_link(pr_detail["html_url"], f"PR-{pr_detail['number']}")
+        row["Link"] = _seasonal_colour_link(
+            pr_detail["html_url"], f"PR-{pr_detail['number']}"
+        )
         pr_data.append(row)
 
     # Apply explicit title truncation, then auto-fit to terminal if interactive

--- a/src/breakfast/cli.py
+++ b/src/breakfast/cli.py
@@ -1463,7 +1463,7 @@ def breakfast(
             return text
 
         def _sc_link(url: str, text: str) -> str:
-            """Apply seasonal colour to a hyperlinked label when seasonal colouring is active."""
+            """Apply seasonal colour to a hyperlinked label when active."""
             if seasonal_colours and colour:
                 return _styled_hyperlink(url, apply_seasonal_colour(text, pr_num))
             return generate_terminal_url_anchor(url, text)

--- a/src/breakfast/cli.py
+++ b/src/breakfast/cli.py
@@ -1457,11 +1457,13 @@ def breakfast(
         pr_num = pr_detail["number"]
 
         def _sc(text: str) -> str:
+            """Apply seasonal colour to plain text when seasonal colouring is active."""
             if seasonal_colours and colour:
                 return apply_seasonal_colour(text, pr_num)
             return text
 
         def _sc_link(url: str, text: str) -> str:
+            """Apply seasonal colour to a hyperlinked label when seasonal colouring is active."""
             if seasonal_colours and colour:
                 return _styled_hyperlink(url, apply_seasonal_colour(text, pr_num))
             return generate_terminal_url_anchor(url, text)

--- a/src/breakfast/cli.py
+++ b/src/breakfast/cli.py
@@ -1456,24 +1456,24 @@ def breakfast(
         author_url = author.get("html_url") or f"https://github.com/{author['login']}"
         pr_num = pr_detail["number"]
 
-        if seasonal_colours and colour:
-            title_text = apply_seasonal_colour(pr_detail["title"], pr_num)
-            author_cell = _styled_hyperlink(
-                author_url,
-                apply_seasonal_colour(author["login"], pr_num),
-            )
-        else:
-            title_text = pr_detail["title"]
-            author_cell = generate_terminal_url_anchor(author_url, author["login"])
+        def _sc(text: str) -> str:
+            if seasonal_colours and colour:
+                return apply_seasonal_colour(text, pr_num)
+            return text
+
+        def _sc_link(url: str, text: str) -> str:
+            if seasonal_colours and colour:
+                return _styled_hyperlink(url, apply_seasonal_colour(text, pr_num))
+            return generate_terminal_url_anchor(url, text)
 
         row = {
-            "Repo": generate_terminal_url_anchor(repo_url, repo["name"]),
-            "PR Title": title_text,
-            "Author": author_cell,
+            "Repo": _sc_link(repo_url, repo["name"]),
+            "PR Title": _sc(pr_detail["title"]),
+            "Author": _sc_link(author_url, author["login"]),
             "State": state_label,
             "Files": click_colour_grade_number(pr_detail["changed_files"]),
             "Commits": click_colour_grade_number(pr_detail["commits"]),
-            "+/-": f"{adds}/{subs}",
+            "+/-": _sc(f"{adds}/{subs}"),
             "Comments": click_colour_grade_number(pr_detail["review_comments"]),
         }
         if age:
@@ -1499,22 +1499,19 @@ def breakfast(
             _hb_owner = pr_detail["base"]["repo"]["owner"]["login"]
             _hb_repo = pr_detail["base"]["repo"]["name"]
             _hb_url = f"https://github.com/{_hb_owner}/{_hb_repo}/tree/{_hb_name}"
-            row["Head Branch"] = generate_terminal_url_anchor(_hb_url, _hb_name)
+            row["Head Branch"] = _sc_link(_hb_url, _hb_name)
         if base_branch:
             _bb_name = pr_detail["base"]["ref"]
             _bb_owner = pr_detail["base"]["repo"]["owner"]["login"]
             _bb_repo = pr_detail["base"]["repo"]["name"]
             _bb_url = f"https://github.com/{_bb_owner}/{_bb_repo}/tree/{_bb_name}"
-            row["Base Branch"] = generate_terminal_url_anchor(_bb_url, _bb_name)
+            row["Base Branch"] = _sc_link(_bb_url, _bb_name)
         row["Mergeable?"] = format_mergeable_status(
             pr_detail["mergeable"],
             pr_detail["mergeable_state"],
             style=status_style,
         )
-        row["Link"] = generate_terminal_url_anchor(
-            pr_detail["html_url"],
-            f"PR-{pr_detail['number']}",
-        )
+        row["Link"] = _sc_link(pr_detail["html_url"], f"PR-{pr_detail['number']}")
         pr_data.append(row)
 
     # Apply explicit title truncation, then auto-fit to terminal if interactive

--- a/src/breakfast/ui.py
+++ b/src/breakfast/ui.py
@@ -289,6 +289,7 @@ def render_colour_diagnostics() -> str:
     ]
 
     def _seasonal_swatch(code: str) -> str:
+        """Render a coloured block swatch for a raw ANSI escape code (named or 256-colour)."""
         parts = code.split(";")
         if len(parts) >= 3:
             n = parts[2].rstrip("m")

--- a/src/breakfast/ui.py
+++ b/src/breakfast/ui.py
@@ -289,7 +289,7 @@ def render_colour_diagnostics() -> str:
     ]
 
     def _seasonal_swatch(code: str) -> str:
-        """Render a coloured block swatch for a raw ANSI escape code (named or 256-colour)."""
+        """Render a coloured block swatch for a raw ANSI escape code."""
         parts = code.split(";")
         if len(parts) >= 3:
             n = parts[2].rstrip("m")
@@ -394,17 +394,19 @@ def render_colour_diagnostics() -> str:
     # ------------------------------------------------------------------
     # 256-colour reference — all hues, full shade range
     # ------------------------------------------------------------------
-    lines.append(click.style("256-colour reference  (all hues, dark → bright)", bold=True))
+    lines.append(
+        click.style("256-colour reference  (all hues, dark → bright)", bold=True)
+    )
     hue_rows = [
-        ("Greens",   [22, 28, 34, 40, 46, 82, 118, 154, 190]),
-        ("Yellows",  [100, 106, 136, 142, 178, 184, 190, 220, 226]),
-        ("Oranges",  [94, 130, 136, 166, 172, 202, 208, 214]),
-        ("Reds",     [52, 88, 124, 160, 196, 197, 203, 210]),
-        ("Purples",  [54, 55, 56, 90, 91, 92, 93, 129, 135, 141, 147]),
-        ("Blues",    [17, 18, 19, 20, 21, 57, 63, 69, 75, 81]),
-        ("Cyans",    [23, 30, 37, 44, 51, 86, 87, 122, 123]),
+        ("Greens", [22, 28, 34, 40, 46, 82, 118, 154, 190]),
+        ("Yellows", [100, 106, 136, 142, 178, 184, 190, 220, 226]),
+        ("Oranges", [94, 130, 136, 166, 172, 202, 208, 214]),
+        ("Reds", [52, 88, 124, 160, 196, 197, 203, 210]),
+        ("Purples", [54, 55, 56, 90, 91, 92, 93, 129, 135, 141, 147]),
+        ("Blues", [17, 18, 19, 20, 21, 57, 63, 69, 75, 81]),
+        ("Cyans", [23, 30, 37, 44, 51, 86, 87, 122, 123]),
         ("Magentas", [53, 89, 125, 126, 161, 162, 197, 198, 199, 207]),
-        ("Greys",    [232, 235, 238, 240, 242, 244, 246, 248, 250, 252, 254]),
+        ("Greys", [232, 235, 238, 240, 242, 244, 246, 248, 250, 252, 254]),
     ]
     for label, codes in hue_rows:
         swatches = "  ".join(f"{_ansi256(n, BLOCK)} {n:<3}" for n in codes)

--- a/src/breakfast/ui.py
+++ b/src/breakfast/ui.py
@@ -1,13 +1,14 @@
 import datetime
+import unicodedata
 
 import click
 
 SEASONAL_PALETTES = {
-    "green": ["\033[38;5;22m", "\033[38;5;34m", "\033[38;5;40m", "\033[38;5;46m"],
-    "purple": ["\033[38;5;54m", "\033[38;5;90m", "\033[38;5;129m", "\033[38;5;165m"],
-    "yellow": ["\033[38;5;100m", "\033[38;5;184m", "\033[38;5;220m", "\033[38;5;226m"],
-    "orange": ["\033[38;5;130m", "\033[38;5;166m", "\033[38;5;202m", "\033[38;5;208m"],
-    "red": ["\033[38;5;88m", "\033[38;5;124m", "\033[38;5;160m", "\033[38;5;196m"],
+    "green": "\033[32m",
+    "purple": "\033[38;5;141m",
+    "yellow": "\033[38;5;226m",
+    "orange": "\033[38;5;208m",
+    "red": "\033[31m",
 }
 
 BREAKFAST_ITEMS = [
@@ -69,8 +70,8 @@ def _easter_month(year: int) -> int:
     return (h + ll - 7 * m + 114) // 31
 
 
-def _seasonal_palette() -> list[str] | None:
-    """Return the 4-shade ANSI palette for the current calendar month, or None.
+def _seasonal_colour() -> str | None:
+    """Return the ANSI colour code for the current calendar month, or None.
 
     Returns None for months with no seasonal theme, so callers can skip
     colouring and fall back to the default terminal colour.
@@ -89,26 +90,24 @@ def _seasonal_palette() -> list[str] | None:
 
 
 def apply_seasonal_colour(text: str, pr_number: int) -> str:
-    """Wrap *text* in a seasonal ANSI 256-colour based on the current month.
+    """Wrap *text* in a seasonal ANSI colour based on the current month.
 
     December 🎄 alternates rows between red and green (candy-cane style).
-    Special months (Jan, Easter, Oct, Dec) use a 4-shade gradient keyed by
-    ``pr_number % 4``. Non-special months return text unstyled so it renders
-    in the default terminal colour, consistent with all other table columns.
-    Callers are expected to guard with the ``no-colour`` setting.
+    Non-special months return text unstyled so it renders in the default
+    terminal colour. Callers are expected to guard with the ``no-colour``
+    setting.
     """
     today = datetime.date.today()
     if today.month == 12:
         colour = (
-            SEASONAL_PALETTES["red"][2]
+            SEASONAL_PALETTES["red"]
             if pr_number % 2 == 0
-            else SEASONAL_PALETTES["green"][2]
+            else SEASONAL_PALETTES["green"]
         )
         return f"{colour}{text}\033[0m"
-    palette = _seasonal_palette()
-    if palette is None:
+    colour = _seasonal_colour()
+    if colour is None:
         return text
-    colour = palette[pr_number % 4]
     return f"{colour}{text}\033[0m"
 
 
@@ -260,14 +259,27 @@ def render_colour_diagnostics() -> str:
     def _named_dim(name, text: str) -> str:
         return click.style(text, fg=name, bold=False)
 
+    def _vpad(text: str, width: int) -> str:
+        """Pad text to visual width, accounting for double-wide emoji."""
+        vlen = 0
+        for ch in text:
+            cat = unicodedata.category(ch)
+            if cat in ("Mn", "Cf"):
+                pass  # variation selectors and zero-width marks
+            elif unicodedata.east_asian_width(ch) in ("W", "F") or ord(ch) > 0x1F000:
+                vlen += 2
+            else:
+                vlen += 1
+        return text + " " * max(0, width - vlen)
+
     BLOCK = "████"
 
     lines = [click.style("🎨 breakfast colour diagnostics", fg="cyan", bold=True), ""]
 
     # ------------------------------------------------------------------
-    # Seasonal palettes (author / PR title gradient)
+    # Seasonal colours (author / PR title)
     # ------------------------------------------------------------------
-    lines.append(click.style("Seasonal palettes  (author & PR title)", bold=True))
+    lines.append(click.style("Seasonal colours  (author & PR title)", bold=True))
     palette_rows = [
         ("January 🗓️", "purple"),
         ("Easter 🐣", "yellow"),
@@ -275,14 +287,18 @@ def render_colour_diagnostics() -> str:
         ("December 🎄 (red)", "red"),
         ("December 🎄 (green)", "green"),
     ]
-    for label, key in palette_rows:
 
-        def _swatch(code: str) -> str:
-            n = code.split(";")[2].rstrip("m")
+    def _seasonal_swatch(code: str) -> str:
+        parts = code.split(";")
+        if len(parts) >= 3:
+            n = parts[2].rstrip("m")
             return f"{_ansi256(int(n), BLOCK)} {n}"
+        n = code[2:-1]
+        return f"{code}{BLOCK}\033[0m {n}"
 
-        swatches = "  ".join(_swatch(c) for c in SEASONAL_PALETTES[key])
-        lines.append(f"  {label:<22}  {swatches}")
+    for label, key in palette_rows:
+        swatch = _seasonal_swatch(SEASONAL_PALETTES[key])
+        lines.append(f"  {_vpad(label, 22)}  {swatch}")
     lines.append("")
 
     # ------------------------------------------------------------------
@@ -372,6 +388,26 @@ def render_colour_diagnostics() -> str:
     lines.append(
         f"  {_named('green', BLOCK)} additions  " f"  {_named('red', BLOCK)} deletions"
     )
+    lines.append("")
+
+    # ------------------------------------------------------------------
+    # 256-colour reference — all hues, full shade range
+    # ------------------------------------------------------------------
+    lines.append(click.style("256-colour reference  (all hues, dark → bright)", bold=True))
+    hue_rows = [
+        ("Greens",   [22, 28, 34, 40, 46, 82, 118, 154, 190]),
+        ("Yellows",  [100, 106, 136, 142, 178, 184, 190, 220, 226]),
+        ("Oranges",  [94, 130, 136, 166, 172, 202, 208, 214]),
+        ("Reds",     [52, 88, 124, 160, 196, 197, 203, 210]),
+        ("Purples",  [54, 55, 56, 90, 91, 92, 93, 129, 135, 141, 147]),
+        ("Blues",    [17, 18, 19, 20, 21, 57, 63, 69, 75, 81]),
+        ("Cyans",    [23, 30, 37, 44, 51, 86, 87, 122, 123]),
+        ("Magentas", [53, 89, 125, 126, 161, 162, 197, 198, 199, 207]),
+        ("Greys",    [232, 235, 238, 240, 242, 244, 246, 248, 250, 252, 254]),
+    ]
+    for label, codes in hue_rows:
+        swatches = "  ".join(f"{_ansi256(n, BLOCK)} {n:<3}" for n in codes)
+        lines.append(f"  {label:<10}  {swatches}")
 
     return "\n".join(lines)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2378,7 +2378,7 @@ def test_colour_diagnostics_flag_exits_zero_and_outputs_swatches():
     runner = CliRunner()
     result = runner.invoke(cli.breakfast, ["--colour-diagnostics"])
     assert result.exit_code == 0
-    assert "Seasonal palettes" in result.output
+    assert "Seasonal colours" in result.output
     assert "Check status" in result.output
     assert "Number gradient" in result.output
 
@@ -2388,7 +2388,7 @@ def test_color_diagnostics_alias_works():
     runner = CliRunner()
     result = runner.invoke(cli.breakfast, ["--color-diagnostics"])
     assert result.exit_code == 0
-    assert "Seasonal palettes" in result.output
+    assert "Seasonal colours" in result.output
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -113,28 +113,27 @@ def test_easter_month_known_years():
         (12, "red"),
     ],
 )
-def test_seasonal_palette_by_special_month(month, expected_key):
+def test_seasonal_colour_by_special_month(month, expected_key):
     with patch("breakfast.ui.datetime") as mock_dt:
         mock_dt.date.today.return_value = _today(month)
-        palette = ui._seasonal_palette()
-    assert palette == ui.SEASONAL_PALETTES[expected_key]
+        colour = ui._seasonal_colour()
+    assert colour == ui.SEASONAL_PALETTES[expected_key]
 
 
 @pytest.mark.parametrize("month", [2, 3, 5, 6, 7, 8, 9, 11])
-def test_seasonal_palette_non_special_months_return_none(month):
+def test_seasonal_colour_non_special_months_return_none(month):
     with patch("breakfast.ui.datetime") as mock_dt:
         mock_dt.date.today.return_value = _today(month)
-        palette = ui._seasonal_palette()
-    assert palette is None
+        colour = ui._seasonal_colour()
+    assert colour is None
 
 
-def test_apply_seasonal_colour_shade_from_pr_number():
+def test_apply_seasonal_colour_uses_single_colour():
     with patch("breakfast.ui.datetime") as mock_dt:
         mock_dt.date.today.return_value = _today(1)  # January → purple
         for pr_num in range(8):
             result = ui.apply_seasonal_colour("alice", pr_num)
-            expected_colour = ui.SEASONAL_PALETTES["purple"][pr_num % 4]
-            assert result.startswith(expected_colour)
+            assert result.startswith(ui.SEASONAL_PALETTES["purple"])
             assert result.endswith("\033[0m")
             assert "alice" in result
 
@@ -153,8 +152,8 @@ def test_apply_seasonal_colour_christmas_alternates():
         even_result = ui.apply_seasonal_colour("Test PR", 2)
         odd_result = ui.apply_seasonal_colour("Test PR", 3)
     # Even PR numbers → red, odd → green
-    assert even_result.startswith(ui.SEASONAL_PALETTES["red"][2])
-    assert odd_result.startswith(ui.SEASONAL_PALETTES["green"][2])
+    assert even_result.startswith(ui.SEASONAL_PALETTES["red"])
+    assert odd_result.startswith(ui.SEASONAL_PALETTES["green"])
 
 
 def test_apply_seasonal_colour_wraps_and_resets():
@@ -172,7 +171,7 @@ def test_apply_seasonal_colour_wraps_and_resets():
 
 def test_render_colour_diagnostics_contains_section_headings():
     result = ui.render_colour_diagnostics()
-    assert "Seasonal palettes" in result
+    assert "Seasonal colours" in result
     assert "PR state" in result
     assert "Check status" in result
     assert "Approval status" in result

--- a/uv.lock
+++ b/uv.lock
@@ -41,7 +41,7 @@ wheels = [
 
 [[package]]
 name = "breakfast"
-version = "0.49.0"
+version = "0.52.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

- **Single colour per season** — replaces 4-shade gradients with one consistent hue: January=orchid (141), Easter=yellow (226), October=orange (208, same as the number gradient), December=named red/green (same as fail/pass)
- **All plain columns coloured** — extends seasonal colour to `Repo`, `+/-`, `Link`, `Head Branch`, and `Base Branch` in addition to the existing `PR Title` and `Author`
- **256-colour reference section** in `--colour-diagnostics` — new section at the bottom shows full shade ranges for greens, yellows, oranges, reds, purples, blues, cyans, magentas, and greys with their codes
- **Alignment fix** — diagnostics label column now uses visual-width padding that correctly handles double-wide emoji (Python's `unicodedata` misclassifies some emoji like 🗓️ as neutral-width); swatch numbers padded to 3 chars for consistent column spacing

## Test plan

- [ ] `uv run breakfast --colour-diagnostics` — verify seasonal colours section shows single swatches, all aligned; verify 256-colour reference at bottom is aligned
- [ ] Run in a special month (or mock the date) to confirm all plain columns pick up seasonal colour
- [ ] `make test` passes

Closes #193

🤖 Generated with [Claude Code](https://claude.com/claude-code)