### PR TITLE
#225: Show ⚠️ amber for behind/unstable/blocked PRs instead of misleading ✅

### DIFF
--- a/docs/manual/output-formats.md
+++ b/docs/manual/output-formats.md
@@ -47,7 +47,7 @@ The default output is a colour-coded terminal table with the following columns:
 | Checks | CI/check run status: pass, fail, pending, none (only with `--checks`) — clickable link to the PR's checks tab |
 | Head Branch | Source branch the PR was raised from (only with `--head-branch`) — clickable link to the branch on GitHub |
 | Base Branch | Target branch the PR merges into (only with `--base-branch`) — clickable link to the branch on GitHub |
-| Mergeable? | Whether the PR can be merged cleanly. Shows `🏁 merged` for merged PRs, `🚫 closed` for closed-but-not-merged PRs, `⏳ computing` while GitHub calculates mergeability |
+| Mergeable? | Whether the PR can be merged cleanly. `✅` means truly ready (`clean`); `⚠️` means no conflicts but not ready (`behind`, `unstable`, or `blocked`); `❌` means conflicts exist. Also shows `🏁 merged`, `🚫 closed`, or `⏳ computing` as appropriate |
 | Link | Clickable link to the PR |
 
 Use `--status-style ascii` if your terminal font renders the status emoji with uneven column widths.

--- a/src/breakfast/ui.py
+++ b/src/breakfast/ui.py
@@ -345,16 +345,20 @@ def format_mergeable_status(
     if is_mergeable is None:
         label = "computing" if style == "ascii" else "⏳ computing"
         return click.style(label, fg=246, bold=False)
-    colour = "green" if is_mergeable else "red"
-    if style == "ascii":
-        prefix = "yes" if is_mergeable else "no"
-    else:
-        prefix = "✅" if is_mergeable else "❌"
-    if mergeable_state:
-        text = f"{prefix} ({mergeable_state})"
-    else:
-        text = prefix
-    return click.style(text, fg=colour, bold=True)
+    if not is_mergeable:
+        prefix = "no" if style == "ascii" else "❌"
+        text = f"{prefix} ({mergeable_state})" if mergeable_state else prefix
+        return click.style(text, fg="red", bold=True)
+    # is_mergeable is True — but only "clean" means genuinely ready to merge.
+    # "behind", "unstable", "blocked" etc. are amber warnings.
+    _AMBER_STATES = {"behind", "unstable", "blocked", "unknown"}
+    if mergeable_state in _AMBER_STATES:
+        prefix = "~" if style == "ascii" else "⚠️"
+        text = f"{prefix} ({mergeable_state})" if mergeable_state else prefix
+        return click.style(text, fg="yellow", bold=True)
+    prefix = "yes" if style == "ascii" else "✅"
+    text = f"{prefix} ({mergeable_state})" if mergeable_state else prefix
+    return click.style(text, fg="green", bold=True)
 
 
 def generate_terminal_url_anchor(url, url_text="Link"):

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -46,6 +46,19 @@ def test_format_mergeable_status():
     assert "yes (clean)" in ui.format_mergeable_status(True, "clean", style="ascii")
 
 
+def test_format_mergeable_status_amber_states():
+    for state in ("behind", "unstable", "blocked"):
+        result = ui.format_mergeable_status(True, state)
+        assert "⚠️" in result, f"expected ⚠️ for state={state!r}"
+        assert state in result
+
+
+def test_format_mergeable_status_amber_ascii():
+    result = ui.format_mergeable_status(True, "behind", style="ascii")
+    assert "~" in result
+    assert "behind" in result
+
+
 def test_format_mergeable_status_merged_pr():
     result = ui.format_mergeable_status(None, None, pr_state="closed", merged=True)
     assert "🏁 merged" in result


### PR DESCRIPTION
## Summary

GitHub's `mergeable: true` only means "no merge conflicts" — not "ready to merge". The `mergeable_state` field carries the real detail. Previously all `mergeable: true` PRs showed ✅ green regardless of state.

New behaviour:

| `mergeable_state` | Display |
|---|---|
| `clean` | ✅ green — genuinely ready |
| `behind` | ⚠️ amber — branch is behind base |
| `unstable` | ⚠️ amber — checks failing/pending |
| `blocked` | ⚠️ amber — branch protection blocking |
| `dirty` | ❌ red — merge conflicts |
| `null` | ⏳ computing |

ASCII style uses `~` for amber states.

Closes #225