### PR TITLE
#232: Fix `repp(s)` typo in `--repo-filter` help

### DIFF
--- a/docs/manual/options.md
+++ b/docs/manual/options.md
@@ -733,7 +733,7 @@ Options:
   --show-config                   Print the resolved config and exit.
   --init-config                   Generate a default config file and exit.
   -o, --organization TEXT         One or multiple organizations to report on
-  -r, --repo-filter TEXT          Filter for specific repp(s)
+  -r, --repo-filter TEXT          Filter for specific repo(s)
   --ignore-author TEXT            Ignore PRs raised by one or more authors
                                   (case-insensitive). Repeat for multiple
                                   authors, e.g. --ignore-author

--- a/src/breakfast/cli.py
+++ b/src/breakfast/cli.py
@@ -506,7 +506,7 @@ def _fetch_pr_bundle(url, fetch_checks, fetch_approvals):
     ),
 )
 @click.option("--organization", "-o", help="One or multiple organizations to report on")
-@click.option("--repo-filter", "-r", help="Filter for specific repp(s)")
+@click.option("--repo-filter", "-r", help="Filter for specific repo(s)")
 @click.option(
     "--ignore-author",
     multiple=True,


### PR DESCRIPTION
## Summary

- Fixes the user-visible `repp(s)` typo in the `--repo-filter` help string in `cli.py` and the matching options dump in `docs/manual/options.md`.

## Test plan

- [x] `make format` clean
- [x] `make lint` clean
- [x] `make test` — 305 passed
- [x] `breakfast --help` shows `Filter for specific repo(s)`

Closes #232

---
_Generated by [Claude Code](https://claude.ai/code/session_01DPW2Z1xzbiM4EnhAxbiA3q)_