### PR TITLE
#255: Reject bool in parse_ttl

### DIFF
--- a/src/breakfast/cache.py
+++ b/src/breakfast/cache.py
@@ -19,6 +19,8 @@ def parse_ttl(value: str | int) -> int:
     Accepts: bare int, string int (e.g. "300"), or suffixed string ("5m", "2h", "30s").
     Raises ValueError for invalid or non-positive values.
     """
+    if isinstance(value, bool):
+        raise ValueError(f"Invalid TTL: {value!r}")
     if isinstance(value, int):
         if value <= 0:
             raise ValueError(f"TTL must be positive, got {value}")

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -61,6 +61,15 @@ def test_parse_ttl_empty_string_raises():
         cache.parse_ttl("")
 
 
+def test_parse_ttl_bool_rejected():
+    """isinstance(True, int) is True; explicit reject so cache-ttl = true
+    in TOML doesn't silently become 1 second."""
+    with pytest.raises(ValueError):
+        cache.parse_ttl(True)
+    with pytest.raises(ValueError):
+        cache.parse_ttl(False)
+
+
 # ---------------------------------------------------------------------------
 # make_cache_key
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- `isinstance(True, int)` is True; `parse_ttl(True)` was silently returning 1 second.
- Reject bool explicitly with a clear error.
- Added tests for both `True` and `False`.

Closes #255

## Test plan
- [x] `make format && make lint && make test` (329 tests pass)
- [ ] Manual: write a config with `cache-ttl = true`, run breakfast, confirm a clear error

🤖 Generated with [Claude Code](https://claude.com/claude-code)