### PR TITLE
#229: Make `logger.configure()` idempotent

### DIFF
--- a/src/breakfast/logger.py
+++ b/src/breakfast/logger.py
@@ -19,7 +19,15 @@ def configure() -> None:
     Opens the log file in write mode so each run starts with a fresh log.
     The cache directory is created if it does not already exist.
     Silently does nothing if the log file cannot be opened.
+
+    Idempotent: any handlers already attached to the breakfast logger are
+    closed and removed before the new one is installed, so repeated calls
+    do not stack handlers or leak file descriptors.
     """
+    for existing in list(logger.handlers):
+        existing.close()
+        logger.removeHandler(existing)
+
     log_path = _get_log_path()
     try:
         log_path.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -42,12 +42,8 @@ def test_log_file_overwritten_on_second_configure(tmp_path, monkeypatch):
     for h in logger_module.logger.handlers:
         h.flush()
 
-    # Reset handlers to simulate a second invocation
-    for h in logger_module.logger.handlers[:]:
-        h.close()
-        logger_module.logger.removeHandler(h)
-
-    # Second run — should overwrite
+    # Second run — configure() now replaces handlers itself, so no manual
+    # cleanup is required between invocations.
     logger_module.configure()
     logger_module.logger.info("second run message")
     for h in logger_module.logger.handlers:
@@ -56,6 +52,20 @@ def test_log_file_overwritten_on_second_configure(tmp_path, monkeypatch):
     content = log_path.read_text()
     assert "second run message" in content
     assert "first run message" not in content
+
+
+def test_configure_replaces_existing_handlers(tmp_path, monkeypatch):
+    """Calling configure() twice should leave exactly one handler attached."""
+    log_path = tmp_path / "breakfast.log"
+    monkeypatch.setattr(logger_module, "_get_log_path", lambda: log_path)
+
+    logger_module.configure()
+    first_handler = logger_module.logger.handlers[0]
+    assert len(logger_module.logger.handlers) == 1
+
+    logger_module.configure()
+    assert len(logger_module.logger.handlers) == 1
+    assert logger_module.logger.handlers[0] is not first_handler
 
 
 def test_log_contains_startup_message(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary

- `configure()` now closes and removes any existing handlers on the breakfast logger before installing the new one, so repeated calls are safe (no stacked handlers, no leaked file descriptors).
- Updates `test_log_file_overwritten_on_second_configure` to drop the manual handler cleanup that previously masked this bug.
- Adds `test_configure_replaces_existing_handlers` asserting that two consecutive `configure()` calls leave exactly one handler attached.

## Test plan

- [x] `make format` clean
- [x] `make lint` clean
- [x] `make test` — 306 passed (was 305 + 1 new test)

Closes #229

---
_Generated by [Claude Code](https://claude.ai/code/session_01DPW2Z1xzbiM4EnhAxbiA3q)_