### PR TITLE
#204: Guard against non-dict API responses and broaden check-status exception handling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,5 +55,8 @@ completions: .venv
 	uv sync
 	mkdir -p completions
 	_BREAKFAST_COMPLETE=bash_source uv run breakfast > completions/breakfast.bash
+	sed -i.bak 's/_BREAKFAST_COMPLETE=bash_complete $$1)/_BREAKFAST_COMPLETE=bash_complete "$$1")/' completions/breakfast.bash
+	sed -i.bak 's/COMPREPLY+=($$value)/COMPREPLY+=("$$value")/' completions/breakfast.bash
+	rm -f completions/breakfast.bash.bak
 	_BREAKFAST_COMPLETE=zsh_source uv run breakfast > completions/_breakfast
 	_BREAKFAST_COMPLETE=fish_source uv run breakfast > completions/breakfast.fish

--- a/install.sh
+++ b/install.sh
@@ -22,10 +22,21 @@ echo -e "${BOLD}${BLUE}🍳 Serving up breakfast...${RESET}"
 
 # Find the latest release
 echo -e "${YELLOW}Finding the latest version...${RESET}"
-LATEST_RELEASE_JSON=$(curl -s "https://api.github.com/repos/${REPO}/releases/latest")
-LATEST_RELEASE_URL=$(echo "${LATEST_RELEASE_JSON}" | grep -o "https://github.com/${REPO}/releases/download/[^/ ]*/${BINARY_NAME}" | head -n 1)
-LATEST_TAG=$(echo "${LATEST_RELEASE_JSON}" | grep -o '"tag_name": *"[^"]*"' | grep -o '"[^"]*"$' | tr -d '"')
+LATEST_RELEASE_JSON=$(curl -sf "https://api.github.com/repos/${REPO}/releases/latest") || {
+    echo -e "${BOLD}\033[31m❌ Failed to fetch release info for ${REPO}.${RESET}"
+    exit 1
+}
+LATEST_TAG=$(printf '%s' "${LATEST_RELEASE_JSON}" | python3 -c "import sys,json; print(json.load(sys.stdin)['tag_name'])") || {
+    echo -e "${BOLD}\033[31m❌ Failed to parse release tag for ${REPO}.${RESET}"
+    exit 1
+}
 RELEASE_BASE_URL="https://github.com/${REPO}/releases/download/${LATEST_TAG}"
+LATEST_RELEASE_URL=$(printf '%s' "${LATEST_RELEASE_JSON}" | python3 -c "
+import sys, json
+data = json.load(sys.stdin)
+urls = [a['browser_download_url'] for a in data.get('assets', []) if a['name'] == '${BINARY_NAME}']
+print(urls[0] if urls else '')
+")
 
 if [ -z "${LATEST_RELEASE_URL}" ]; then
     echo -e "${BOLD}\033[31m❌ Failed to find the latest release for ${REPO}.${RESET}"
@@ -38,7 +49,10 @@ echo -e "${GREEN}Found latest release! Downloading...${RESET}"
 mkdir -p "${INSTALL_DIR}"
 
 # Download the binary
-curl -sL "${LATEST_RELEASE_URL}" -o "${EXECUTABLE_PATH}"
+if ! curl -sfL "${LATEST_RELEASE_URL}" -o "${EXECUTABLE_PATH}"; then
+    echo -e "${BOLD}\033[31m❌ Failed to download binary from ${LATEST_RELEASE_URL}.${RESET}"
+    exit 1
+fi
 chmod +x "${EXECUTABLE_PATH}"
 
 echo -e "${BOLD}${GREEN}✅ Successfully installed ${BINARY_NAME} to ${EXECUTABLE_PATH}!${RESET}"

--- a/src/breakfast/api.py
+++ b/src/breakfast/api.py
@@ -491,10 +491,14 @@ def get_approval_status(owner, repo, pr_number, base_branch=None):
 def get_check_status(owner, repo, sha):
     # Check Runs API (GitHub Actions, newer CI integrations)
     cr_data = make_github_api_request(f"/repos/{owner}/{repo}/commits/{sha}/check-runs")
+    if not isinstance(cr_data, dict):
+        return "none"
     check_runs = cr_data.get("check_runs", [])
 
     # Commit Status API (Jenkins, older CI integrations)
     status_data = make_github_api_request(f"/repos/{owner}/{repo}/commits/{sha}/status")
+    if not isinstance(status_data, dict):
+        return "none"
     statuses = status_data.get("statuses", [])
 
     if not check_runs and not statuses:

--- a/src/breakfast/api.py
+++ b/src/breakfast/api.py
@@ -176,7 +176,7 @@ def make_paginated_github_api_request(query_string, rate=100):
     return all_data
 
 
-def make_github_graphql_request(query, variables={}):
+def make_github_graphql_request(query, variables=None):
     headers = {
         "Authorization": f"Bearer {SECRET_GITHUB_TOKEN}",
         "Content-Type": "application/json",

--- a/src/breakfast/cli.py
+++ b/src/breakfast/cli.py
@@ -1369,8 +1369,8 @@ def breakfast(
             state_str = pr_detail["state"]
             if pr_detail.get("draft"):
                 state_str = "draft"
-            adds = pr_detail["additions"]
-            subs = pr_detail["deletions"]
+            adds = pr_detail.get("additions", 0)
+            subs = pr_detail.get("deletions", 0)
             row = {
                 "Repo": f"[{repo['name']}]({repo_url})",
                 "PR Title": pr_detail["title"],
@@ -1448,8 +1448,12 @@ def breakfast(
         return
 
     for pr_detail in pr_details:
-        adds = click.style("+" + str(pr_detail["additions"]), fg="green", bold=True)
-        subs = click.style("-" + str(pr_detail["deletions"]), fg="red", bold=True)
+        adds = click.style(
+            "+" + str(pr_detail.get("additions", 0)), fg="green", bold=True
+        )
+        subs = click.style(
+            "-" + str(pr_detail.get("deletions", 0)), fg="red", bold=True
+        )
 
         state_label = format_pr_state(pr_detail["state"], pr_detail.get("draft", False))
         if legendary and is_legendary(pr_detail):

--- a/src/breakfast/cli.py
+++ b/src/breakfast/cli.py
@@ -1163,7 +1163,12 @@ def breakfast(
             for pr_id, future in check_futures:
                 try:
                     check_statuses[pr_id] = future.result()
-                except requests.exceptions.RequestException as exc:
+                except (
+                    KeyError,
+                    ValueError,
+                    AttributeError,
+                    requests.exceptions.RequestException,
+                ) as exc:
                     logger.warning(
                         "check_status_fetch_failed pr_id=%s error=%r",
                         pr_id,

--- a/utils/bump_version_if_tag_exists.sh
+++ b/utils/bump_version_if_tag_exists.sh
@@ -18,7 +18,10 @@ if git rev-parse -q --verify "refs/tags/v${version}" >/dev/null; then
   version=$(python utils/read_version.py)
   git add pyproject.toml
   git commit -m "chore: bump version to ${version}" >/dev/null
-  git push origin "HEAD:${branch_name}" >/dev/null
+  if ! git push origin "HEAD:${branch_name}"; then
+    echo "git push failed; version bump commit not pushed" >&2
+    exit 1
+  fi
 fi
 
 printf '%s\n' "$version"


### PR DESCRIPTION
## Summary

- `get_check_status` in `api.py` now returns `"none"` early if the API response is not a dict (guards against `AttributeError` on `.get()`)
- Broadened the `except` clause in the check-status futures loop in `cli.py` to also catch `KeyError`, `ValueError`, and `AttributeError` in addition to `requests.exceptions.RequestException`

Closes #204