### PR TITLE
#204: Remove isinstance guards from get_check_status, rely on EAFP

### DIFF
--- a/src/breakfast/api.py
+++ b/src/breakfast/api.py
@@ -491,14 +491,10 @@ def get_approval_status(owner, repo, pr_number, base_branch=None):
 def get_check_status(owner, repo, sha):
     # Check Runs API (GitHub Actions, newer CI integrations)
     cr_data = make_github_api_request(f"/repos/{owner}/{repo}/commits/{sha}/check-runs")
-    if not isinstance(cr_data, dict):
-        return "none"
     check_runs = cr_data.get("check_runs", [])
 
     # Commit Status API (Jenkins, older CI integrations)
     status_data = make_github_api_request(f"/repos/{owner}/{repo}/commits/{sha}/status")
-    if not isinstance(status_data, dict):
-        return "none"
     statuses = status_data.get("statuses", [])
 
     if not check_runs and not statuses:


### PR DESCRIPTION
## Summary

- Removes the `isinstance(cr_data, dict)` and `isinstance(status_data, dict)` guards added in #215 — the API typing can be trusted, and if it does break the `AttributeError` will surface naturally via the broadened `except` clause in the caller
- The only surviving fix from #204 is the broadened `except (KeyError, ValueError, AttributeError, RequestException)` in `cli.py`

Closes #204