### PR TITLE
#37: Add --label and --exclude-label filters

### DIFF
--- a/docs/manual/options.md
+++ b/docs/manual/options.md
@@ -94,6 +94,24 @@ breakfast -o my-org -r my-app --filter-approval pending --filter-approval change
 
 > **Note:** Review and check statuses are cached alongside PR details, so repeated runs with these flags skip redundant API calls.
 
+### `--label`
+
+Only show PRs that have a specific label. Matching is **case-insensitive**. Repeat the flag to require any of the given labels (OR logic).
+
+```bash
+breakfast -o my-org --label bug                          # only PRs labelled "bug"
+breakfast -o my-org --label bug --label enhancement      # PRs with "bug" OR "enhancement"
+```
+
+### `--exclude-label`
+
+Exclude PRs that have a specific label. Matching is **case-insensitive**. Repeat to exclude any of the given labels.
+
+```bash
+breakfast -o my-org --exclude-label wip                  # hide WIP PRs
+breakfast -o my-org --exclude-label wip --exclude-label blocked
+```
+
 ### `--search`, `-s`
 
 Filter PRs by title. Accepts a plain string or a regular expression pattern; matching is always **case-insensitive**.

--- a/src/breakfast/cli.py
+++ b/src/breakfast/cli.py
@@ -673,6 +673,23 @@ def _fetch_pr_bundle(url, fetch_checks, fetch_approvals):
     help="Only show PRs with this review approval status. Repeat for multiple values.",
 )
 @click.option(
+    "--label",
+    "filter_label",
+    multiple=True,
+    help=(
+        "Only show PRs that have this label (repeatable, case-insensitive)."
+        " e.g. --label bug --label enhancement"
+    ),
+)
+@click.option(
+    "--exclude-label",
+    multiple=True,
+    help=(
+        "Exclude PRs that have this label (repeatable, case-insensitive)."
+        " e.g. --exclude-label wip"
+    ),
+)
+@click.option(
     "--legendary/--no-legendary",
     default=None,
     help=(
@@ -786,6 +803,8 @@ def breakfast(
     filter_state,
     filter_check,
     filter_approval,
+    filter_label,
+    exclude_label,
     legendary,
     legendary_only,
     search,
@@ -1254,6 +1273,8 @@ def breakfast(
         check_statuses=check_statuses,
         approval_statuses=approval_statuses,
         search_title=search,
+        filter_label=filter_label,
+        exclude_label=exclude_label,
     )
     logger.info(
         "filter_result before=%d after=%d",

--- a/src/breakfast/config.py
+++ b/src/breakfast/config.py
@@ -393,6 +393,8 @@ def filter_pr_details(
     check_statuses=None,
     approval_statuses=None,
     search_title=None,
+    filter_label=None,
+    exclude_label=None,
 ):
     ignore_set = normalize_ignore_authors(ignore_authors)
     current_user_login_normalized = (
@@ -438,6 +440,14 @@ def filter_pr_details(
         if search_title is not None:
             title = pr_detail.get("title", "")
             if not re.search(search_title, title, re.IGNORECASE):
+                continue
+        if filter_label:
+            pr_labels = {lb["name"].lower() for lb in pr_detail.get("labels", [])}
+            if not any(lbl.lower() in pr_labels for lbl in filter_label):
+                continue
+        if exclude_label:
+            pr_labels = {lb["name"].lower() for lb in pr_detail.get("labels", [])}
+            if any(lbl.lower() in pr_labels for lbl in exclude_label):
                 continue
 
         filtered.append(pr_detail)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -196,6 +196,71 @@ def test_filter_pr_details_combined_filters():
     assert {r["id"] for r in result} == {1, 2}
 
 
+def test_filter_pr_details_filter_label_single():
+    pr_details = [
+        {**_make_pr(pr_id=1), "labels": [{"name": "bug"}, {"name": "urgent"}]},
+        {**_make_pr(pr_id=2), "labels": [{"name": "enhancement"}]},
+        {**_make_pr(pr_id=3), "labels": []},
+    ]
+
+    result = config.filter_pr_details(pr_details, [], filter_label=("bug",))
+    assert [r["id"] for r in result] == [1]
+
+
+def test_filter_pr_details_filter_label_multiple_or():
+    pr_details = [
+        {**_make_pr(pr_id=1), "labels": [{"name": "bug"}]},
+        {**_make_pr(pr_id=2), "labels": [{"name": "enhancement"}]},
+        {**_make_pr(pr_id=3), "labels": [{"name": "docs"}]},
+    ]
+
+    result = config.filter_pr_details(
+        pr_details, [], filter_label=("bug", "enhancement")
+    )
+    assert {r["id"] for r in result} == {1, 2}
+
+
+def test_filter_pr_details_filter_label_case_insensitive():
+    pr_details = [
+        {**_make_pr(pr_id=1), "labels": [{"name": "Bug"}]},
+        {**_make_pr(pr_id=2), "labels": [{"name": "docs"}]},
+    ]
+
+    result = config.filter_pr_details(pr_details, [], filter_label=("bug",))
+    assert [r["id"] for r in result] == [1]
+
+
+def test_filter_pr_details_filter_label_no_labels_on_pr():
+    pr_details = [
+        {**_make_pr(pr_id=1), "labels": []},
+        {**_make_pr(pr_id=2)},  # labels key absent
+    ]
+
+    result = config.filter_pr_details(pr_details, [], filter_label=("bug",))
+    assert result == []
+
+
+def test_filter_pr_details_exclude_label():
+    pr_details = [
+        {**_make_pr(pr_id=1), "labels": [{"name": "wip"}]},
+        {**_make_pr(pr_id=2), "labels": [{"name": "ready"}]},
+        {**_make_pr(pr_id=3), "labels": []},
+    ]
+
+    result = config.filter_pr_details(pr_details, [], exclude_label=("wip",))
+    assert {r["id"] for r in result} == {2, 3}
+
+
+def test_filter_pr_details_exclude_label_case_insensitive():
+    pr_details = [
+        {**_make_pr(pr_id=1), "labels": [{"name": "WIP"}]},
+        {**_make_pr(pr_id=2), "labels": [{"name": "ready"}]},
+    ]
+
+    result = config.filter_pr_details(pr_details, [], exclude_label=("wip",))
+    assert [r["id"] for r in result] == [2]
+
+
 def test_get_config_dir_xdg(tmp_path, monkeypatch):
     custom_path = tmp_path / "custom-xdg"
     monkeypatch.setenv("XDG_CONFIG_HOME", str(custom_path))


### PR DESCRIPTION
## Summary
- Added `--label` option to show only PRs with specific labels (repeatable, OR logic, case-insensitive)
- Added `--exclude-label` option to hide PRs with specific labels (repeatable, case-insensitive)
- Filter logic added to `filter_pr_details()` in `config.py`
- Manual page updated with examples

Closes #37

## Test plan
- [x] `make format && make lint && make test` (334 tests pass)
- [x] Tests: single label, multiple labels (OR), case-insensitivity, absent labels, exclude single, exclude case-insensitive

🤖 Generated with [Claude Code](https://claude.com/claude-code)