### PR TITLE
#227: Fix crash when GitHub API returns null repository entry

### DIFF
--- a/src/breakfast/api.py
+++ b/src/breakfast/api.py
@@ -288,6 +288,8 @@ def get_github_prs(organization, repo_filter):
     prs = []
     for response in gql_responses:
         for repo in response["data"]["organization"]["repositories"]["nodes"]:
+            if repo is None:
+                continue
             if _match_repo_filter(repo["name"], repo_filter):
                 for pr in repo["pullRequests"]["nodes"]:
                     prs.append(pr["url"])

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -198,6 +198,33 @@ def test_get_github_prs_filters_and_paginates(monkeypatch):
     ]
 
 
+def test_get_github_prs_skips_null_repo_nodes(monkeypatch):
+    response = {
+        "data": {
+            "organization": {
+                "repositories": {
+                    "nodes": [
+                        None,
+                        {
+                            "name": "valid-repo",
+                            "pullRequests": {
+                                "nodes": [{"url": "https://example.com/valid-repo/1"}]
+                            },
+                        },
+                    ],
+                    "pageInfo": {"endCursor": None, "hasNextPage": False},
+                }
+            }
+        }
+    }
+    monkeypatch.setattr(api, "make_github_graphql_request", lambda _q, _v: response)
+    monkeypatch.setattr(api, "BREAKFAST_ITEMS", ["*"])
+
+    prs = api.get_github_prs("org", None)
+
+    assert prs == ["https://example.com/valid-repo/1"]
+
+
 def test_get_authenticated_user_login(monkeypatch):
     monkeypatch.setattr(
         api,


### PR DESCRIPTION
## Summary
- Added `repo is None` guard in `get_github_prs()` before accessing `repo["name"]`
- GitHub GraphQL can return `null` nodes in the repositories list for deleted or inaccessible repos
- Regression test asserts null nodes are silently skipped without crashing

Closes #227

## Test plan
- [x] `make format && make lint && make test` (329 tests pass)
- [x] New test: `test_get_github_prs_skips_null_repo_nodes`

🤖 Generated with [Claude Code](https://claude.com/claude-code)