### PR TITLE
#182: Add --format csv output

### DIFF
--- a/docs/manual/options.md
+++ b/docs/manual/options.md
@@ -176,18 +176,21 @@ Processing platform PRs...🍩🧇...Done
 
 ### `--format`
 
-Choose the output format. Accepted values: `table` (default), `json`, `markdown`.
+Choose the output format. Accepted values: `table` (default), `json`, `markdown`, `csv`.
 
 ```text
 breakfast -o my-org -r platform --format markdown
 breakfast -o my-org -r platform --format json
+breakfast -o my-org -r platform --format csv
 ```
 
 You can also set a persistent default in your config file:
 
 ```toml
-format = "markdown"
+format = "csv"
 ```
+
+See [Output Formats](output-formats.md) for full details on each format.
 
 ### `--markdown`
 

--- a/docs/manual/output-formats.md
+++ b/docs/manual/output-formats.md
@@ -2,7 +2,7 @@
 
 ## stdout and stderr
 
-All data output — tables, JSON, Markdown, and summary views — goes to **stdout**.
+All data output — tables, JSON, Markdown, CSV, and summary views — goes to **stdout**.
 All progress messages, spinner emoji, warnings, and errors go to **stderr**.
 
 This means every output format is safe to pipe or redirect independently:
@@ -11,9 +11,10 @@ This means every output format is safe to pipe or redirect independently:
 breakfast -o my-org -r platform > prs.txt                    # capture table only
 breakfast -o my-org -r platform --json | jq '...'            # pipe JSON cleanly
 breakfast -o my-org -r platform --format markdown > prs.md   # capture Markdown
+breakfast -o my-org -r platform --format csv > prs.csv       # capture CSV
 ```
 
-The `format` config key accepts `"table"` (default), `"json"`, or `"markdown"`.
+The `format` config key accepts `"table"` (default), `"json"`, `"markdown"`, or `"csv"`.
 Any other value triggers a warning on stderr and falls back to `"table"`.
 
 ## Table output (default)
@@ -81,6 +82,45 @@ $ breakfast -o my-org -r platform --format markdown 2>/dev/null
 - OSC 8 terminal hyperlinks are converted to `[text](url)` Markdown links.
 - Optional columns (`--age`, `--checks`, `--approvals`, `--head-branch`, `--base-branch`) are included when their flags are set.
 - Progress messages still go to stderr, so the output can be redirected cleanly.
+
+## CSV output (`--format csv`)
+
+With `--format csv`, output is RFC 4180-compliant CSV — ready to import into Excel, Google Sheets, or any tool that accepts CSV.
+
+```text
+$ breakfast -o my-org -r platform --format csv 2>/dev/null
+repo,pr_number,title,author,url,state,draft,created_at,updated_at,additions,deletions,changed_files,commits,review_comments,labels,requested_reviewers
+platform-api,142,Add user search,alice,https://github.com/my-org/platform-api/pull/142,open,False,2026-03-05T10:30:00Z,2026-03-06T14:00:00Z,42,10,3,1,0,,bob
+platform-api,138,Fix login bug,bob,https://github.com/my-org/platform-api/pull/138,open,False,2026-02-21T09:15:00Z,2026-03-04T16:30:00Z,5,2,1,1,3,bug,
+```
+
+- Header row is always present.
+- ANSI colour codes are stripped — all values are plain text.
+- Multi-value fields (`labels`, `requested_reviewers`) are joined with `|` within the cell.
+- Optional columns (`--age`, `--checks`, `--approvals`) are appended when their flags are set.
+- Progress messages still go to stderr, so the output can be redirected cleanly.
+- `format = "csv"` in `config.toml` sets CSV as the persistent default.
+
+### Optional columns in CSV
+
+| Flag | Added column(s) |
+| --- | --- |
+| `--age` | `age_days` |
+| `--checks` | `checks` |
+| `--approvals` | `approval`, `approval_current`, `approval_required` |
+
+### Shell examples
+
+```bash
+# Import to Google Sheets or Excel
+breakfast -o my-org -r platform --format csv 2>/dev/null > prs.csv
+
+# Count PRs per author with awk
+breakfast -o my-org -r platform --format csv 2>/dev/null | awk -F, 'NR>1 {print $4}' | sort | uniq -c
+
+# Filter with csvkit
+breakfast -o my-org -r platform --format csv 2>/dev/null | csvgrep -c author -m alice
+```
 
 ## JSON output (`--json` / `--format json`)
 

--- a/src/breakfast/cli.py
+++ b/src/breakfast/cli.py
@@ -1,3 +1,5 @@
+import csv
+import io
 import json
 import random
 import re
@@ -556,7 +558,7 @@ def _fetch_pr_bundle(url, fetch_checks, fetch_approvals):
     "--format",
     "output_format",
     default=None,
-    type=click.Choice(["table", "json", "markdown"], case_sensitive=False),
+    type=click.Choice(["table", "json", "markdown", "csv"], case_sensitive=False),
     help=(
         "Output format: table (default), json, or markdown. "
         "Overrides --json/--no-json/--markdown when both are given."
@@ -846,11 +848,16 @@ def breakfast(
         fmt = "markdown" if markdown_flag else "table"
     else:
         cfg_format = cfg.get("format")
-        if cfg_format is not None and cfg_format not in {"table", "json", "markdown"}:
+        if cfg_format is not None and cfg_format not in {
+            "table",
+            "json",
+            "markdown",
+            "csv",
+        }:
             click.echo(
                 click.style(
                     f"Warning: unrecognised format '{cfg_format}' in config"
-                    " — expected 'table', 'json', or 'markdown'."
+                    " — expected 'table', 'json', 'markdown', or 'csv'."
                     " Falling back to 'table'.",
                     fg="yellow",
                 ),
@@ -1439,6 +1446,86 @@ def breakfast(
         if api_stats:
             _print_debug_summary(
                 t0_total, len(md_data), get_api_stats(), get_graphql_rate_limit()
+            )
+        return
+
+    if fmt == "csv":
+        buf = io.StringIO()
+        fieldnames = [
+            "repo",
+            "pr_number",
+            "title",
+            "author",
+            "url",
+            "state",
+            "draft",
+            "created_at",
+            "updated_at",
+            "additions",
+            "deletions",
+            "changed_files",
+            "commits",
+            "review_comments",
+            "labels",
+            "requested_reviewers",
+        ]
+        if age:
+            fieldnames.append("age_days")
+        if checks:
+            fieldnames.append("checks")
+        if approvals:
+            fieldnames.append("approval")
+            fieldnames.append("approval_current")
+            fieldnames.append("approval_required")
+        writer = csv.DictWriter(buf, fieldnames=fieldnames, extrasaction="ignore")
+        writer.writeheader()
+        for pr_detail in pr_details:
+            row = {
+                "repo": pr_detail["base"]["repo"]["name"],
+                "pr_number": pr_detail["number"],
+                "title": pr_detail["title"],
+                "author": pr_detail["user"]["login"],
+                "url": pr_detail["html_url"],
+                "state": pr_detail["state"],
+                "draft": pr_detail.get("draft", False),
+                "created_at": pr_detail.get("created_at", ""),
+                "updated_at": pr_detail.get("updated_at", ""),
+                "additions": pr_detail.get("additions", ""),
+                "deletions": pr_detail.get("deletions", ""),
+                "changed_files": pr_detail.get("changed_files", ""),
+                "commits": pr_detail.get("commits", ""),
+                "review_comments": pr_detail.get("review_comments", ""),
+                "labels": "|".join(lb["name"] for lb in pr_detail.get("labels", [])),
+                "requested_reviewers": "|".join(
+                    r["login"] for r in pr_detail.get("requested_reviewers", [])
+                ),
+            }
+            if age:
+                row["age_days"] = get_pr_age_days(pr_detail)
+            if checks:
+                row["checks"] = check_statuses.get(pr_detail["id"], "none")
+            if approvals:
+                approval_detail = approval_details.get(pr_detail["id"], {})
+                row["approval"] = approval_statuses.get(pr_detail["id"], "pending")
+                row["approval_current"] = approval_detail.get("current", "")
+                row["approval_required"] = approval_detail.get("required", "")
+            writer.writerow(row)
+        click.echo(buf.getvalue(), nl=False)
+        logger.info(
+            "render_complete elapsed_ms=%d", int((time.monotonic() - t_render) * 1000)
+        )
+        if not no_update_check:
+            update_msg = check_for_update()
+            if update_msg:
+                logger.info("update_available msg=%r", update_msg)
+                click.echo(
+                    click.style(update_msg, fg="cyan", bold=True),
+                    err=True,
+                    color=colour,
+                )
+        if api_stats:
+            _print_debug_summary(
+                t0_total, len(pr_details), get_api_stats(), get_graphql_rate_limit()
             )
         return
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,3 +1,5 @@
+import csv
+import io
 import json
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timezone
@@ -2754,7 +2756,7 @@ def test_config_format_table_produces_table_output(monkeypatch, tmp_path):
 
 def test_config_format_invalid_warns_and_falls_back_to_table(monkeypatch, tmp_path):
     cfg_file = tmp_path / "config.toml"
-    cfg_file.write_text('format = "csv"\norganization = "org"\n')
+    cfg_file.write_text('format = "tofu"\norganization = "org"\n')
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
     monkeypatch.setattr(cli, "check_for_update", lambda: None)
@@ -2766,8 +2768,8 @@ def test_config_format_invalid_warns_and_falls_back_to_table(monkeypatch, tmp_pa
     result = CliRunner().invoke(cli.breakfast, ["--config", str(cfg_file)])
 
     assert result.exit_code == 0
-    assert "csv" in result.stderr
-    assert "table" in result.stderr.lower() or "Falling back" in result.stderr
+    assert "tofu" in result.stderr
+    assert "Falling back" in result.stderr
     assert "PR-1" in result.stdout
 
 
@@ -2915,3 +2917,136 @@ def test_format_flag_overrides_json_flag(monkeypatch):
     assert "| Repo" in result.stdout
     with pytest.raises(json.JSONDecodeError):
         json.loads(result.stdout)
+
+
+# ---------------------------------------------------------------------------
+# CSV format (#182)
+# ---------------------------------------------------------------------------
+
+
+def test_format_csv_produces_header_row(monkeypatch):
+    monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
+    monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
+    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(
+        cli, "get_github_prs", lambda *_: ["https://github.com/org/repo/pull/1"]
+    )
+    monkeypatch.setattr(api, "make_github_api_request", _fake_pr_detail)
+
+    result = CliRunner().invoke(
+        cli.breakfast, ["-o", "org", "-r", "repo", "--format", "csv"]
+    )
+
+    assert result.exit_code == 0
+    lines = result.stdout.splitlines()
+    assert lines[0].startswith("repo,pr_number,title,author,url")
+
+
+def test_format_csv_contains_pr_data(monkeypatch):
+    monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
+    monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
+    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(
+        cli, "get_github_prs", lambda *_: ["https://github.com/org/repo/pull/1"]
+    )
+    monkeypatch.setattr(api, "make_github_api_request", _fake_pr_detail)
+
+    result = CliRunner().invoke(
+        cli.breakfast, ["-o", "org", "-r", "repo", "--format", "csv"]
+    )
+
+    assert result.exit_code == 0
+    assert "repo" in result.stdout
+    assert "https://github.com/org/repo/pull/1" in result.stdout
+
+
+def test_format_csv_strips_ansi_codes(monkeypatch):
+    monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
+    monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
+    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(
+        cli, "get_github_prs", lambda *_: ["https://github.com/org/repo/pull/1"]
+    )
+    monkeypatch.setattr(api, "make_github_api_request", _fake_pr_detail)
+
+    result = CliRunner().invoke(
+        cli.breakfast, ["-o", "org", "-r", "repo", "--format", "csv"]
+    )
+
+    assert result.exit_code == 0
+    assert "\x1b[" not in result.stdout
+    assert "\x1b]8;;" not in result.stdout
+
+
+def test_format_csv_output_goes_to_stdout(monkeypatch):
+    monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
+    monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
+    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(
+        cli, "get_github_prs", lambda *_: ["https://github.com/org/repo/pull/1"]
+    )
+    monkeypatch.setattr(api, "make_github_api_request", _fake_pr_detail)
+
+    result = CliRunner().invoke(
+        cli.breakfast, ["-o", "org", "-r", "repo", "--format", "csv"]
+    )
+
+    assert result.exit_code == 0
+    assert "Processing" in result.stderr
+    assert "Processing" not in result.stdout
+    assert "repo,pr_number" in result.stdout
+
+
+def test_format_csv_is_valid_csv(monkeypatch):
+    monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
+    monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
+    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(
+        cli, "get_github_prs", lambda *_: ["https://github.com/org/repo/pull/1"]
+    )
+    monkeypatch.setattr(api, "make_github_api_request", _fake_pr_detail)
+
+    result = CliRunner().invoke(
+        cli.breakfast, ["-o", "org", "-r", "repo", "--format", "csv"]
+    )
+
+    assert result.exit_code == 0
+    rows = list(csv.DictReader(io.StringIO(result.stdout)))
+    assert len(rows) == 1
+    assert rows[0]["repo"] == "repo"
+    assert rows[0]["pr_number"] == "1"
+
+
+def test_format_csv_includes_optional_age_column(monkeypatch):
+    monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
+    monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
+    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(
+        cli, "get_github_prs", lambda *_: ["https://github.com/org/repo/pull/1"]
+    )
+    monkeypatch.setattr(api, "make_github_api_request", _fake_pr_detail)
+
+    result = CliRunner().invoke(
+        cli.breakfast, ["-o", "org", "-r", "repo", "--format", "csv", "--age"]
+    )
+
+    assert result.exit_code == 0
+    rows = list(csv.DictReader(io.StringIO(result.stdout)))
+    assert "age_days" in rows[0]
+
+
+def test_config_format_csv_produces_csv_output(monkeypatch, tmp_path):
+    cfg_file = tmp_path / "config.toml"
+    cfg_file.write_text('format = "csv"\norganization = "org"\n')
+    monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
+    monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
+    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(
+        cli, "get_github_prs", lambda *_: ["https://github.com/org/repo/pull/1"]
+    )
+    monkeypatch.setattr(api, "make_github_api_request", _fake_pr_detail)
+
+    result = CliRunner().invoke(cli.breakfast, ["--config", str(cfg_file)])
+
+    assert result.exit_code == 0
+    assert result.stdout.startswith("repo,pr_number")


### PR DESCRIPTION
## Summary

- Adds `--format csv` (RFC 4180-compliant) via Python's built-in `csv` module — no new dependencies
- Header row always present; all values are plain text (no ANSI codes)
- Multi-value fields (`labels`, `requested_reviewers`) joined with `|` within the cell
- Optional columns appended when their flags are active: `--age` → `age_days`, `--checks` → `checks`, `--approvals` → `approval`, `approval_current`, `approval_required`
- `format = "csv"` in `config.toml` sets a persistent default
- Fixed the existing `test_config_format_invalid_warns_and_falls_back_to_table` test, which was using `"csv"` as the invalid format value — now uses `"tofu"`

## Docs updated

- `docs/manual/output-formats.md` — new CSV section with schema, example output, optional columns table, and shell examples
- `docs/manual/options.md` — updated `--format` entry to include `csv`

## Test plan

- [ ] `make test` passes (300 tests)
- [ ] `make lint` passes
- [ ] `breakfast -o <org> -r <repo> --format csv 2>/dev/null` produces valid CSV
- [ ] `breakfast -o <org> -r <repo> --format csv --age --checks 2>/dev/null` includes `age_days` and `checks` columns
- [ ] `format = "csv"` in config produces CSV output without `--format` flag

Closes #182

🤖 Generated with [Claude Code](https://claude.com/claude-code)