### PR TITLE
#244: Normalize scalar list-type config keys to list in load_config

### DIFF
--- a/src/breakfast/config.py
+++ b/src/breakfast/config.py
@@ -238,6 +238,9 @@ def _key_present_in_file(key: str, content: str) -> bool:
     return bool(re.search(pattern, content, re.MULTILINE))
 
 
+_LIST_KEYS = {"ignore-author", "repo-filter"}
+
+
 def load_config(config_path=None):
     if config_path:
         paths = [Path(config_path).expanduser().resolve()]
@@ -255,6 +258,23 @@ def load_config(config_path=None):
                     msg = f"Warning: Failed to parse config {path}: {e}"
                     click.echo(click.style(msg, fg="yellow"), err=True)
                     continue
+            for key in _LIST_KEYS:
+                if key in data and not isinstance(data[key], list):
+                    logger.warning(
+                        "config_scalar_for_list_key path=%s key=%s value=%r",
+                        path,
+                        key,
+                        data[key],
+                    )
+                    click.echo(
+                        click.style(
+                            f"Warning: config key '{key}' should be a list "
+                            f'(e.g. ["{data[key]}"]), wrapping scalar automatically.',
+                            fg="yellow",
+                        ),
+                        err=True,
+                    )
+                    data[key] = [data[key]]
             for key, value in data.items():
                 if isinstance(value, list) and isinstance(merged.get(key), list):
                     merged[key] = value + merged[key]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -452,3 +452,55 @@ def test_load_config_continues_after_invalid_toml(tmp_path, monkeypatch):
 
     result = config.load_config()
     assert result.get("organization") == "test-org"
+
+
+def test_load_config_wraps_scalar_ignore_author_to_list(tmp_path, monkeypatch):
+    """A scalar ignore-author value is wrapped in a list with a stderr warning."""
+    cfg_file = tmp_path / ".breakfast.toml"
+    cfg_file.write_text('ignore-author = "alice"')
+    echo_calls = []
+    monkeypatch.setattr(
+        config.click, "echo", lambda msg, **kw: echo_calls.append((msg, kw))
+    )
+    monkeypatch.setattr(config.click, "style", lambda msg, **kw: msg)
+
+    result = config.load_config(str(cfg_file))
+
+    assert result["ignore-author"] == ["alice"]
+    warning_calls = [c for c in echo_calls if "ignore-author" in str(c[0])]
+    assert len(warning_calls) == 1
+    assert warning_calls[0][1].get("err") is True
+
+
+def test_load_config_wraps_scalar_repo_filter_to_list(tmp_path, monkeypatch):
+    """A scalar repo-filter value is wrapped in a list with a stderr warning."""
+    cfg_file = tmp_path / ".breakfast.toml"
+    cfg_file.write_text('repo-filter = "myapp"')
+    echo_calls = []
+    monkeypatch.setattr(
+        config.click, "echo", lambda msg, **kw: echo_calls.append((msg, kw))
+    )
+    monkeypatch.setattr(config.click, "style", lambda msg, **kw: msg)
+
+    result = config.load_config(str(cfg_file))
+
+    assert result["repo-filter"] == ["myapp"]
+    warning_calls = [c for c in echo_calls if "repo-filter" in str(c[0])]
+    assert len(warning_calls) == 1
+    assert warning_calls[0][1].get("err") is True
+
+
+def test_load_config_list_ignore_author_not_wrapped(tmp_path, monkeypatch):
+    """A list ignore-author value is loaded as-is without any warning."""
+    cfg_file = tmp_path / ".breakfast.toml"
+    cfg_file.write_text('ignore-author = ["alice", "bob"]')
+    echo_calls = []
+    monkeypatch.setattr(
+        config.click, "echo", lambda msg, **kw: echo_calls.append((msg, kw))
+    )
+
+    result = config.load_config(str(cfg_file))
+
+    assert result["ignore-author"] == ["alice", "bob"]
+    warning_calls = [c for c in echo_calls if "ignore-author" in str(c[0])]
+    assert len(warning_calls) == 0


### PR DESCRIPTION
## Summary

- `ignore-author` and `repo-filter` are list-typed config keys, but TOML allows users to accidentally write them as scalars (e.g. `ignore-author = "alice"`)
- The old code passed scalars straight through to the merge dict — callers then received a string instead of a list, causing iteration over characters rather than author names
- Added `_LIST_KEYS = {"ignore-author", "repo-filter"}` and a pre-merge normalization pass: if a value for a list key is not already a list, it is wrapped in one and a yellow warning is emitted to stderr

## Tests added

Three new tests in `tests/test_config.py`:
- `test_load_config_wraps_scalar_ignore_author_to_list` — scalar `ignore-author = "alice"` becomes `["alice"]` with a stderr warning
- `test_load_config_wraps_scalar_repo_filter_to_list` — scalar `repo-filter = "myapp"` becomes `["myapp"]` with a stderr warning
- `test_load_config_list_ignore_author_not_wrapped` — list value `["alice", "bob"]` is loaded unchanged with no warning

Closes #244

---
_Generated by [Claude Code](https://claude.ai/code/session_01DPW2Z1xzbiM4EnhAxbiA3q)_