### PR TITLE
#256: Write cache files atomically

### DIFF
--- a/src/breakfast/cache.py
+++ b/src/breakfast/cache.py
@@ -1,5 +1,6 @@
 import hashlib
 import json
+import os
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -7,6 +8,17 @@ import click
 
 from .logger import logger
 from .xdg import get_cache_dir
+
+
+def _atomic_write_text(path: Path, content: str) -> None:
+    """Write *content* to *path* atomically via temp file + os.replace.
+
+    Prevents truncated cache files when the process is interrupted mid-write.
+    """
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(content)
+    os.replace(tmp, path)
+
 
 _CACHE_DIR = get_cache_dir()
 
@@ -111,7 +123,7 @@ def write_graphql_cache(org: str, repo_filter: str, urls: list) -> None:
             "url_count": len(urls),
             "urls": urls,
         }
-        path.write_text(json.dumps(payload))
+        _atomic_write_text(path, json.dumps(payload))
         logger.debug("cache_write layer=graphql path=%s url_count=%d", path, len(urls))
     except OSError as exc:
         logger.warning(
@@ -222,7 +234,7 @@ def write_pr_cache(
             payload["approval_details"] = {
                 str(k): v for k, v in approval_details.items()
             }
-        path.write_text(json.dumps(payload))
+        _atomic_write_text(path, json.dumps(payload))
         logger.debug(
             "cache_write layer=pr_detail path=%s pr_count=%d", path, len(pr_details)
         )

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -179,6 +179,24 @@ def test_write_pr_cache_creates_directory(monkeypatch, tmp_path):
     assert nested.exists()
 
 
+def test_write_pr_cache_is_atomic_no_lingering_tmp(monkeypatch, tmp_path):
+    """Atomic write: no .tmp file should remain after a successful write."""
+    monkeypatch.setattr(cache, "_CACHE_DIR", tmp_path)
+    cache.write_pr_cache("org", "filter", [{"number": 1}])
+    leftovers = list(tmp_path.glob("*.tmp"))
+    assert leftovers == []
+    # The real cache file should be present and valid JSON.
+    assert cache.cache_path("org", "filter").exists()
+
+
+def test_write_graphql_cache_is_atomic_no_lingering_tmp(monkeypatch, tmp_path):
+    monkeypatch.setattr(cache, "_CACHE_DIR", tmp_path)
+    cache.write_graphql_cache("org", "filter", ["https://example.com/pr/1"])
+    leftovers = list(tmp_path.glob("*.tmp"))
+    assert leftovers == []
+    assert cache.graphql_cache_path("org", "filter").exists()
+
+
 def test_write_pr_cache_silent_on_failure(monkeypatch, tmp_path):
     """A write failure must not raise an exception."""
     monkeypatch.setattr(cache, "_CACHE_DIR", tmp_path / "does_not_exist" / "x")


### PR DESCRIPTION
## Summary
- Added `_atomic_write_text` helper using temp file + `os.replace`.
- Routed both cache writers through it so interrupted writes don't leave truncated JSON behind.
- Regression tests assert no `.tmp` file lingers after a successful write.

Closes #256

## Test plan
- [x] `make format && make lint && make test` (330 tests pass)
- [ ] Manual: simulate interrupted write (e.g. Ctrl-C during a fetch with `--cache`), confirm next run does not warn

🤖 Generated with [Claude Code](https://claude.com/claude-code)