### PR TITLE
#103: Add per-repo PR cache for partial cache hits

### DIFF
--- a/.antigravitycli/cdf78009-abb6-4f5f-b958-26b2b56757d7.json
+++ b/.antigravitycli/cdf78009-abb6-4f5f-b958-26b2b56757d7.json
@@ -1,0 +1,1 @@
+/Users/steve/.gemini/config/projects/cdf78009-abb6-4f5f-b958-26b2b56757d7.json

--- a/.antigravitycli/cdf78009-abb6-4f5f-b958-26b2b56757d7.json
+++ b/.antigravitycli/cdf78009-abb6-4f5f-b958-26b2b56757d7.json
@@ -1,1 +1,0 @@
-/Users/steve/.gemini/config/projects/cdf78009-abb6-4f5f-b958-26b2b56757d7.json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
           python-version: "3.11"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@94527f2e458b27549849d47d273a16bec83a01e9 # v7
         with:
           version: "latest"
 
@@ -38,7 +38,7 @@ jobs:
           python-version: "3.11"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@94527f2e458b27549849d47d273a16bec83a01e9 # v7
         with:
           version: "latest"
 
@@ -58,7 +58,7 @@ jobs:
           python-version: "3.11"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@94527f2e458b27549849d47d273a16bec83a01e9 # v7
         with:
           version: "latest"
 
@@ -75,7 +75,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Check spelling
-        uses: crate-ci/typos@v1.42.2
+        uses: crate-ci/typos@f99a422d725e876bfb232c50e25e754cfef45cff # v1.42.2
 
   docs-lint:
     runs-on: ubuntu-latest
@@ -99,7 +99,7 @@ jobs:
           python-version: "3.11"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@94527f2e458b27549849d47d273a16bec83a01e9 # v7
         with:
           version: "latest"
 
@@ -124,7 +124,7 @@ jobs:
           python-version: "3.11"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@94527f2e458b27549849d47d273a16bec83a01e9 # v7
         with:
           version: "latest"
 
@@ -162,7 +162,7 @@ jobs:
           python-version: "3.11"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@94527f2e458b27549849d47d273a16bec83a01e9 # v7
         with:
           version: "latest"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
           python-version: "3.11"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@94527f2e458b27549849d47d273a16bec83a01e9 # v7
+        uses: astral-sh/setup-uv@v7
         with:
           version: "latest"
 
@@ -38,7 +38,7 @@ jobs:
           python-version: "3.11"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@94527f2e458b27549849d47d273a16bec83a01e9 # v7
+        uses: astral-sh/setup-uv@v7
         with:
           version: "latest"
 
@@ -58,7 +58,7 @@ jobs:
           python-version: "3.11"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@94527f2e458b27549849d47d273a16bec83a01e9 # v7
+        uses: astral-sh/setup-uv@v7
         with:
           version: "latest"
 
@@ -75,7 +75,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Check spelling
-        uses: crate-ci/typos@f99a422d725e876bfb232c50e25e754cfef45cff # v1.42.2
+        uses: crate-ci/typos@v1.42.2
 
   docs-lint:
     runs-on: ubuntu-latest
@@ -99,7 +99,7 @@ jobs:
           python-version: "3.11"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@94527f2e458b27549849d47d273a16bec83a01e9 # v7
+        uses: astral-sh/setup-uv@v7
         with:
           version: "latest"
 
@@ -124,7 +124,7 @@ jobs:
           python-version: "3.11"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@94527f2e458b27549849d47d273a16bec83a01e9 # v7
+        uses: astral-sh/setup-uv@v7
         with:
           version: "latest"
 
@@ -162,7 +162,7 @@ jobs:
           python-version: "3.11"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@94527f2e458b27549849d47d273a16bec83a01e9 # v7
+        uses: astral-sh/setup-uv@v7
         with:
           version: "latest"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
           python-version: "3.11"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v3
+        uses: astral-sh/setup-uv@v7
         with:
           version: "latest"
 
@@ -38,7 +38,7 @@ jobs:
           python-version: "3.11"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v3
+        uses: astral-sh/setup-uv@v7
         with:
           version: "latest"
 
@@ -58,7 +58,7 @@ jobs:
           python-version: "3.11"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v3
+        uses: astral-sh/setup-uv@v7
         with:
           version: "latest"
 
@@ -75,7 +75,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Check spelling
-        uses: crate-ci/typos@master
+        uses: crate-ci/typos@v1.42.2
 
   docs-lint:
     runs-on: ubuntu-latest
@@ -99,7 +99,7 @@ jobs:
           python-version: "3.11"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v3
+        uses: astral-sh/setup-uv@v7
         with:
           version: "latest"
 
@@ -124,7 +124,7 @@ jobs:
           python-version: "3.11"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v3
+        uses: astral-sh/setup-uv@v7
         with:
           version: "latest"
 
@@ -162,7 +162,7 @@ jobs:
           python-version: "3.11"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v3
+        uses: astral-sh/setup-uv@v7
         with:
           version: "latest"
 

--- a/.gitignore
+++ b/.gitignore
@@ -179,3 +179,7 @@ cython_debug/
 # Generated build artifacts
 /completions/
 /man1/
+
+# Claude Code worktrees and Antigravity CLI state
+.claude/worktrees/
+.antigravitycli/

--- a/docs/manual/options.md
+++ b/docs/manual/options.md
@@ -201,6 +201,24 @@ breakfast -o my-org --exclude-label wip                  # hide WIP PRs
 breakfast -o my-org --exclude-label wip --exclude-label blocked
 ```
 
+### `--filter-stale`
+
+Only show PRs that have been open for more than N days (based on creation date). Pairs naturally with `--age` to see the age column.
+
+```bash
+breakfast -o my-org --filter-stale 14         # PRs open for more than 14 days
+breakfast -o my-org --filter-stale 30 --age   # stale PRs with age column visible
+```
+
+### `--filter-inactive`
+
+Only show PRs that have not been updated in the last N days. Useful for surfacing PRs that need a nudge.
+
+```bash
+breakfast -o my-org --filter-inactive 7       # not updated in the last 7 days
+breakfast -o my-org --filter-stale 14 --filter-inactive 3
+```
+
 ### `--search`, `-s`
 
 Filter PRs by title. Accepts a plain string or a regular expression pattern; matching is always **case-insensitive**.

--- a/docs/manual/options.md
+++ b/docs/manual/options.md
@@ -122,6 +122,25 @@ With `--ignore-author dependabot[bot]`, the bot PR is excluded:
 +---------+----------------+-----------------+--------+---------+-------+---------+------------+----------+--------------+--------+
 ```
 
+### `--fetch-state`
+
+Control which PR states are **fetched** from GitHub. By default only open PRs are
+retrieved. Use this flag to include closed or merged PRs in your results.
+
+Accepted values: `open` (default), `closed`, `merged`, `all`.
+
+```bash
+breakfast -o my-org -r platform --fetch-state closed    # closed PRs only
+breakfast -o my-org -r platform --fetch-state merged    # merged PRs only
+breakfast -o my-org -r platform --fetch-state all       # every state
+```
+
+> **Note:** Fetching closed or merged PRs can be significantly slower since
+> there are usually many more of them. Combine with `--limit` to keep output
+> manageable.
+
+Config key: `fetch-state = "open"`
+
 ### `--filter-state`
 
 Only show PRs with a specific state. Accepted values: `open`, `closed`, `draft`. Repeat the flag to match multiple states.

--- a/docs/manual/options.md
+++ b/docs/manual/options.md
@@ -301,12 +301,13 @@ Processing platform PRs...🍩🧇...Done
 
 ### `--format`
 
-Choose the output format. Accepted values: `table` (default), `json`, `markdown`, `csv`.
+Choose the output format. Accepted values: `table` (default), `json`, `markdown`, `csv`, `template`.
 
 ```text
 breakfast -o my-org -r platform --format markdown
 breakfast -o my-org -r platform --format json
 breakfast -o my-org -r platform --format csv
+breakfast -o my-org -r platform --format template --template "{repo}: {title}"
 ```
 
 You can also set a persistent default in your config file:
@@ -316,6 +317,39 @@ format = "csv"
 ```
 
 See [Output Formats](output-formats.md) for full details on each format.
+
+### `--template`
+
+A Python format string used when `--format template` is active. One line is printed per PR with the template fields substituted.
+
+Available fields:
+
+| Field                    | Description                          |
+|--------------------------|--------------------------------------|
+| `{repo}`                 | Repository name                      |
+| `{title}`                | PR title                             |
+| `{author}`               | Author GitHub login                  |
+| `{url}`                  | PR URL                               |
+| `{state}`                | PR state (`open`, `closed`)          |
+| `{number}`               | PR number                            |
+| `{created_at}`           | ISO 8601 creation timestamp          |
+| `{updated_at}`           | ISO 8601 last-updated timestamp      |
+| `{additions}`            | Lines added                          |
+| `{deletions}`            | Lines deleted                        |
+| `{changed_files}`        | Files changed                        |
+| `{commits}`              | Commit count                         |
+| `{review_comments}`      | Review comment count                 |
+| `{labels}`               | Pipe-separated label names           |
+| `{requested_reviewers}`  | Pipe-separated reviewer logins       |
+
+```bash
+breakfast -o my-org --format template --template "{repo}: {title} by {author} — {url}"
+breakfast -o my-org --format template --template "{number}\t{title}\t{url}"
+```
+
+If an unknown field is used, breakfast exits with an error message.
+
+Config keys: `format = "template"` and `template = "{repo}: {title} ({url})"`
 
 ### `--markdown`
 
@@ -837,6 +871,40 @@ Config key: `summarise-repo-prs = true`
 > **Note:** `--summarise-user-prs` and `--summarise-repo-prs` are mutually
 > exclusive. All standard filter flags (`--author`, `--repo-filter`,
 > `--filter-state`, etc.) apply before the summary is computed.
+
+## Sorting
+
+### `--sort`
+
+Sort the PR list by a named field. By default PRs are grouped by repository
+(`repo`). Available choices:
+
+| Value      | Sorts by                                      |
+|------------|-----------------------------------------------|
+| `repo`     | Repository name (default)                     |
+| `age`      | Days since the PR was opened (oldest first)   |
+| `updated`  | Last-updated timestamp (most-recently first)  |
+| `author`   | PR author login (alphabetical)                |
+| `comments` | Total comment count (issue + review comments) |
+| `reviews`  | Review comment count only                     |
+
+```bash
+breakfast -o my-org --sort age          # oldest PRs first
+breakfast -o my-org --sort comments     # most commented first
+```
+
+Config key: `sort = "repo"`
+
+### `--reverse`
+
+Reverse the sort order imposed by `--sort`.
+
+```bash
+breakfast -o my-org --sort age --reverse    # newest PRs first
+breakfast -o my-org --sort author --reverse # Z→A author order
+```
+
+Config key: `sort-reverse = false`
 
 ## Other options
 

--- a/src/breakfast/api.py
+++ b/src/breakfast/api.py
@@ -266,26 +266,36 @@ def _match_exclude_repos(repo_name, exclude_repos):
     return False
 
 
-def get_github_prs(organization, repo_filters):
-    base_query = """
-    query($organization: String!, $cursor: String){
-      organization(login: $organization){
-        repositories(after: $cursor, first:100){
-          nodes{
+_FETCH_STATE_MAP = {
+    "open": ["OPEN"],
+    "closed": ["CLOSED"],
+    "merged": ["MERGED"],
+    "all": ["OPEN", "CLOSED", "MERGED"],
+}
+
+
+def get_github_prs(organization, repo_filters, fetch_state="open"):
+    states_list = _FETCH_STATE_MAP.get(fetch_state.lower(), ["OPEN"])
+    states_gql = ", ".join(states_list)
+    base_query = f"""
+    query($organization: String!, $cursor: String){{
+      organization(login: $organization){{
+        repositories(after: $cursor, first:100){{
+          nodes{{
             name
-            pullRequests(first:100,states: [OPEN]){
-                nodes{
+            pullRequests(first:100,states: [{states_gql}]){{
+                nodes{{
                     url
-                 }
-            }
-          }
-          pageInfo {
+                 }}
+            }}
+          }}
+          pageInfo {{
             endCursor
             hasNextPage
-          }
-        }
-      }
-    }
+          }}
+        }}
+      }}
+    }}
         """
     variables = {"organization": organization}
 

--- a/src/breakfast/api.py
+++ b/src/breakfast/api.py
@@ -544,3 +544,28 @@ def get_check_status(owner, repo, sha):
         return "fail"
 
     return "pass"
+
+
+def _pr_days_since(timestamp_str, now=None):
+    """Return the number of days since the given ISO 8601 timestamp, or 0 on error."""
+    if not timestamp_str:
+        return 0
+    try:
+        dt = datetime.datetime.fromisoformat(timestamp_str.replace("Z", "+00:00"))
+    except ValueError:
+        return 0
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=datetime.timezone.utc)
+    if now is None:
+        now = datetime.datetime.now(datetime.timezone.utc)
+    return max((now - dt).days, 0)
+
+
+def get_pr_age_days(pr_detail, now=None):
+    """Return the age in days of a PR since it was created."""
+    return _pr_days_since(pr_detail.get("created_at"), now=now)
+
+
+def get_pr_inactive_days(pr_detail, now=None):
+    """Return the number of days since a PR was last updated."""
+    return _pr_days_since(pr_detail.get("updated_at"), now=now)

--- a/src/breakfast/cache.py
+++ b/src/breakfast/cache.py
@@ -206,6 +206,113 @@ def read_pr_cache(org: str, repo_filter: str, ttl: int) -> dict | None:
         return None
 
 
+def repo_pr_cache_path(org: str, repo_name: str) -> Path:
+    raw = f"{org.lower()}:{repo_name.lower()}"
+    key = hashlib.sha256(raw.encode()).hexdigest()[:16]
+    return _CACHE_DIR / f"pr_repo_{key}.json"
+
+
+def read_repo_pr_cache(org: str, repo_name: str, ttl: int) -> dict | None:
+    """Return cached PR details for a single repo, or None on miss/expiry."""
+    path = repo_pr_cache_path(org, repo_name)
+    try:
+        if not path.exists():
+            logger.debug("cache_miss layer=repo_pr path=%s reason=file_not_found", path)
+            return None
+        data = json.loads(path.read_text())
+        fetched_at = datetime.fromisoformat(data["fetched_at"])
+        age = (datetime.now(timezone.utc) - fetched_at).total_seconds()
+        if age > ttl:
+            logger.debug(
+                "cache_miss layer=repo_pr path=%s reason=expired age=%.0fs ttl=%ss",
+                path,
+                age,
+                ttl,
+            )
+            return None
+        raw_checks = data.get("check_statuses")
+        raw_approvals = data.get("approval_statuses")
+        raw_approval_details = data.get("approval_details")
+        logger.debug(
+            "cache_hit layer=repo_pr path=%s age=%.0fs pr_count=%d",
+            path,
+            age,
+            len(data["prs"]),
+        )
+        return {
+            "prs": data["prs"],
+            "check_statuses": (
+                {int(k): v for k, v in raw_checks.items()}
+                if raw_checks is not None
+                else None
+            ),
+            "approval_statuses": (
+                {int(k): v for k, v in raw_approvals.items()}
+                if raw_approvals is not None
+                else None
+            ),
+            "approval_details": (
+                {int(k): v for k, v in raw_approval_details.items()}
+                if raw_approval_details is not None
+                else None
+            ),
+        }
+    except (OSError, json.JSONDecodeError, KeyError, ValueError, TypeError) as exc:
+        logger.warning(
+            "cache_read_error layer=repo_pr path=%s error=%r", path, str(exc)
+        )
+        click.echo(
+            click.style(f"Warning: failed to read repo PR cache: {exc}", fg="yellow"),
+            err=True,
+        )
+        return None
+
+
+def write_repo_pr_cache(
+    org: str,
+    repo_name: str,
+    pr_details: list,
+    check_statuses: dict | None = None,
+    approval_statuses: dict | None = None,
+    approval_details: dict | None = None,
+) -> None:
+    """Write PR details for a single repo to disk cache."""
+    try:
+        _CACHE_DIR.mkdir(parents=True, exist_ok=True)
+        path = repo_pr_cache_path(org, repo_name)
+        payload = {
+            "fetched_at": datetime.now(timezone.utc).isoformat(),
+            "organization": org,
+            "repo": repo_name,
+            "pr_count": len(pr_details),
+            "prs": pr_details,
+        }
+        if check_statuses is not None:
+            payload["check_statuses"] = {str(k): v for k, v in check_statuses.items()}
+        if approval_statuses is not None:
+            payload["approval_statuses"] = {
+                str(k): v for k, v in approval_statuses.items()
+            }
+        if approval_details is not None:
+            payload["approval_details"] = {
+                str(k): v for k, v in approval_details.items()
+            }
+        _atomic_write_text(path, json.dumps(payload))
+        logger.debug(
+            "cache_write layer=repo_pr path=%s pr_count=%d", path, len(pr_details)
+        )
+    except OSError as exc:
+        logger.warning(
+            "cache_write_error layer=repo_pr path=%s error=%r",
+            repo_pr_cache_path(org, repo_name),
+            str(exc),
+        )
+        click.echo(
+            click.style(f"Warning: failed to write repo PR cache: {exc}", fg="yellow"),
+            err=True,
+        )
+
+
 def write_pr_cache(
     org: str,
     repo_filter: str,

--- a/src/breakfast/cli.py
+++ b/src/breakfast/cli.py
@@ -24,6 +24,7 @@ from .api import (
     get_check_status,
     get_github_prs,
     get_graphql_rate_limit,
+    get_pr_age_days,
 )
 from .cache import (
     parse_ttl,
@@ -421,26 +422,6 @@ def _org_spec_cache_segment(org: str, scoped: list[str] | None) -> str:
     return org.lower() + ":" + filter_str
 
 
-def get_pr_age_days(pr_detail, now=None):
-    from datetime import datetime, timezone
-
-    created_at = pr_detail.get("created_at")
-    if not created_at:
-        return 0
-
-    try:
-        created_dt = datetime.fromisoformat(created_at.replace("Z", "+00:00"))
-    except ValueError:
-        logger.debug("get_pr_age_days invalid_date created_at=%r", created_at)
-        return 0
-
-    if created_dt.tzinfo is None:
-        created_dt = created_dt.replace(tzinfo=timezone.utc)
-    if now is None:
-        now = datetime.now(timezone.utc)
-
-    return max((now - created_dt).days, 0)
-
 
 _LEGENDARY_COMMENT_THRESHOLD = 100
 _LEGENDARY_AGE_THRESHOLD_DAYS = 30
@@ -824,6 +805,18 @@ def _fetch_pr_bundle(url, fetch_checks, fetch_approvals):
     ),
 )
 @click.option(
+    "--filter-stale",
+    type=int,
+    default=None,
+    help="Only show PRs older than N days (by creation date).",
+)
+@click.option(
+    "--filter-inactive",
+    type=int,
+    default=None,
+    help="Only show PRs not updated in the last N days.",
+)
+@click.option(
     "--legendary/--no-legendary",
     default=None,
     help=(
@@ -942,6 +935,8 @@ def breakfast(
     filter_reviewer,
     filter_label,
     exclude_label,
+    filter_stale,
+    filter_inactive,
     legendary,
     legendary_only,
     search,
@@ -1552,6 +1547,8 @@ def breakfast(
         filter_reviewer=filter_reviewer,
         filter_label=filter_label,
         exclude_label=exclude_label,
+        filter_stale=filter_stale,
+        filter_inactive=filter_inactive,
     )
     logger.info(
         "filter_result before=%d after=%d",

--- a/src/breakfast/cli.py
+++ b/src/breakfast/cli.py
@@ -771,8 +771,7 @@ def _fetch_pr_bundle(url, fetch_checks, fetch_approvals):
 @click.option(
     "--fetch-state",
     type=click.Choice(["open", "closed", "merged", "all"], case_sensitive=False),
-    default="open",
-    show_default=True,
+    default=None,
     help=(
         "Which PR states to fetch from GitHub. 'open' fetches only open PRs"
         " (default). Use 'closed', 'merged', or 'all' to include other states."
@@ -1069,7 +1068,7 @@ def breakfast(
     )
     workers = workers if workers is not None else cfg.get("workers", 64)
     fetch_state = (
-        fetch_state if fetch_state != "open" else cfg.get("fetch-state", "open")
+        fetch_state if fetch_state is not None else cfg.get("fetch-state", "open")
     )
     if status_style not in {"emoji", "ascii"}:
         status_style = "emoji"

--- a/src/breakfast/cli.py
+++ b/src/breakfast/cli.py
@@ -769,6 +769,16 @@ def _fetch_pr_bundle(url, fetch_checks, fetch_approvals):
     ),
 )
 @click.option(
+    "--fetch-state",
+    type=click.Choice(["open", "closed", "merged", "all"], case_sensitive=False),
+    default="open",
+    show_default=True,
+    help=(
+        "Which PR states to fetch from GitHub. 'open' fetches only open PRs"
+        " (default). Use 'closed', 'merged', or 'all' to include other states."
+    ),
+)
+@click.option(
     "--filter-state",
     type=click.Choice(["open", "closed", "draft"], case_sensitive=False),
     multiple=True,
@@ -926,6 +936,7 @@ def breakfast(
     cache,
     refresh,
     refresh_prs,
+    fetch_state,
     filter_state,
     filter_check,
     filter_approval,
@@ -1057,6 +1068,9 @@ def breakfast(
         else cfg.get("max-title-length")
     )
     workers = workers if workers is not None else cfg.get("workers", 64)
+    fetch_state = (
+        fetch_state if fetch_state != "open" else cfg.get("fetch-state", "open")
+    )
     if status_style not in {"emoji", "ascii"}:
         status_style = "emoji"
     legendary = legendary if legendary is not None else cfg.get("legendary", False)
@@ -1265,7 +1279,7 @@ def breakfast(
                     repo_filters if scoped_filters is None else scoped_filters
                 )
                 try:
-                    prs.extend(get_github_prs(org, effective_filters))
+                    prs.extend(get_github_prs(org, effective_filters, fetch_state))
                 except (
                     requests.exceptions.ConnectionError,
                     requests.exceptions.Timeout,

--- a/src/breakfast/cli.py
+++ b/src/breakfast/cli.py
@@ -422,7 +422,6 @@ def _org_spec_cache_segment(org: str, scoped: list[str] | None) -> str:
     return org.lower() + ":" + filter_str
 
 
-
 _LEGENDARY_COMMENT_THRESHOLD = 100
 _LEGENDARY_AGE_THRESHOLD_DAYS = 30
 _LEGENDARY_EMOJI = "⚔️"

--- a/src/breakfast/cli.py
+++ b/src/breakfast/cli.py
@@ -29,8 +29,10 @@ from .cache import (
     parse_ttl,
     read_graphql_cache,
     read_pr_cache,
+    read_repo_pr_cache,
     write_graphql_cache,
     write_pr_cache,
+    write_repo_pr_cache,
 )
 from .config import (
     filter_pr_details,
@@ -1304,29 +1306,80 @@ def breakfast(
                 if not _match_exclude_repos(_extract_repo_name(url), exclude_repos)
             ]
 
+        # --- Layer 2.5: per-repo PR cache ---
+        # Group URLs by repo so we can check per-repo cache before fetching.
+        urls_to_fetch = list(prs) if prs else []
+        repo_hit_prs: list = []
+        repo_hit_checks: dict = {}
+        repo_hit_approvals: dict = {}
+        repo_hit_approval_details: dict = {}
+
+        if cache_enabled and not refresh_prs and prs:
+            repos_to_urls: dict[tuple[str, str], list[str]] = {}
+            for url in prs:
+                parts = urlparse(url).path.strip("/").split("/")
+                if len(parts) >= 4:
+                    repos_to_urls.setdefault((parts[0], parts[1]), []).append(url)
+
+            uncached_urls: list[str] = []
+            for (org_name, rname), repo_urls in repos_to_urls.items():
+                cached = read_repo_pr_cache(org_name, rname, cache_ttl_seconds)
+                if cached is not None:
+                    repo_hit_prs.extend(cached["prs"])
+                    if cached["check_statuses"]:
+                        repo_hit_checks.update(cached["check_statuses"])
+                    if cached["approval_statuses"]:
+                        repo_hit_approvals.update(cached["approval_statuses"])
+                    if cached["approval_details"]:
+                        repo_hit_approval_details.update(cached["approval_details"])
+                else:
+                    uncached_urls.extend(repo_urls)
+            urls_to_fetch = uncached_urls
+
         pr_details = []
         failed_urls = []
+        newly_fetched_by_repo: dict[str, dict] = {}
         repo_display = ", ".join(repo_filters) if repo_filters else "all repos"
         click.echo(f"Processing {repo_display} PRs...", nl=False, err=True)
-        if prs:
-            max_workers = min(workers, len(prs))
+
+        if not urls_to_fetch and repo_hit_prs:
+            click.echo("⚡", nl=False, err=True)
+
+        if urls_to_fetch:
+            max_workers = min(workers, len(urls_to_fetch))
             with ThreadPoolExecutor(max_workers=max_workers) as executor:
                 future_to_url = {
                     executor.submit(_fetch_pr_bundle, url, checks, approvals): url
-                    for url in prs
+                    for url in urls_to_fetch
                 }
                 for future in as_completed(future_to_url):
                     url = future_to_url[future]
                     try:
                         pr_detail, check_status, approval_detail = future.result()
                         pr_details.append(pr_detail)
+                        rname = pr_detail["base"]["repo"]["name"]
+                        url_parts = urlparse(url).path.strip("/").split("/")
+                        org_name = url_parts[0] if len(url_parts) >= 2 else ""
+                        rd = newly_fetched_by_repo.setdefault(
+                            (org_name, rname),
+                            {
+                                "prs": [],
+                                "checks": {},
+                                "approvals": {},
+                                "approval_details": {},
+                            },
+                        )
+                        rd["prs"].append(pr_detail)
                         if check_status is not None:
                             check_statuses[pr_detail["id"]] = check_status
+                            rd["checks"][pr_detail["id"]] = check_status
                         if approval_detail is not None:
                             approval_statuses[pr_detail["id"]] = approval_detail[
                                 "status"
                             ]
                             approval_details[pr_detail["id"]] = approval_detail
+                            rd["approvals"][pr_detail["id"]] = approval_detail["status"]
+                            rd["approval_details"][pr_detail["id"]] = approval_detail
                         click.echo(
                             random.choices(BREAKFAST_ITEMS)[0],
                             nl=False,
@@ -1340,7 +1393,32 @@ def breakfast(
                             "pr_detail_fetch_failed url=%s error=%r", url, str(exc)
                         )
                         failed_urls.append(url)
-        statuses_from_bundle = True
+
+        # Write per-repo cache for repos fetched in this run
+        if cache_enabled and newly_fetched_by_repo:
+            for (org_name, rname), rdata in newly_fetched_by_repo.items():
+                write_repo_pr_cache(
+                    org_name,
+                    rname,
+                    rdata["prs"],
+                    check_statuses=rdata["checks"] or None,
+                    approval_statuses=rdata["approvals"] or None,
+                    approval_details=rdata["approval_details"] or None,
+                )
+
+        # Merge per-repo cache hits into the main collections
+        pr_details.extend(repo_hit_prs)
+        check_statuses.update(repo_hit_checks)
+        approval_statuses.update(repo_hit_approvals)
+        approval_details.update(repo_hit_approval_details)
+
+        # When all PRs came from per-repo cache, use cached statuses path
+        statuses_from_bundle = bool(urls_to_fetch)
+        if not statuses_from_bundle and repo_hit_prs:
+            cached_check_statuses = repo_hit_checks or None
+            cached_approval_statuses = repo_hit_approvals or None
+            cached_approval_details = repo_hit_approval_details or None
+
         click.echo("...Done", err=True)
         if failed_urls:
             examples = ", ".join(failed_urls[:3])

--- a/src/breakfast/cli.py
+++ b/src/breakfast/cli.py
@@ -656,10 +656,24 @@ def _fetch_pr_bundle(url, fetch_checks, fetch_approvals):
     "--format",
     "output_format",
     default=None,
-    type=click.Choice(["table", "json", "markdown", "csv"], case_sensitive=False),
+    type=click.Choice(
+        ["table", "json", "markdown", "csv", "template"], case_sensitive=False
+    ),
     help=(
-        "Output format: table (default), json, or markdown. "
+        "Output format: table (default), json, markdown, csv, or template. "
         "Overrides --json/--no-json/--markdown when both are given."
+    ),
+)
+@click.option(
+    "--template",
+    "template_str",
+    default=None,
+    help=(
+        "Format string for --format template. "
+        "Fields: {repo}, {title}, {author}, {url}, {state}, {number},"
+        " {created_at}, {updated_at}, {additions}, {deletions},"
+        " {changed_files}, {commits}, {review_comments}, {labels},"
+        " {requested_reviewers}."
     ),
 )
 @click.option(
@@ -843,6 +857,26 @@ def _fetch_pr_bundle(url, fetch_checks, fetch_approvals):
     ),
 )
 @click.option(
+    "--sort",
+    "sort_by",
+    type=click.Choice(
+        ["repo", "age", "updated", "author", "comments", "reviews"],
+        case_sensitive=False,
+    ),
+    default=None,
+    help=(
+        "Sort PRs by field. Choices: repo (default), age, updated,"
+        " author, comments, reviews."
+    ),
+)
+@click.option(
+    "--reverse",
+    "sort_reverse",
+    is_flag=True,
+    default=False,
+    help="Reverse the sort order.",
+)
+@click.option(
     "--api-stats",
     is_flag=True,
     default=False,
@@ -915,6 +949,7 @@ def breakfast(
     json_output,
     markdown_flag,
     output_format,
+    template_str,
     checks,
     approvals,
     head_branch,
@@ -945,6 +980,8 @@ def breakfast(
     colour_diagnostics,
     summarise_user_prs,
     summarise_repo_prs,
+    sort_by,
+    sort_reverse,
 ):
     t0_total = time.monotonic()
     configure_logging()
@@ -1033,11 +1070,12 @@ def breakfast(
             "json",
             "markdown",
             "csv",
+            "template",
         }:
             click.echo(
                 click.style(
                     f"Warning: unrecognised format '{cfg_format}' in config"
-                    " — expected 'table', 'json', 'markdown', or 'csv'."
+                    " — expected 'table', 'json', 'markdown', 'csv', or 'template'."
                     " Falling back to 'table'.",
                     fg="yellow",
                 ),
@@ -1046,6 +1084,7 @@ def breakfast(
             cfg_format = "table"
         fmt = cfg_format or "table"
     json_output = fmt == "json"
+    template_str = template_str if template_str is not None else cfg.get("template")
     checks = checks if checks is not None else cfg.get("checks", False)
     approvals = approvals if approvals is not None else cfg.get("approvals", False)
     head_branch = (
@@ -1077,6 +1116,8 @@ def breakfast(
     seasonal_colours = cfg.get("seasonal-colours", True)
     summarise_user_prs = summarise_user_prs or cfg.get("summarise-user-prs", False)
     summarise_repo_prs = summarise_repo_prs or cfg.get("summarise-repo-prs", False)
+    sort_by = sort_by if sort_by is not None else cfg.get("sort", "repo")
+    sort_reverse = sort_reverse or cfg.get("sort-reverse", False)
 
     if summarise_user_prs and summarise_repo_prs:
         click.echo(
@@ -1565,7 +1606,18 @@ def breakfast(
             err=True,
             color=colour,
         )
-    pr_details.sort(key=lambda pr: pr["base"]["repo"]["name"])
+    _SORT_KEYS = {
+        "repo": lambda pr: pr["base"]["repo"]["name"],
+        "age": lambda pr: get_pr_age_days(pr),
+        "updated": lambda pr: pr.get("updated_at", ""),
+        "author": lambda pr: pr.get("user", {}).get("login", "").lower(),
+        "comments": lambda pr: pr.get("comments", 0) + pr.get("review_comments", 0),
+        "reviews": lambda pr: pr.get("review_comments", 0),
+    }
+    pr_details.sort(
+        key=_SORT_KEYS.get(sort_by or "repo", _SORT_KEYS["repo"]),
+        reverse=sort_reverse,
+    )
     if legendary_only:
         pr_details = [pr for pr in pr_details if is_legendary(pr)]
     if limit is not None:
@@ -1820,6 +1872,66 @@ def breakfast(
             update_msg = check_for_update()
             if update_msg:
                 logger.info("update_available msg=%r", update_msg)
+                click.echo(
+                    click.style(update_msg, fg="cyan", bold=True),
+                    err=True,
+                    color=colour,
+                )
+        if api_stats:
+            _print_debug_summary(
+                t0_total, len(pr_details), get_api_stats(), get_graphql_rate_limit()
+            )
+        return
+
+    if fmt == "template":
+        if not template_str:
+            click.echo(
+                click.style(
+                    "Error: --template is required when using --format template.",
+                    fg="red",
+                    bold=True,
+                ),
+                err=True,
+                color=colour,
+            )
+            sys.exit(1)
+        for pr_detail in pr_details:
+            fields = {
+                "repo": pr_detail["base"]["repo"]["name"],
+                "title": pr_detail.get("title", ""),
+                "author": pr_detail.get("user", {}).get("login", ""),
+                "url": pr_detail.get("html_url", ""),
+                "state": pr_detail.get("state", ""),
+                "number": pr_detail.get("number", ""),
+                "created_at": pr_detail.get("created_at", ""),
+                "updated_at": pr_detail.get("updated_at", ""),
+                "additions": pr_detail.get("additions", 0),
+                "deletions": pr_detail.get("deletions", 0),
+                "changed_files": pr_detail.get("changed_files", 0),
+                "commits": pr_detail.get("commits", 0),
+                "review_comments": pr_detail.get("review_comments", 0),
+                "labels": "|".join(lb["name"] for lb in pr_detail.get("labels", [])),
+                "requested_reviewers": "|".join(
+                    r["login"] for r in pr_detail.get("requested_reviewers", [])
+                ),
+            }
+            try:
+                click.echo(template_str.format_map(fields))
+            except KeyError as e:
+                click.echo(
+                    click.style(
+                        f"Error: unknown template field {e}. "
+                        "See --help for available fields.",
+                        fg="red",
+                        bold=True,
+                    ),
+                    err=True,
+                    color=colour,
+                )
+                sys.exit(1)
+        if not no_update_check:
+            update_msg = check_for_update()
+            if update_msg:
                 click.echo(
                     click.style(update_msg, fg="cyan", bold=True),
                     err=True,

--- a/src/breakfast/config.py
+++ b/src/breakfast/config.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import click
 
+from .api import get_pr_age_days, get_pr_inactive_days
 from .logger import logger
 from .xdg import get_config_dir, get_config_paths
 
@@ -410,6 +411,8 @@ def filter_pr_details(
     filter_reviewer=None,
     filter_label=None,
     exclude_label=None,
+    filter_stale=None,
+    filter_inactive=None,
 ):
     ignore_set = normalize_ignore_authors(ignore_authors)
     current_user_login_normalized = (
@@ -469,6 +472,11 @@ def filter_pr_details(
         if exclude_label:
             pr_labels = {lb["name"].lower() for lb in pr_detail.get("labels", [])}
             if any(lbl.lower() in pr_labels for lbl in exclude_label):
+                continue
+        if filter_stale is not None and get_pr_age_days(pr_detail) < filter_stale:
+            continue
+        if filter_inactive is not None:
+            if get_pr_inactive_days(pr_detail) < filter_inactive:
                 continue
 
         filtered.append(pr_detail)

--- a/src/breakfast/config.py
+++ b/src/breakfast/config.py
@@ -120,8 +120,17 @@ _DEFAULT_CONFIG_CONTENT = """\
 # Output format. "table" renders a coloured terminal table (default).
 # "json" outputs machine-readable JSON — useful for scripting or piping.
 # "markdown" renders a GitHub-flavoured Markdown table — great for pasting into docs.
-# Equivalent to: --format table|json|markdown
+# "csv" outputs comma-separated values for spreadsheet import.
+# "template" renders each PR using a custom format string (see template below).
+# Equivalent to: --format table|json|markdown|csv|template
 # format = "table"
+
+# Custom format string for --format template.
+# Available fields: {repo}, {title}, {author}, {url}, {state}, {number},
+#   {created_at}, {updated_at}, {additions}, {deletions}, {changed_files},
+#   {commits}, {review_comments}, {labels}, {requested_reviewers}
+# Equivalent to: --template <value>
+# template = "{repo}: {title} ({url})"
 
 # How status columns (Checks, Approved, Mergeable?) are rendered.
 #   emoji  — colourful emoji labels, e.g. ✅ pass, ❌ fail  (default)
@@ -211,6 +220,20 @@ _DEFAULT_CONFIG_CONTENT = """\
 # oldest PR age, and total comments per repo.
 # Equivalent to: --summarise-repo-prs
 # summarise-repo-prs = false
+
+
+# -----------------------------------------------------------------------------
+# Sorting
+# Control how the PR list is ordered.
+# -----------------------------------------------------------------------------
+
+# Sort PRs by field. Choices: repo (default), age, updated, author, comments, reviews.
+# Equivalent to: --sort <field>
+# sort = "repo"
+
+# Reverse the sort order.
+# Equivalent to: --reverse
+# sort-reverse = false
 """
 
 

--- a/src/breakfast/config.py
+++ b/src/breakfast/config.py
@@ -49,6 +49,11 @@ _DEFAULT_CONFIG_CONTENT = """\
 # Control which PRs appear in the output.
 # -----------------------------------------------------------------------------
 
+# Which PR states to fetch from GitHub. Default: open.
+# Choices: open, closed, merged, all.
+# Equivalent to: --fetch-state <value>
+# fetch-state = "open"
+
 # Repositories to exclude from results. Supports glob patterns (same syntax as
 # --repo-filter). Useful for hiding archived repos, forks, or internal tooling.
 # Equivalent to: --exclude-repo "old-*" --exclude-repo "infra-*"

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -211,6 +211,25 @@ def _single_page_response(repos):
     }
 
 
+def _single_page_graphql(pr_urls):
+    """Return a one-page GraphQL response with a single repo containing pr_urls."""
+    return {
+        "data": {
+            "organization": {
+                "repositories": {
+                    "nodes": [
+                        {
+                            "name": "repo",
+                            "pullRequests": {"nodes": [{"url": u} for u in pr_urls]},
+                        }
+                    ],
+                    "pageInfo": {"endCursor": None, "hasNextPage": False},
+                }
+            }
+        }
+    }
+
+
 def test_get_github_prs_skips_null_repo_nodes(monkeypatch):
     response = {
         "data": {
@@ -257,6 +276,73 @@ def test_match_exclude_repos_multiple_patterns():
 def test_match_exclude_repos_empty():
     assert api._match_exclude_repos("anything", []) is False
     assert api._match_exclude_repos("anything", None) is False
+
+
+def test_get_github_prs_fetch_state_open_uses_open_enum(monkeypatch):
+    captured = []
+
+    def fake_graphql(query, _variables):
+        captured.append(query)
+        return _single_page_graphql(["https://github.com/org/repo/pull/1"])
+
+    monkeypatch.setattr(api, "make_github_graphql_request", fake_graphql)
+    monkeypatch.setattr(api, "BREAKFAST_ITEMS", ["*"])
+
+    api.get_github_prs("org", "", "open")
+
+    assert "OPEN" in captured[0]
+    assert "CLOSED" not in captured[0]
+    assert "MERGED" not in captured[0]
+
+
+def test_get_github_prs_fetch_state_closed_uses_closed_enum(monkeypatch):
+    captured = []
+
+    def fake_graphql(query, _variables):
+        captured.append(query)
+        return _single_page_graphql([])
+
+    monkeypatch.setattr(api, "make_github_graphql_request", fake_graphql)
+    monkeypatch.setattr(api, "BREAKFAST_ITEMS", ["*"])
+
+    api.get_github_prs("org", "", "closed")
+
+    assert "CLOSED" in captured[0]
+    assert "OPEN" not in captured[0]
+
+
+def test_get_github_prs_fetch_state_all_includes_all_enums(monkeypatch):
+    captured = []
+
+    def fake_graphql(query, _variables):
+        captured.append(query)
+        return _single_page_graphql([])
+
+    monkeypatch.setattr(api, "make_github_graphql_request", fake_graphql)
+    monkeypatch.setattr(api, "BREAKFAST_ITEMS", ["*"])
+
+    api.get_github_prs("org", "", "all")
+
+    assert "OPEN" in captured[0]
+    assert "CLOSED" in captured[0]
+    assert "MERGED" in captured[0]
+
+
+def test_get_github_prs_fetch_state_merged(monkeypatch):
+    captured = []
+
+    def fake_graphql(query, _variables):
+        captured.append(query)
+        return _single_page_graphql([])
+
+    monkeypatch.setattr(api, "make_github_graphql_request", fake_graphql)
+    monkeypatch.setattr(api, "BREAKFAST_ITEMS", ["*"])
+
+    api.get_github_prs("org", "", "merged")
+
+    assert "MERGED" in captured[0]
+    assert "OPEN" not in captured[0]
+    assert "CLOSED" not in captured[0]
 
 
 def test_get_authenticated_user_login(monkeypatch):

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -359,3 +359,74 @@ def test_write_pr_cache_failure_warns_to_stderr(tmp_path, monkeypatch):
     warning_calls = [c for c in echo_calls if "Warning" in str(c[0])]
     assert len(warning_calls) == 1
     assert warning_calls[0][1].get("err") is True
+
+
+# ---------------------------------------------------------------------------
+# per-repo PR cache
+# ---------------------------------------------------------------------------
+
+
+def test_write_then_read_repo_pr_cache_roundtrip(monkeypatch, tmp_path):
+    monkeypatch.setattr(cache, "_CACHE_DIR", tmp_path)
+    prs = [{"number": 1, "id": 101, "title": "hello"}]
+    cache.write_repo_pr_cache("myorg", "myrepo", prs)
+    result = cache.read_repo_pr_cache("myorg", "myrepo", 300)
+    assert result is not None
+    assert result["prs"] == prs
+    assert result["check_statuses"] is None
+    assert result["approval_statuses"] is None
+    assert result["approval_details"] is None
+
+
+def test_write_then_read_repo_pr_cache_with_statuses(monkeypatch, tmp_path):
+    monkeypatch.setattr(cache, "_CACHE_DIR", tmp_path)
+    prs = [{"number": 1, "id": 101}]
+    checks = {101: "pass"}
+    approvals = {101: "approved"}
+    details = {101: {"status": "approved", "current": 1, "required": 1}}
+    cache.write_repo_pr_cache(
+        "myorg",
+        "myrepo",
+        prs,
+        check_statuses=checks,
+        approval_statuses=approvals,
+        approval_details=details,
+    )
+    result = cache.read_repo_pr_cache("myorg", "myrepo", 300)
+    assert result["prs"] == prs
+    assert result["check_statuses"] == checks
+    assert result["approval_statuses"] == approvals
+    assert result["approval_details"] == details
+
+
+def test_read_repo_pr_cache_miss_no_file(monkeypatch, tmp_path):
+    monkeypatch.setattr(cache, "_CACHE_DIR", tmp_path)
+    assert cache.read_repo_pr_cache("myorg", "myrepo", 300) is None
+
+
+def test_read_repo_pr_cache_expired(monkeypatch, tmp_path):
+    monkeypatch.setattr(cache, "_CACHE_DIR", tmp_path)
+    cache.write_repo_pr_cache("myorg", "myrepo", [{"number": 1}])
+    path = cache.repo_pr_cache_path("myorg", "myrepo")
+    data = json.loads(path.read_text())
+    old_time = (datetime.now(timezone.utc) - timedelta(seconds=600)).isoformat()
+    data["fetched_at"] = old_time
+    path.write_text(json.dumps(data))
+    assert cache.read_repo_pr_cache("myorg", "myrepo", 300) is None
+
+
+def test_read_repo_pr_cache_not_expired(monkeypatch, tmp_path):
+    monkeypatch.setattr(cache, "_CACHE_DIR", tmp_path)
+    cache.write_repo_pr_cache("myorg", "myrepo", [{"number": 1}])
+    result = cache.read_repo_pr_cache("myorg", "myrepo", 300)
+    assert result is not None
+
+
+def test_repo_pr_cache_key_differs_from_whole_blob_key(tmp_path, monkeypatch):
+    monkeypatch.setattr(cache, "_CACHE_DIR", tmp_path)
+    # repo_pr_cache_path uses (org, repo_name), not (org, repo_filter)
+    p1 = cache.repo_pr_cache_path("org", "my-repo")
+    p2 = cache.cache_path("org", "my-repo")
+    assert p1 != p2
+    assert p1.name.startswith("pr_repo_")
+    assert p2.name.startswith("prs_")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1559,10 +1559,10 @@ def test_cli_init_config(monkeypatch):
 # ---------------------------------------------------------------------------
 
 
-def _make_pr_detail(number=1):
+def _make_pr_detail(number=1, repo="repo"):
     return {
         "base": {
-            "repo": {"name": "repo", "owner": {"login": "org"}},
+            "repo": {"name": repo, "owner": {"login": "org"}},
             "ref": "main",
         },
         "head": {"sha": "abc123"},
@@ -1577,7 +1577,7 @@ def _make_pr_detail(number=1):
         "commits": 1,
         "review_comments": 0,
         "created_at": "2026-01-10T00:00:00Z",
-        "html_url": f"https://github.com/org/repo/pull/{number}",
+        "html_url": f"https://github.com/org/{repo}/pull/{number}",
         "number": number,
         "id": 1000 + number,
     }
@@ -1889,6 +1889,167 @@ def test_refresh_prs_writes_fresh_pr_cache(monkeypatch, tmp_path):
 
     cached = cache.read_pr_cache("org", "repo", 300)
     assert cached is not None, "--refresh-prs should write fresh data to PR cache"
+
+
+# ---------------------------------------------------------------------------
+# Per-repo PR cache tests
+# ---------------------------------------------------------------------------
+
+
+def test_per_repo_cache_hit_skips_fetch(monkeypatch, tmp_path):
+    """When per-repo cache has a fresh entry, that repo's PRs are not fetched."""
+    monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
+    monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
+    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cache, "_CACHE_DIR", tmp_path)
+    monkeypatch.setattr(cli, "read_repo_pr_cache", cache.read_repo_pr_cache)
+    monkeypatch.setattr(cli, "write_repo_pr_cache", cache.write_repo_pr_cache)
+    monkeypatch.setattr(cli, "read_pr_cache", cache.read_pr_cache)
+    monkeypatch.setattr(cli, "write_pr_cache", cache.write_pr_cache)
+    monkeypatch.setattr(cli, "read_graphql_cache", cache.read_graphql_cache)
+    monkeypatch.setattr(cli, "write_graphql_cache", cache.write_graphql_cache)
+
+    # Pre-populate the GraphQL URL cache and per-repo PR cache
+    cache.write_graphql_cache("org", "repo", ["https://github.com/org/repo/pull/42"])
+    cache.write_repo_pr_cache("org", "repo", [_make_pr_detail(42, repo="repo")])
+
+    fetch_called = []
+    monkeypatch.setattr(cli, "get_github_prs", lambda *a: fetch_called.append(1) or [])
+
+    def _should_not_be_called(_url):
+        raise AssertionError("REST API should not be called on per-repo cache hit")
+
+    monkeypatch.setattr(api, "make_github_api_request", _should_not_be_called)
+
+    runner = CliRunner()
+    result = runner.invoke(cli.breakfast, ["-o", "org", "-r", "repo", "--cache"])
+
+    assert result.exit_code == 0, result.output
+    assert "PR number 42" in result.stdout
+    assert len(fetch_called) == 0
+
+
+def test_per_repo_cache_partial_hit(monkeypatch, tmp_path):
+    """When one repo is cached and another is not, only the uncached repo is fetched."""
+    monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
+    monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
+    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cache, "_CACHE_DIR", tmp_path)
+    monkeypatch.setattr(cli, "read_repo_pr_cache", cache.read_repo_pr_cache)
+    monkeypatch.setattr(cli, "write_repo_pr_cache", cache.write_repo_pr_cache)
+    monkeypatch.setattr(cli, "read_pr_cache", cache.read_pr_cache)
+    monkeypatch.setattr(cli, "write_pr_cache", cache.write_pr_cache)
+    monkeypatch.setattr(cli, "read_graphql_cache", cache.read_graphql_cache)
+    monkeypatch.setattr(cli, "write_graphql_cache", cache.write_graphql_cache)
+
+    # repo-a is cached, repo-b is not
+    cache.write_graphql_cache(
+        "org",
+        "",
+        [
+            "https://github.com/org/repo-a/pull/1",
+            "https://github.com/org/repo-b/pull/2",
+        ],
+    )
+    cache.write_repo_pr_cache("org", "repo-a", [_make_pr_detail(1, repo="repo-a")])
+
+    fetched_urls = []
+
+    def fake_rest(url):
+        # _fetch_pr_detail converts https://github.com/org/repo-b/pull/2 →
+        # /repos/org/repo-b/pulls/2
+        fetched_urls.append(url)
+        if "repo-b" in url and "2" in url:
+            return _make_pr_detail(2, repo="repo-b")
+        raise AssertionError(f"unexpected REST URL: {url}")
+
+    monkeypatch.setattr(cli, "get_github_prs", lambda *a: [])
+    monkeypatch.setattr(api, "make_github_api_request", fake_rest)
+
+    runner = CliRunner()
+    result = runner.invoke(cli.breakfast, ["-o", "org", "-r", "", "--cache"])
+
+    assert result.exit_code == 0, result.output
+    assert "PR number 1" in result.stdout
+    assert "PR number 2" in result.stdout
+    # Only repo-b's PR should have been fetched via REST
+    assert any("repo-b" in u for u in fetched_urls)
+    assert not any("repo-a" in u for u in fetched_urls)
+
+
+def test_per_repo_cache_writes_after_fetch(monkeypatch, tmp_path):
+    """After fetching fresh PRs, a per-repo cache file is written for each repo."""
+    monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
+    monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
+    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cache, "_CACHE_DIR", tmp_path)
+    monkeypatch.setattr(cli, "read_repo_pr_cache", cache.read_repo_pr_cache)
+    monkeypatch.setattr(cli, "write_repo_pr_cache", cache.write_repo_pr_cache)
+    monkeypatch.setattr(cli, "read_pr_cache", cache.read_pr_cache)
+    monkeypatch.setattr(cli, "write_pr_cache", cache.write_pr_cache)
+
+    monkeypatch.setattr(
+        cli,
+        "get_github_prs",
+        lambda *a: ["https://github.com/org/myrepo/pull/7"],
+    )
+    monkeypatch.setattr(
+        api,
+        "make_github_api_request",
+        lambda _: _make_pr_detail(7, repo="myrepo"),
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(cli.breakfast, ["-o", "org", "-r", "myrepo", "--cache"])
+
+    assert result.exit_code == 0, result.output
+    cached = cache.read_repo_pr_cache("org", "myrepo", 300)
+    assert cached is not None, "per-repo cache should be written after fetch"
+    assert len(cached["prs"]) == 1
+    assert cached["prs"][0]["number"] == 7
+
+
+def test_per_repo_cache_expired_triggers_refetch(monkeypatch, tmp_path):
+    """An expired per-repo cache entry causes a fresh fetch for that repo."""
+    import json as _json
+    from datetime import timedelta
+
+    monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
+    monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
+    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cache, "_CACHE_DIR", tmp_path)
+    monkeypatch.setattr(cli, "read_repo_pr_cache", cache.read_repo_pr_cache)
+    monkeypatch.setattr(cli, "write_repo_pr_cache", cache.write_repo_pr_cache)
+    monkeypatch.setattr(cli, "read_pr_cache", cache.read_pr_cache)
+    monkeypatch.setattr(cli, "write_pr_cache", cache.write_pr_cache)
+    monkeypatch.setattr(cli, "read_graphql_cache", cache.read_graphql_cache)
+    monkeypatch.setattr(cli, "write_graphql_cache", cache.write_graphql_cache)
+
+    # Write per-repo cache, then backdate it to expire
+    cache.write_graphql_cache("org", "repo", ["https://github.com/org/repo/pull/5"])
+    cache.write_repo_pr_cache("org", "repo", [_make_pr_detail(99, repo="repo")])
+    path = cache.repo_pr_cache_path("org", "repo")
+    data = _json.loads(path.read_text())
+    from datetime import datetime, timezone
+
+    old_time = (datetime.now(timezone.utc) - timedelta(seconds=600)).isoformat()
+    data["fetched_at"] = old_time
+    path.write_text(_json.dumps(data))
+
+    fetch_calls = []
+    monkeypatch.setattr(cli, "get_github_prs", lambda *a: [])
+    monkeypatch.setattr(
+        api,
+        "make_github_api_request",
+        lambda _: fetch_calls.append(1) or _make_pr_detail(5, repo="repo"),
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(cli.breakfast, ["-o", "org", "-r", "repo", "--cache"])
+
+    assert result.exit_code == 0, result.output
+    assert len(fetch_calls) >= 1, "expired per-repo cache should trigger a fresh fetch"
+    assert "PR number 5" in result.stdout
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3347,6 +3347,196 @@ def test_group_prs_by_sums_both_comment_fields():
 
 
 # ---------------------------------------------------------------------------
+# --sort / --reverse tests
+# ---------------------------------------------------------------------------
+
+
+def _make_sort_pr(number, repo, author, created_at, updated_at, comments=0):
+    return {
+        "base": {
+            "repo": {"name": repo, "owner": {"login": "org"}},
+            "ref": "main",
+        },
+        "head": {"sha": "abc123"},
+        "mergeable": True,
+        "mergeable_state": "clean",
+        "additions": 1,
+        "deletions": 0,
+        "title": f"PR {number}",
+        "user": {"login": author},
+        "state": "open",
+        "draft": False,
+        "changed_files": 1,
+        "commits": 1,
+        "comments": comments,
+        "review_comments": comments,
+        "created_at": created_at,
+        "updated_at": updated_at,
+        "html_url": f"https://github.com/org/{repo}/pull/{number}",
+        "number": number,
+        "id": 2000 + number,
+        "labels": [],
+        "requested_reviewers": [],
+    }
+
+
+def _sort_invoke(monkeypatch, prs, *extra_args):
+    monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "tok")
+    monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
+    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    pr_by_url = {pr["html_url"]: pr for pr in prs}
+
+    def _fake_api(path):
+        # path looks like /repos/org/repo/pulls/N — map back to the PR
+        for pr in prs:
+            parts = pr["html_url"].split("/")
+            owner, repo_name, num = parts[-4], parts[-3], parts[-1]
+            if path == f"/repos/{owner}/{repo_name}/pulls/{num}":
+                return pr
+        raise KeyError(path)
+
+    monkeypatch.setattr(cli, "get_github_prs", lambda *_: list(pr_by_url))
+    monkeypatch.setattr(api, "make_github_api_request", _fake_api)
+    runner = CliRunner()
+    return runner.invoke(cli.breakfast, ["-o", "org", *extra_args])
+
+
+_TS_A = "2025-01-01T00:00:00Z"
+_TS_B = "2025-06-01T00:00:00Z"
+_TS_OLD = "2024-01-01T00:00:00Z"
+
+
+def test_sort_default_by_repo(monkeypatch):
+    prs = [
+        _make_sort_pr(1, "zebra", "alice", _TS_A, _TS_B),
+        _make_sort_pr(2, "alpha", "bob", _TS_A, _TS_A),
+    ]
+    result = _sort_invoke(monkeypatch, prs)
+    assert result.exit_code == 0
+    assert result.stdout.index("alpha") < result.stdout.index("zebra")
+
+
+def test_sort_by_age(monkeypatch):
+    prs = [
+        _make_sort_pr(1, "repo", "alice", _TS_B, _TS_B),
+        _make_sort_pr(2, "repo", "bob", _TS_OLD, _TS_OLD),
+    ]
+    result = _sort_invoke(monkeypatch, prs, "--sort", "age", "--age")
+    assert result.exit_code == 0
+    # ascending age: newest PR (smallest age in days) first
+    assert result.stdout.index("PR 1") < result.stdout.index("PR 2")
+
+
+def test_sort_by_age_reverse(monkeypatch):
+    prs = [
+        _make_sort_pr(1, "repo", "alice", _TS_B, _TS_B),
+        _make_sort_pr(2, "repo", "bob", _TS_OLD, _TS_OLD),
+    ]
+    result = _sort_invoke(monkeypatch, prs, "--sort", "age", "--reverse", "--age")
+    assert result.exit_code == 0
+    # reversed: oldest PR (most days) first
+    assert result.stdout.index("PR 2") < result.stdout.index("PR 1")
+
+
+def test_sort_by_author(monkeypatch):
+    prs = [
+        _make_sort_pr(1, "repo", "zara", _TS_A, _TS_A),
+        _make_sort_pr(2, "repo", "alice", _TS_A, _TS_A),
+    ]
+    result = _sort_invoke(monkeypatch, prs, "--sort", "author")
+    assert result.exit_code == 0
+    assert result.stdout.index("alice") < result.stdout.index("zara")
+
+
+def test_sort_reverse(monkeypatch):
+    prs = [
+        _make_sort_pr(1, "alpha", "alice", _TS_A, _TS_A),
+        _make_sort_pr(2, "zebra", "bob", _TS_A, _TS_A),
+    ]
+    result = _sort_invoke(monkeypatch, prs, "--sort", "repo", "--reverse")
+    assert result.exit_code == 0
+    assert result.stdout.index("zebra") < result.stdout.index("alpha")
+
+
+# ---------------------------------------------------------------------------
+# --format template (#183)
+# ---------------------------------------------------------------------------
+
+
+def test_format_template_basic(monkeypatch):
+    monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "tok")
+    monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
+    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(
+        cli, "get_github_prs", lambda *_: ["https://github.com/org/repo/pull/1"]
+    )
+    monkeypatch.setattr(api, "make_github_api_request", _fake_pr_detail)
+
+    result = CliRunner().invoke(
+        cli.breakfast,
+        ["-o", "org", "--format", "template", "--template", "{repo}:{title}"],
+    )
+
+    assert result.exit_code == 0
+    assert "repo:My PR" in result.stdout
+
+
+def test_format_template_output_to_stdout(monkeypatch):
+    monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "tok")
+    monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
+    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(
+        cli, "get_github_prs", lambda *_: ["https://github.com/org/repo/pull/1"]
+    )
+    monkeypatch.setattr(api, "make_github_api_request", _fake_pr_detail)
+
+    result = CliRunner().invoke(
+        cli.breakfast,
+        ["-o", "org", "--format", "template", "--template", "{url}"],
+    )
+
+    assert result.exit_code == 0
+    assert "https://github.com/org/repo/pull/1" in result.stdout
+    assert "https://github.com/org/repo/pull/1" not in result.stderr
+
+
+def test_format_template_missing_template_string_exits(monkeypatch):
+    monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "tok")
+    monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
+    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(
+        cli, "get_github_prs", lambda *_: ["https://github.com/org/repo/pull/1"]
+    )
+    monkeypatch.setattr(api, "make_github_api_request", _fake_pr_detail)
+
+    result = CliRunner().invoke(
+        cli.breakfast,
+        ["-o", "org", "--format", "template"],
+    )
+
+    assert result.exit_code == 1
+    assert "--template" in result.stderr
+
+
+def test_format_template_unknown_field_exits(monkeypatch):
+    monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "tok")
+    monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
+    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(
+        cli, "get_github_prs", lambda *_: ["https://github.com/org/repo/pull/1"]
+    )
+    monkeypatch.setattr(api, "make_github_api_request", _fake_pr_detail)
+
+    result = CliRunner().invoke(
+        cli.breakfast,
+        ["-o", "org", "--format", "template", "--template", "{nonexistent_field}"],
+    )
+
+    assert result.exit_code == 1
+    assert "nonexistent_field" in result.stderr
+
+
+# ---------------------------------------------------------------------------
 # Multiple organizations (#62)
 # ---------------------------------------------------------------------------
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -68,7 +68,7 @@ def test_cli_outputs_table(monkeypatch):
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
     monkeypatch.setattr(cli, "check_for_update", lambda: None)
 
-    def fake_get_prs(_org, _repo_filter):
+    def fake_get_prs(_org, _repo_filter, _state="open"):
         return ["https://github.com/org/repo/pull/1"]
 
     def fake_api_request(_path):
@@ -106,7 +106,7 @@ def test_cli_outputs_age_column_when_enabled(monkeypatch):
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
     monkeypatch.setattr(cli, "check_for_update", lambda: None)
 
-    def fake_get_prs(_org, _repo_filter):
+    def fake_get_prs(_org, _repo_filter, _state="open"):
         return ["https://github.com/org/repo/pull/1"]
 
     def fake_api_request(_path):
@@ -169,7 +169,7 @@ def test_cli_outputs_head_branch_column_when_enabled(monkeypatch):
     monkeypatch.setattr(
         cli,
         "get_github_prs",
-        lambda _org, _repo_filter: ["https://github.com/org/repo/pull/1"],
+        lambda _org, _repo_filter, _s="open": ["https://github.com/org/repo/pull/1"],
     )
     monkeypatch.setattr(
         api,
@@ -192,7 +192,7 @@ def test_cli_outputs_base_branch_column_when_enabled(monkeypatch):
     monkeypatch.setattr(
         cli,
         "get_github_prs",
-        lambda _org, _repo_filter: ["https://github.com/org/repo/pull/1"],
+        lambda _org, _repo_filter, _s="open": ["https://github.com/org/repo/pull/1"],
     )
     monkeypatch.setattr(
         api,
@@ -215,7 +215,7 @@ def test_cli_head_and_base_branch_hidden_by_default(monkeypatch):
     monkeypatch.setattr(
         cli,
         "get_github_prs",
-        lambda _org, _repo_filter: ["https://github.com/org/repo/pull/1"],
+        lambda _org, _repo_filter, _s="open": ["https://github.com/org/repo/pull/1"],
     )
     monkeypatch.setattr(
         api,
@@ -236,7 +236,7 @@ def test_cli_outputs_json(monkeypatch):
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
     monkeypatch.setattr(cli, "check_for_update", lambda: None)
 
-    def fake_get_prs(_org, _repo_filter):
+    def fake_get_prs(_org, _repo_filter, _state="open"):
         return ["https://github.com/org/repo/pull/1"]
 
     def fake_api_request(_path):
@@ -287,7 +287,7 @@ def test_cli_outputs_json(monkeypatch):
 def test_cli_json_output_is_valid_json_when_empty(monkeypatch):
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "get_github_prs", lambda _org, _repo: [])
+    monkeypatch.setattr(cli, "get_github_prs", lambda _org, _repo, _state="open": [])
     monkeypatch.setattr(cli, "check_for_update", lambda: None)
 
     runner = CliRunner()
@@ -302,7 +302,7 @@ def test_cli_continues_when_one_pr_fetch_fails(monkeypatch):
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
     monkeypatch.setattr(cli, "check_for_update", lambda: None)
 
-    def fake_get_prs(_org, _repo_filter):
+    def fake_get_prs(_org, _repo_filter, _state="open"):
         return [
             "https://github.com/org/repo/pull/1",
             "https://github.com/org/repo/pull/2",
@@ -354,7 +354,7 @@ def test_cli_mine_only_filters_to_authenticated_user(monkeypatch):
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
     monkeypatch.setattr(cli, "check_for_update", lambda: None)
 
-    def fake_get_prs(_org, _repo_filter):
+    def fake_get_prs(_org, _repo_filter, _state="open"):
         return [
             "https://github.com/org/repo/pull/1",
             "https://github.com/org/repo/pull/2",
@@ -421,7 +421,7 @@ def test_cli_outputs_checks_column(monkeypatch):
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
     monkeypatch.setattr(cli, "check_for_update", lambda: None)
 
-    def fake_get_prs(_org, _repo_filter):
+    def fake_get_prs(_org, _repo_filter, _state="open"):
         return ["https://github.com/org/repo/pull/1"]
 
     def fake_api_request(path):
@@ -472,7 +472,7 @@ def test_cli_checks_no_collision_across_repos(monkeypatch):
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
     monkeypatch.setattr(cli, "check_for_update", lambda: None)
 
-    def fake_get_prs(_org, _repo_filter):
+    def fake_get_prs(_org, _repo_filter, _state="open"):
         return [
             "https://github.com/org/repo-a/pull/17",
             "https://github.com/org/repo-b/pull/17",
@@ -549,7 +549,7 @@ def test_cli_checks_not_shown_by_default(monkeypatch):
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
     monkeypatch.setattr(cli, "check_for_update", lambda: None)
 
-    def fake_get_prs(_org, _repo_filter):
+    def fake_get_prs(_org, _repo_filter, _state="open"):
         return ["https://github.com/org/repo/pull/1"]
 
     def fake_api_request(_path):
@@ -601,7 +601,7 @@ def test_cli_json_includes_checks_when_enabled(monkeypatch):
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
     monkeypatch.setattr(cli, "check_for_update", lambda: None)
 
-    def fake_get_prs(_org, _repo_filter):
+    def fake_get_prs(_org, _repo_filter, _state="open"):
         return ["https://github.com/org/repo/pull/1"]
 
     def fake_api_request(path):
@@ -657,7 +657,7 @@ def test_cli_json_excludes_checks_by_default(monkeypatch):
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
     monkeypatch.setattr(cli, "check_for_update", lambda: None)
 
-    def fake_get_prs(_org, _repo_filter):
+    def fake_get_prs(_org, _repo_filter, _state="open"):
         return ["https://github.com/org/repo/pull/1"]
 
     def fake_api_request(_path):
@@ -731,7 +731,7 @@ def test_cli_outputs_approvals_column(monkeypatch):
 
     pr_detail = _make_pr_detail()
 
-    def fake_get_prs(_org, _repo_filter):
+    def fake_get_prs(_org, _repo_filter, _state="open"):
         return ["https://github.com/org/repo/pull/1"]
 
     def fake_api_request(path):
@@ -767,7 +767,7 @@ def test_cli_renders_review_required_for_incomplete_reviews(monkeypatch):
     monkeypatch.setattr(
         cli,
         "get_github_prs",
-        lambda _org, _repo_filter: ["https://github.com/org/repo/pull/1"],
+        lambda _org, _repo_filter, _s="open": ["https://github.com/org/repo/pull/1"],
     )
 
     def fake_api_request(path):
@@ -810,7 +810,7 @@ def test_cli_renders_approval_counts_for_multi_review_branch(monkeypatch):
     monkeypatch.setattr(
         cli,
         "get_github_prs",
-        lambda _org, _repo_filter: ["https://github.com/org/repo/pull/1"],
+        lambda _org, _repo_filter, _s="open": ["https://github.com/org/repo/pull/1"],
     )
     monkeypatch.setattr(api, "make_github_api_request", fake_api_request)
     monkeypatch.setattr(
@@ -838,7 +838,9 @@ def test_cli_approvals_not_shown_by_default(monkeypatch):
     pr_detail = _make_pr_detail()
 
     monkeypatch.setattr(
-        cli, "get_github_prs", lambda _o, _r: ["https://github.com/org/repo/pull/1"]
+        cli,
+        "get_github_prs",
+        lambda _o, _r, _s="open": ["https://github.com/org/repo/pull/1"],
     )
     monkeypatch.setattr(api, "make_github_api_request", lambda _path: pr_detail)
 
@@ -862,7 +864,9 @@ def test_cli_json_includes_approval_when_enabled(monkeypatch):
         return pr_detail
 
     monkeypatch.setattr(
-        cli, "get_github_prs", lambda _o, _r: ["https://github.com/org/repo/pull/1"]
+        cli,
+        "get_github_prs",
+        lambda _o, _r, _s="open": ["https://github.com/org/repo/pull/1"],
     )
     monkeypatch.setattr(api, "make_github_api_request", fake_api_request)
     monkeypatch.setattr(
@@ -900,7 +904,9 @@ def test_cli_json_includes_approval_counts_when_available(monkeypatch):
         return pr_detail
 
     monkeypatch.setattr(
-        cli, "get_github_prs", lambda _o, _r: ["https://github.com/org/repo/pull/1"]
+        cli,
+        "get_github_prs",
+        lambda _o, _r, _s="open": ["https://github.com/org/repo/pull/1"],
     )
     monkeypatch.setattr(api, "make_github_api_request", fake_api_request)
     monkeypatch.setattr(
@@ -933,7 +939,9 @@ def test_cli_json_excludes_approval_by_default(monkeypatch):
     pr_detail = _make_pr_detail()
 
     monkeypatch.setattr(
-        cli, "get_github_prs", lambda _o, _r: ["https://github.com/org/repo/pull/1"]
+        cli,
+        "get_github_prs",
+        lambda _o, _r, _s="open": ["https://github.com/org/repo/pull/1"],
     )
     monkeypatch.setattr(api, "make_github_api_request", lambda _path: pr_detail)
 
@@ -961,7 +969,7 @@ def test_cli_approvals_config_file(tmp_path):
 def test_no_update_check_flag_skips_update(monkeypatch):
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "get_github_prs", lambda _o, _r: [])
+    monkeypatch.setattr(cli, "get_github_prs", lambda _o, _r, _s="open": [])
     check_called = []
     monkeypatch.setattr(
         cli,
@@ -982,7 +990,7 @@ def test_no_update_check_flag_skips_update(monkeypatch):
 def test_no_update_check_env_var(monkeypatch):
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "get_github_prs", lambda _o, _r: [])
+    monkeypatch.setattr(cli, "get_github_prs", lambda _o, _r, _s="open": [])
     monkeypatch.setenv("BREAKFAST_NO_UPDATE_CHECK", "1")
     check_called = []
     monkeypatch.setattr(
@@ -1011,7 +1019,7 @@ def test_cli_exclude_repo_filtering(monkeypatch):
         "https://github.com/org/exclude-me/pull/2",
         "https://github.com/malformed-url-no-repo",
     ]
-    monkeypatch.setattr(cli, "get_github_prs", lambda _o, _r: mock_urls)
+    monkeypatch.setattr(cli, "get_github_prs", lambda _o, _r, _s="open": mock_urls)
 
     fetched_urls = []
 
@@ -1057,7 +1065,7 @@ def test_cli_truncates_title_when_max_title_length_set(monkeypatch):
 
     long_title = "A" * 100
 
-    def fake_get_prs(_org, _repo_filter):
+    def fake_get_prs(_org, _repo_filter, _state="open"):
         return ["https://github.com/org/repo/pull/1"]
 
     def fake_api_request(_path):
@@ -1098,7 +1106,7 @@ def test_cli_does_not_truncate_title_when_max_title_length_unset(monkeypatch):
 
     long_title = "A" * 100
 
-    def fake_get_prs(_org, _repo_filter):
+    def fake_get_prs(_org, _repo_filter, _state="open"):
         return ["https://github.com/org/repo/pull/1"]
 
     def fake_api_request(_path):
@@ -1134,7 +1142,7 @@ def test_cli_limit_caps_results(monkeypatch):
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
     monkeypatch.setattr(cli, "check_for_update", lambda: None)
 
-    def fake_get_prs(_org, _repo_filter):
+    def fake_get_prs(_org, _repo_filter, _state="open"):
         return [f"https://github.com/org/repo/pull/{i}" for i in range(1, 6)]
 
     def fake_api_request(path):
@@ -1259,7 +1267,7 @@ def test_cli_status_columns_use_ascii_to_keep_rows_aligned(monkeypatch):
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
     monkeypatch.setattr(cli, "check_for_update", lambda: None)
 
-    def fake_get_prs(_org, _repo_filter):
+    def fake_get_prs(_org, _repo_filter, _state="open"):
         return [
             "https://github.com/org/repo/pull/1",
             "https://github.com/org/repo/pull/2",
@@ -1338,7 +1346,9 @@ def test_auto_fit_truncates_title_to_terminal_width(monkeypatch):
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
     monkeypatch.setattr(cli, "check_for_update", lambda: None)
     monkeypatch.setattr(
-        cli, "get_github_prs", lambda _o, _r: ["https://github.com/org/repo/pull/1"]
+        cli,
+        "get_github_prs",
+        lambda _o, _r, _s="open": ["https://github.com/org/repo/pull/1"],
     )
     monkeypatch.setattr(
         api, "make_github_api_request", lambda _: _make_pr_fixture(title="A" * 200)
@@ -1360,7 +1370,9 @@ def test_auto_fit_skips_truncation_when_title_fits(monkeypatch):
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
     monkeypatch.setattr(cli, "check_for_update", lambda: None)
     monkeypatch.setattr(
-        cli, "get_github_prs", lambda _o, _r: ["https://github.com/org/repo/pull/1"]
+        cli,
+        "get_github_prs",
+        lambda _o, _r, _s="open": ["https://github.com/org/repo/pull/1"],
     )
     monkeypatch.setattr(
         api, "make_github_api_request", lambda _: _make_pr_fixture(title="Short title")
@@ -1381,7 +1393,9 @@ def test_auto_fit_truncates_repo_and_author_before_dropping(monkeypatch):
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
     monkeypatch.setattr(cli, "check_for_update", lambda: None)
     monkeypatch.setattr(
-        cli, "get_github_prs", lambda _o, _r: ["https://github.com/org/repo/pull/1"]
+        cli,
+        "get_github_prs",
+        lambda _o, _r, _s="open": ["https://github.com/org/repo/pull/1"],
     )
 
     def fake_api(_path):
@@ -1411,7 +1425,9 @@ def test_auto_fit_compresses_mergeable_before_dropping(monkeypatch):
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
     monkeypatch.setattr(cli, "check_for_update", lambda: None)
     monkeypatch.setattr(
-        cli, "get_github_prs", lambda _o, _r: ["https://github.com/org/repo/pull/1"]
+        cli,
+        "get_github_prs",
+        lambda _o, _r, _s="open": ["https://github.com/org/repo/pull/1"],
     )
     monkeypatch.setattr(api, "make_github_api_request", lambda _: _make_pr_fixture())
 
@@ -1478,7 +1494,9 @@ def test_auto_fit_drops_columns_when_very_narrow(monkeypatch):
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
     monkeypatch.setattr(cli, "check_for_update", lambda: None)
     monkeypatch.setattr(
-        cli, "get_github_prs", lambda _o, _r: ["https://github.com/org/repo/pull/1"]
+        cli,
+        "get_github_prs",
+        lambda _o, _r, _s="open": ["https://github.com/org/repo/pull/1"],
     )
     monkeypatch.setattr(api, "make_github_api_request", lambda _: _make_pr_fixture())
 
@@ -1499,7 +1517,9 @@ def test_auto_fit_noop_when_not_tty(monkeypatch):
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
     monkeypatch.setattr(cli, "check_for_update", lambda: None)
     monkeypatch.setattr(
-        cli, "get_github_prs", lambda _o, _r: ["https://github.com/org/repo/pull/1"]
+        cli,
+        "get_github_prs",
+        lambda _o, _r, _s="open": ["https://github.com/org/repo/pull/1"],
     )
     monkeypatch.setattr(
         api, "make_github_api_request", lambda _: _make_pr_fixture(title="A" * 200)
@@ -1518,7 +1538,9 @@ def test_explicit_max_title_length_overrides_auto_fit(monkeypatch):
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
     monkeypatch.setattr(cli, "check_for_update", lambda: None)
     monkeypatch.setattr(
-        cli, "get_github_prs", lambda _o, _r: ["https://github.com/org/repo/pull/1"]
+        cli,
+        "get_github_prs",
+        lambda _o, _r, _s="open": ["https://github.com/org/repo/pull/1"],
     )
     monkeypatch.setattr(
         api, "make_github_api_request", lambda _: _make_pr_fixture(title="A" * 100)
@@ -1618,7 +1640,7 @@ def test_no_cache_flag_always_fetches(monkeypatch, tmp_path):
 
     api_called = []
 
-    def fake_get_prs(_org, _repo):
+    def fake_get_prs(_org, _repo, _s="open"):
         api_called.append(1)
         return ["https://github.com/org/repo/pull/1"]
 
@@ -2518,7 +2540,7 @@ def test_debug_flag_prints_summary_to_stderr(monkeypatch):
         },
     )
 
-    def fake_get_prs(_org, _repo_filter):
+    def fake_get_prs(_org, _repo_filter, _state="open"):
         return ["https://github.com/org/repo/pull/1"]
 
     def fake_api_request(_path):
@@ -3419,7 +3441,7 @@ def test_multiple_repo_filters_includes_matching_prs(monkeypatch):
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
     monkeypatch.setattr(cli, "check_for_update", lambda: None)
 
-    def fake_get_prs(_org, repo_filters):
+    def fake_get_prs(_org, repo_filters, _state="open"):
         assert set(repo_filters) == {"api", "platform"}
         return [
             "https://github.com/org/api-gateway/pull/1",
@@ -3461,7 +3483,7 @@ def test_multiple_repo_filters_config_list(monkeypatch, tmp_path):
 
     captured = []
 
-    def fake_get_prs(_org, repo_filters):
+    def fake_get_prs(_org, repo_filters, _state="open"):
         captured.extend(repo_filters)
         return []
 
@@ -3504,7 +3526,7 @@ def test_scoped_filter_overrides_global_repo_filter(monkeypatch):
 
     captured = {}
 
-    def fake_get_prs(org, repo_filters):
+    def fake_get_prs(org, repo_filters, _state="open"):
         captured[org] = list(repo_filters)
         return []
 
@@ -3524,7 +3546,7 @@ def test_empty_scoped_filter_matches_all_ignoring_global(monkeypatch):
 
     captured = {}
 
-    def fake_get_prs(org, repo_filters):
+    def fake_get_prs(org, repo_filters, _state="open"):
         captured[org] = list(repo_filters)
         return []
 
@@ -3544,7 +3566,7 @@ def test_mixed_scoped_and_global_filters(monkeypatch):
 
     captured = {}
 
-    def fake_get_prs(org, repo_filters):
+    def fake_get_prs(org, repo_filters, _state="open"):
         captured[org] = list(repo_filters)
         return []
 
@@ -3570,7 +3592,7 @@ def test_scoped_filter_from_config(monkeypatch, tmp_path):
 
     captured = {}
 
-    def fake_get_prs(org, repo_filters):
+    def fake_get_prs(org, repo_filters, _state="open"):
         captured[org] = list(repo_filters)
         return []
 
@@ -3638,7 +3660,7 @@ def test_cli_duplicate_org_fetches_prevented(monkeypatch):
 
     calls = []
 
-    def fake_get_prs(org, repo_filters):
+    def fake_get_prs(org, repo_filters, _state="open"):
         filters = list(repo_filters) if repo_filters is not None else None
         calls.append((org, filters))
         return []

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -306,6 +306,62 @@ def test_filter_pr_details_exclude_label_case_insensitive():
     assert [r["id"] for r in result] == [2]
 
 
+def _make_pr_dated(pr_id, created_at, updated_at):
+    return {
+        "id": pr_id,
+        "user": {"login": "alice"},
+        "state": "open",
+        "created_at": created_at,
+        "updated_at": updated_at,
+        "base": {"repo": {"name": "repo"}},
+        "number": pr_id,
+    }
+
+
+def test_filter_pr_details_filter_stale():
+    pr_details = [
+        _make_pr_dated(1, "2020-01-01T00:00:00Z", "2020-01-02T00:00:00Z"),
+        _make_pr_dated(2, "2099-12-31T00:00:00Z", "2099-12-31T00:00:00Z"),
+    ]
+
+    result = config.filter_pr_details(pr_details, [], filter_stale=7)
+    assert [r["id"] for r in result] == [1]
+
+
+def test_filter_pr_details_filter_stale_boundary():
+    pr_details = [
+        _make_pr_dated(1, "2020-01-01T00:00:00Z", "2020-01-01T00:00:00Z"),
+    ]
+    result_old = config.filter_pr_details(pr_details, [], filter_stale=1)
+    assert len(result_old) == 1
+
+    result_not_old_enough = config.filter_pr_details(
+        pr_details, [], filter_stale=999999
+    )
+    assert len(result_not_old_enough) == 0
+
+
+def test_filter_pr_details_filter_inactive():
+    pr_details = [
+        _make_pr_dated(1, "2020-01-01T00:00:00Z", "2020-01-02T00:00:00Z"),
+        _make_pr_dated(2, "2020-01-01T00:00:00Z", "2099-12-31T00:00:00Z"),
+    ]
+
+    result = config.filter_pr_details(pr_details, [], filter_inactive=7)
+    assert [r["id"] for r in result] == [1]
+
+
+def test_filter_pr_details_stale_and_inactive_combined():
+    pr_details = [
+        _make_pr_dated(1, "2020-01-01T00:00:00Z", "2020-01-02T00:00:00Z"),
+        _make_pr_dated(2, "2020-01-01T00:00:00Z", "2099-12-31T00:00:00Z"),
+        _make_pr_dated(3, "2099-12-31T00:00:00Z", "2020-01-01T00:00:00Z"),
+    ]
+
+    result = config.filter_pr_details(pr_details, [], filter_stale=7, filter_inactive=7)
+    assert [r["id"] for r in result] == [1]
+
+
 def test_get_config_dir_xdg(tmp_path, monkeypatch):
     custom_path = tmp_path / "custom-xdg"
     monkeypatch.setenv("XDG_CONFIG_HOME", str(custom_path))


### PR DESCRIPTION
## Summary

- Adds a new cache layer (2.5) between GraphQL URL list and PR detail fetch
- PR URLs are grouped by repo name (parsed from the GitHub HTML URL)
- Repos with a fresh per-repo cache entry skip REST fetching; stale or absent repos are fetched fresh
- Per-repo cache files (`pr_repo_*.json`) are written after each fetch, storing PR details plus check/approval statuses when available
- When ALL repos are from per-repo cache, the existing cached-statuses path handles check/approval re-fetch if needed
- Backward compatible: whole-blob `prs_*.json` cache still written alongside

## Test plan

- [ ] `make format && make lint && make test` passes (344 tests)
- [ ] `test_per_repo_cache_hit_skips_fetch` — full cache hit avoids REST calls
- [ ] `test_per_repo_cache_partial_hit` — only uncached repos are fetched
- [ ] `test_per_repo_cache_writes_after_fetch` — cache file written for fetched repos
- [ ] `test_per_repo_cache_expired_triggers_refetch` — expired entry triggers fresh fetch
- [ ] 5 new cache unit tests for `read_repo_pr_cache`/`write_repo_pr_cache`

Closes #103

🤖 Generated with [Claude Code](https://claude.com/claude-code)