### PR TITLE
#254: Don't inflate current_reviews to required when approved

### DIFF
--- a/src/breakfast/api.py
+++ b/src/breakfast/api.py
@@ -429,9 +429,6 @@ def get_approval_summary(owner, repo, pr_number, base_branch=None):
     if required_reviews is not None and review_decision is None and status != "changes":
         status = "approved" if current_reviews >= required_reviews else "pending"
 
-    if required_reviews is not None and status == "approved":
-        current_reviews = max(current_reviews, required_reviews)
-
     return {
         "status": status,
         "current": current_reviews,

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -508,6 +508,9 @@ def test_get_approval_summary_includes_counts_for_multi_review_branch(monkeypatc
 def test_get_approval_summary_preserves_approved_when_github_reports_approved(
     monkeypatch,
 ):
+    """When GitHub reports APPROVED but the latest review tally is below the
+    required count, the displayed count must reflect the actual review tally,
+    not be silently inflated to required."""
     monkeypatch.setattr(
         api,
         "make_github_graphql_request",
@@ -528,7 +531,7 @@ def test_get_approval_summary_preserves_approved_when_github_reports_approved(
 
     summary = api.get_approval_summary("org", "repo", 1, base_branch="main")
 
-    assert summary == {"status": "approved", "current": 2, "required": 2}
+    assert summary == {"status": "approved", "current": 1, "required": 2}
 
 
 def test_get_check_status_mixed_sources(monkeypatch):


### PR DESCRIPTION
## Summary
- Removed the silent bump of `current_reviews` to `required_reviews` when status is approved.
- Display the true tally from the latest reviews so PRs approved against a stricter requirement (admin overrides, dismissed approvals) remain visible as such.
- Updated the existing test to assert the true count.

Closes #254

## Test plan
- [x] `make format && make lint && make test` (328 tests pass)
- [ ] Manual: `breakfast --approvals` against a PR with reviewDecision == APPROVED but fewer current reviews than required

🤖 Generated with [Claude Code](https://claude.com/claude-code)