### PR TITLE
#38: Add --filter-reviewer filter

### DIFF
--- a/docs/manual/options.md
+++ b/docs/manual/options.md
@@ -94,6 +94,15 @@ breakfast -o my-org -r my-app --filter-approval pending --filter-approval change
 
 > **Note:** Review and check statuses are cached alongside PR details, so repeated runs with these flags skip redundant API calls.
 
+### `--filter-reviewer`
+
+Only show PRs that have a specific user listed as a requested reviewer. Matching is **case-insensitive**. Repeat the flag to include any of the given reviewers (OR logic).
+
+```bash
+breakfast -o my-org --filter-reviewer alice              # PRs requesting review from alice
+breakfast -o my-org --filter-reviewer alice --filter-reviewer bob
+```
+
 ### `--search`, `-s`
 
 Filter PRs by title. Accepts a plain string or a regular expression pattern; matching is always **case-insensitive**.

--- a/src/breakfast/cli.py
+++ b/src/breakfast/cli.py
@@ -673,6 +673,14 @@ def _fetch_pr_bundle(url, fetch_checks, fetch_approvals):
     help="Only show PRs with this review approval status. Repeat for multiple values.",
 )
 @click.option(
+    "--filter-reviewer",
+    multiple=True,
+    help=(
+        "Only show PRs that have this user as a requested reviewer"
+        " (repeatable, case-insensitive). e.g. --filter-reviewer alice"
+    ),
+)
+@click.option(
     "--legendary/--no-legendary",
     default=None,
     help=(
@@ -786,6 +794,7 @@ def breakfast(
     filter_state,
     filter_check,
     filter_approval,
+    filter_reviewer,
     legendary,
     legendary_only,
     search,
@@ -1254,6 +1263,7 @@ def breakfast(
         check_statuses=check_statuses,
         approval_statuses=approval_statuses,
         search_title=search,
+        filter_reviewer=filter_reviewer,
     )
     logger.info(
         "filter_result before=%d after=%d",

--- a/src/breakfast/config.py
+++ b/src/breakfast/config.py
@@ -393,6 +393,7 @@ def filter_pr_details(
     check_statuses=None,
     approval_statuses=None,
     search_title=None,
+    filter_reviewer=None,
 ):
     ignore_set = normalize_ignore_authors(ignore_authors)
     current_user_login_normalized = (
@@ -438,6 +439,12 @@ def filter_pr_details(
         if search_title is not None:
             title = pr_detail.get("title", "")
             if not re.search(search_title, title, re.IGNORECASE):
+                continue
+        if filter_reviewer:
+            reviewers = {
+                r["login"].lower() for r in pr_detail.get("requested_reviewers", [])
+            }
+            if not any(rv.lower() in reviewers for rv in filter_reviewer):
                 continue
 
         filtered.append(pr_detail)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -196,6 +196,51 @@ def test_filter_pr_details_combined_filters():
     assert {r["id"] for r in result} == {1, 2}
 
 
+def test_filter_pr_details_filter_reviewer_single():
+    pr_details = [
+        {
+            **_make_pr(pr_id=1),
+            "requested_reviewers": [{"login": "alice"}, {"login": "bob"}],
+        },
+        {**_make_pr(pr_id=2), "requested_reviewers": [{"login": "carol"}]},
+        {**_make_pr(pr_id=3), "requested_reviewers": []},
+    ]
+
+    result = config.filter_pr_details(pr_details, [], filter_reviewer=("alice",))
+    assert [r["id"] for r in result] == [1]
+
+
+def test_filter_pr_details_filter_reviewer_multiple_or():
+    pr_details = [
+        {**_make_pr(pr_id=1), "requested_reviewers": [{"login": "alice"}]},
+        {**_make_pr(pr_id=2), "requested_reviewers": [{"login": "bob"}]},
+        {**_make_pr(pr_id=3), "requested_reviewers": [{"login": "carol"}]},
+    ]
+
+    result = config.filter_pr_details(pr_details, [], filter_reviewer=("alice", "bob"))
+    assert {r["id"] for r in result} == {1, 2}
+
+
+def test_filter_pr_details_filter_reviewer_case_insensitive():
+    pr_details = [
+        {**_make_pr(pr_id=1), "requested_reviewers": [{"login": "Alice"}]},
+        {**_make_pr(pr_id=2), "requested_reviewers": [{"login": "bob"}]},
+    ]
+
+    result = config.filter_pr_details(pr_details, [], filter_reviewer=("alice",))
+    assert [r["id"] for r in result] == [1]
+
+
+def test_filter_pr_details_filter_reviewer_no_reviewers():
+    pr_details = [
+        {**_make_pr(pr_id=1), "requested_reviewers": []},
+        {**_make_pr(pr_id=2)},  # field absent
+    ]
+
+    result = config.filter_pr_details(pr_details, [], filter_reviewer=("alice",))
+    assert result == []
+
+
 def test_get_config_dir_xdg(tmp_path, monkeypatch):
     custom_path = tmp_path / "custom-xdg"
     monkeypatch.setenv("XDG_CONFIG_HOME", str(custom_path))


### PR DESCRIPTION
## Summary
- Added `--filter-reviewer` option to show only PRs with a specific requested reviewer
- Matching is case-insensitive; repeat the flag for OR logic (any of the given reviewers)
- Filter logic added to `filter_pr_details()` in `config.py`
- Manual page updated with examples

Closes #38

## Test plan
- [x] `make format && make lint && make test` (332 tests pass)
- [x] Tests: single reviewer, multiple (OR), case-insensitive, absent reviewers field

🤖 Generated with [Claude Code](https://claude.com/claude-code)