### PR TITLE
#101: Replace tabulate call in _table_width with direct width calculation

### DIFF
--- a/src/breakfast/cli.py
+++ b/src/breakfast/cli.py
@@ -136,16 +136,25 @@ def _styled_hyperlink(url, styled_text):
 
 
 def _table_width(rows):
-    """Return visual table width via the border line (ANSI-stripped for accuracy)."""
-    plain_rows = [{k: _strip_ansi(v) for k, v in row.items()} for row in rows]
-    table_str = tabulate(
-        plain_rows,
-        headers="keys",
-        showindex="always",
-        tablefmt="outline",
-        disable_numparse=True,
-    )
-    return len(table_str.splitlines()[0])
+    """Return visual table width without rendering the full table.
+
+    Replicates the border line width of tabulate's outline format.
+    Each column contributes max(header_len+4, cell_max+2) dashes plus
+    a leading '+'. The index column uses header_len=0.
+    """
+    if not rows:
+        return 0
+    headers = list(rows[0].keys())
+    idx_width = len(str(len(rows) - 1))
+    # Index column: header is empty, content is the row number
+    total = 1 + max(4, idx_width + 2) + 1
+    for h in headers:
+        cell_max = max(
+            (len(_strip_ansi(str(row.get(h, "")))) for row in rows),
+            default=0,
+        )
+        total += max(len(h) + 4, cell_max + 2) + 1
+    return total
 
 
 def _truncate_col(pr_data, key, terminal_width, min_len=8):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1136,6 +1136,35 @@ def _make_pr_fixture(title="Test PR", number=1):
     }
 
 
+def test_table_width_matches_tabulate_border():
+    """_table_width must agree with the actual tabulate outline border width."""
+    test_cases = [
+        [{"Repo": "repo", "PR Title": "title", "Author": "alice"}],
+        [
+            {"Repo": "short", "PR Title": "a", "Author": "bob"},
+            {
+                "Repo": "a-very-long-repository-name",
+                "PR Title": "longer title here",
+                "Author": "carol",
+            },
+        ],
+        [{"Col": "x"} for _ in range(10)],
+        [{"A": "hello", "B": "\x1b[32mgreen\x1b[0m", "C": "plain"}],
+    ]
+    for rows in test_cases:
+        plain_rows = [{k: cli._strip_ansi(v) for k, v in row.items()} for row in rows]
+        expected = len(
+            tabulate(
+                plain_rows,
+                headers="keys",
+                showindex="always",
+                tablefmt="outline",
+                disable_numparse=True,
+            ).splitlines()[0]
+        )
+        assert cli._table_width(rows) == expected, f"Mismatch for rows={rows!r}"
+
+
 def test_auto_fit_measures_later_rows_when_fitting_table():
     rows = [
         {


### PR DESCRIPTION
## Summary

- Replaces the full `tabulate()` render in `_table_width` with a direct column-width formula
- Formula: `max(header_len + 4, cell_max + 2)` per data column, plus `max(4, idx_width + 2)` for the index column — matches tabulate's `outline` format exactly
- Adds a unit test verifying the new implementation agrees with actual tabulate output across representative inputs (single row, multi-row, 10-row index, ANSI-stripped cells)

## Test plan

- [ ] `make format && make lint && make test` passes (335 tests)
- [ ] New test `test_table_width_matches_tabulate_border` confirms formula parity with tabulate for 4 representative cases

Closes #101

🤖 Generated with [Claude Code](https://claude.com/claude-code)