### PR TITLE
#251: Sum both comment fields in PR summary groups

### DIFF
--- a/src/breakfast/cli.py
+++ b/src/breakfast/cli.py
@@ -411,7 +411,9 @@ def _group_prs_by(pr_details, group_by):
             groups[key]["draft_count"] += 1
         age = get_pr_age_days(pr)
         groups[key]["oldest_age"] = max(groups[key]["oldest_age"], age)
-        groups[key]["total_comments"] += pr.get("review_comments", 0)
+        groups[key]["total_comments"] += pr.get("comments", 0) + pr.get(
+            "review_comments", 0
+        )
     return sorted(
         [
             (

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3051,3 +3051,35 @@ def test_config_format_csv_produces_csv_output(monkeypatch, tmp_path):
 
     assert result.exit_code == 0
     assert result.stdout.startswith("repo,pr_number")
+
+
+def _make_summary_pr(login, repo, comments=0, review_comments=0, draft=False):
+    return {
+        "user": {"login": login, "html_url": f"https://github.com/{login}"},
+        "base": {
+            "repo": {
+                "name": repo,
+                "html_url": f"https://github.com/org/{repo}",
+            }
+        },
+        "html_url": f"https://github.com/org/{repo}/pull/1",
+        "draft": draft,
+        "comments": comments,
+        "review_comments": review_comments,
+        "created_at": "2026-05-13T00:00:00Z",
+    }
+
+
+def test_group_prs_by_sums_both_comment_fields():
+    pr_details = [
+        _make_summary_pr("alice", "api", comments=7, review_comments=3),
+        _make_summary_pr("alice", "web", comments=1, review_comments=4),
+    ]
+
+    groups = cli._group_prs_by(pr_details, "user")
+
+    assert len(groups) == 1
+    name, _url, count, _drafts, _age, total_comments = groups[0]
+    assert name == "alice"
+    assert count == 2
+    assert total_comments == 7 + 3 + 1 + 4


### PR DESCRIPTION
## Summary
- `is_legendary` counts `comments + review_comments`, but `_group_prs_by` only summed `review_comments`. Aligned the summary view with the legendary rule.
- Added a regression test in `tests/test_cli.py`.

Closes #251

## Test plan
- [x] `make format && make lint && make test` (329 tests pass)
- [ ] Manual: `breakfast --summarise-user-prs` against an org with legendary PRs and confirm totals are larger

🤖 Generated with [Claude Code](https://claude.com/claude-code)