### PR TITLE
#252: Don't hide open PRs behind a single draft block

### DIFF
--- a/src/breakfast/ui.py
+++ b/src/breakfast/ui.py
@@ -590,9 +590,14 @@ def render_pr_summary(groups, title, label_header, colour, seasonal_colours):
         filled = max(1, int(count / max_count * bar_max_width)) if max_count else 1
 
         # Split filled blocks: solid █ for open PRs, medium-shade ▒ for drafts.
+        # Always show at least one solid block when there are any non-draft PRs,
+        # otherwise small draft minorities visually hide the open PRs entirely.
         if draft_count > 0 and count > 0:
             draft_blocks = max(1, round(draft_count / count * filled))
-            draft_blocks = min(draft_blocks, filled)
+            if draft_count < count:
+                draft_blocks = min(draft_blocks, filled - 1)
+            else:
+                draft_blocks = min(draft_blocks, filled)
         else:
             draft_blocks = 0
         solid_blocks = filled - draft_blocks

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -404,3 +404,20 @@ def test_render_pr_summary_all_draft_bar_all_light():
     alice_line = next(ln for ln in result.splitlines() if "alice" in ln)
     assert "█" not in alice_line
     assert "▒" in alice_line
+
+
+def test_render_pr_summary_small_draft_minority_keeps_solid_block():
+    """A group with only one draft out of many PRs must still show open PRs.
+
+    Previously, max(1, ...) forced a draft block even when filled was 1,
+    erasing the solid blocks for small (relative) groups.
+    """
+    # bob is the largest group (filled bar). alice has 10 PRs total, only 1
+    # draft, but is small relative to bob — filled will be 1.
+    groups = [
+        ("bob", _ALICE_URL, 200, 0, 5, 0),
+        ("alice", _ALICE_URL, 10, 1, 5, 0),
+    ]
+    result = ui.render_pr_summary(groups, "Title", "Author", False, False)
+    alice_line = next(ln for ln in result.splitlines() if "alice" in ln)
+    assert "█" in alice_line


### PR DESCRIPTION
## Summary
- `render_pr_summary` was forcing a draft block even when only one block was filled, hiding the open PRs entirely.
- Cap `draft_blocks` at `filled - 1` unless the group is truly all drafts.
- Added a regression test covering the small-relative-group case.

Closes #252

## Test plan
- [x] `make format && make lint && make test` (329 tests pass)
- [ ] Manual: `breakfast --summarise-user-prs` against an org with one dominant author and several small ones with a single draft each

🤖 Generated with [Claude Code](https://claude.com/claude-code)