### PR TITLE
#242: Filter None conclusions from check_runs set in get_check_status

### DIFF
--- a/src/breakfast/api.py
+++ b/src/breakfast/api.py
@@ -505,7 +505,9 @@ def get_check_status(owner, repo, sha):
         if cr.get("status") in ("queued", "in_progress"):
             return "pending"
 
-    cr_conclusions = {cr.get("conclusion") for cr in check_runs}
+    cr_conclusions = {
+        cr["conclusion"] for cr in check_runs if cr.get("conclusion") is not None
+    }
     cr_fail_states = {"failure", "cancelled", "timed_out", "action_required"}
 
     # Commit statuses: look for pending or failures

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -918,3 +918,42 @@ def test_make_github_api_request_403_without_rate_limit_header_raises_http_error
 
     with pytest.raises(requests.exceptions.HTTPError):
         api.make_github_api_request("/user")
+
+
+def test_get_check_status_none_conclusion_not_counted_as_pass(monkeypatch):
+    """In-progress check runs have conclusion=None; they must not be included in the
+    conclusions set so that a mix of in-progress + passing runs does not falsely pass.
+    """
+
+    def fake_api(path):
+        if "check-runs" in path:
+            return {
+                "check_runs": [
+                    # completed and passing
+                    {"status": "completed", "conclusion": "success"},
+                    # queued/in-progress checks have conclusion=None
+                    {"status": "queued", "conclusion": None},
+                ]
+            }
+        return {"statuses": []}
+
+    monkeypatch.setattr(api, "make_github_api_request", fake_api)
+    assert api.get_check_status("org", "repo", "abc123") == "pending"
+
+
+def test_get_check_status_all_completed_with_none_filtered(monkeypatch):
+    """conclusion=None must be excluded from the conclusions set; only non-None values
+    should be used to determine pass/fail."""
+
+    def fake_api(path):
+        if "check-runs" in path:
+            return {
+                "check_runs": [
+                    {"status": "completed", "conclusion": "success"},
+                    {"status": "completed", "conclusion": None},
+                ]
+            }
+        return {"statuses": []}
+
+    monkeypatch.setattr(api, "make_github_api_request", fake_api)
+    assert api.get_check_status("org", "repo", "abc123") == "pass"


### PR DESCRIPTION
## Summary

- `get_check_status` built the `cr_conclusions` set using `cr.get("conclusion")`, which includes `None` for queued/in-progress check runs
- `None` in the set doesn't match any fail state, but it pollutes the set in ways that could cause subtle false-pass results for checks without a `status` early-exit guard
- Changed to a comprehension that excludes `None` entries: `{cr["conclusion"] for cr in check_runs if cr.get("conclusion") is not None}`

## Tests added

Two new tests in `tests/test_api.py`:
- `test_get_check_status_none_conclusion_not_counted_as_pass` — verifies that a queued check with `conclusion=None` alongside a passing check still returns `"pending"`
- `test_get_check_status_all_completed_with_none_filtered` — verifies that a completed check with `conclusion=None` does not prevent a `"pass"` result when all other conclusions are passing

Closes #242

---
_Generated by [Claude Code](https://claude.ai/code/session_01DPW2Z1xzbiM4EnhAxbiA3q)_