### PR TITLE
#243: Handle pre-release version strings in _parse_version_tuple

### DIFF
--- a/src/breakfast/updater.py
+++ b/src/breakfast/updater.py
@@ -1,4 +1,5 @@
 import json
+import re
 import time
 from datetime import datetime, timezone
 from importlib.metadata import PackageNotFoundError
@@ -85,7 +86,13 @@ def get_latest_version():
 
 def _parse_version_tuple(version_str):
     try:
-        return tuple(int(x) for x in version_str.split("."))
+        parts = []
+        for segment in version_str.split("."):
+            m = re.match(r"\d+", segment)
+            if not m:
+                break
+            parts.append(int(m.group()))
+        return tuple(parts)
     except (ValueError, AttributeError) as exc:
         logger.debug(
             "parse_version_failed version_str=%r error=%r", version_str, str(exc)
@@ -101,7 +108,7 @@ def check_for_update():
             return None
         if _parse_version_tuple(latest) > _parse_version_tuple(current):
             return (
-                f"🍳 A fresh breakfast is ready! "
+                f"\U0001f373 A fresh breakfast is ready! "
                 f"v{current} → v{latest} "
                 f"— update at https://github.com/{_UPDATE_CHECK_REPO}/releases/latest"
             )

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -14,6 +14,27 @@ def test_parse_version_tuple():
     assert updater._parse_version_tuple(None) == ()
 
 
+def test_parse_version_tuple_prerelease_alpha():
+    assert updater._parse_version_tuple("1.0.0a1") == (1, 0, 0)
+
+
+def test_parse_version_tuple_prerelease_dash():
+    assert updater._parse_version_tuple("1.0.0-beta") == (1, 0, 0)
+
+
+def test_parse_version_tuple_prerelease_rc():
+    assert updater._parse_version_tuple("2.1.0rc3") == (2, 1, 0)
+
+
+def test_parse_version_tuple_prerelease_compared_correctly():
+    assert updater._parse_version_tuple("1.0.0a1") < updater._parse_version_tuple(
+        "1.0.1"
+    )
+    assert updater._parse_version_tuple("2.0.0-beta") < updater._parse_version_tuple(
+        "2.0.1"
+    )
+
+
 def test_check_for_update_newer_available(monkeypatch):
     monkeypatch.setattr(updater, "pkg_version", lambda _name: "0.9.0")
     monkeypatch.setattr(updater, "get_latest_version", lambda: "0.10.0")


### PR DESCRIPTION
## Summary

- `_parse_version_tuple` used `int(x) for x in version_str.split(".")` which raises `ValueError` for pre-release segments like `"0a1"`, `"0-beta"`, or `"0rc3"`
- The `except` clause returns `()`, so a pre-release installed version would compare as `()` against any release tuple — causing a false update notification every run
- Fixed by using `re.match(r"\d+", segment)` to extract the leading numeric portion of each segment, stopping at the first non-numeric segment

## Tests added

Four new tests in `tests/test_updater.py`:
- `test_parse_version_tuple_prerelease_alpha` — `"1.0.0a1"` → `(1, 0, 0)`
- `test_parse_version_tuple_prerelease_dash` — `"1.0.0-beta"` → `(1, 0, 0)`
- `test_parse_version_tuple_prerelease_rc` — `"2.1.0rc3"` → `(2, 1, 0)`
- `test_parse_version_tuple_prerelease_compared_correctly` — pre-release tuples compare correctly against later releases

Closes #243

---
_Generated by [Claude Code](https://claude.ai/code/session_01DPW2Z1xzbiM4EnhAxbiA3q)_