### PR TITLE
#79: Add release summary to update notifications

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -27,7 +27,8 @@ When updating project rules, update **all four files** to keep them consistent.
 4. **PR Titles:** Include the issue number: `#N: Description` (e.g., `#42: Add Avocado Toast output`).
 5. **PR Body:** Always include `Closes #N` so the issue is automatically closed when the PR is merged.
 6. **CI Checks:** After pushing to a branch with an open PR, wait for all CI checks to complete (`gh pr checks`). If any check fails, investigate and fix the root cause — do not ignore failures or proceed without understanding them.
-7. **Conventional Git Commits:** Use standard prefixes for git commits: `feat:`, `fix:`, `chore:`, `docs:`, `refactor:`, `test:`, `ci:`.
+7. **Release notes format:** Releases are created by CI via `gh release create --generate-notes`. If editing release notes manually (e.g. via the GitHub UI), use bullet points (`- item`) for each change. The `update-summary` feature extracts the first three bullets, strips Markdown headers and URLs, and caps at 200 characters — prose paragraphs at the top of the body produce poor summaries.
+8. **Conventional Git Commits:** Use standard prefixes for git commits: `feat:`, `fix:`, `chore:`, `docs:`, `refactor:`, `test:`, `ci:`.
 
 ## Tooling & Environment
 - **Python:** >= 3.11

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,6 +76,8 @@ When updating project rules, update **all four files** to keep them consistent.
 - On merges to `main`, create a release and tag; ensure the version is bumped before release.
 - Add a sanity check: if a tag already exists for the current version, run `git mkver patch` to bump it before releasing.
 - Prefer using Makefile targets for CI steps (add targets as needed to keep local/CI workflows consistent).
+- Releases are created by CI via `gh release create --generate-notes`, which auto-formats merged PR titles as `* title by @author in <URL>` bullets.
+- **Release notes format:** The `update-summary` feature reads the release body and extracts the first three bullet points (`- ` or `* `), strips Markdown headers and URLs, and caps output at 200 characters. If editing release notes manually (e.g. via the GitHub UI), use clean bullet points so `update-summary` renders useful output — avoid prose paragraphs at the top of the body.
 
 ## Code Quality
 - Use `ruff` (lint + import sorting) and `black` (formatting).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,6 +76,8 @@ When updating project rules, update **all four files** to keep them consistent.
 - On merges to `main`, create a release and tag; ensure the version is bumped before release.
 - Add a sanity check: if a tag already exists for the current version, run `git mkver patch` to bump it before releasing.
 - Prefer using Makefile targets for CI steps (add targets as needed to keep local/CI workflows consistent).
+- Releases are created by CI via `gh release create --generate-notes`, which auto-formats merged PR titles as `* title by @author in <URL>` bullets.
+- **Release notes format:** The `update-summary` feature reads the release body and extracts the first three bullet points (`- ` or `* `), strips Markdown headers and URLs, and caps output at 200 characters. If editing release notes manually (e.g. via the GitHub UI), use clean bullet points so `update-summary` renders useful output — avoid prose paragraphs at the top of the body.
 
 ## Code Quality
 - Use `ruff` (lint + import sorting) and `black` (formatting).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -158,3 +158,40 @@ All four files convey the same project rules. **When updating project convention
 
 - Do **not** run `git mkver patch` on feature branches — it mutates the version file.
 - Version bumps happen when preparing a release, not during regular development.
+
+## Releases
+
+Releases are created automatically by CI on every push to `main` (excluding version-bump commits). The workflow runs:
+
+```bash
+gh release create vX.Y.Z --generate-notes
+```
+
+GitHub auto-generates release notes from merged PR titles, formatted as:
+
+```markdown
+## What's Changed
+* #N: PR title by @author in https://github.com/.../pull/N
+
+**Full Changelog**: https://github.com/.../compare/vX...vY
+```
+
+### Release notes and `update-summary`
+
+The `update-summary` config option lets users opt in to seeing a short digest of the release body when a new version is available. It works by:
+
+1. Picking the first three bullet-point lines (`-`, `*`, or `•` prefixes)
+2. Stripping Markdown headers and bare URLs
+3. Capping the result at 200 characters
+
+The auto-generated `--generate-notes` format is compatible (the `## What's Changed` header is stripped, bullet lines are picked up, and the Full Changelog URL is stripped). However, the output includes `by @author in` tails left after URL removal, which can look awkward.
+
+**If you edit release notes manually** (e.g. via the GitHub UI after the release is created), use clean bullet points for the best `update-summary` output:
+
+```markdown
+- Add --sort option for custom PR ordering
+- Fix --checks with per-repo cache hits
+- New --exclude-label filter
+```
+
+Avoid opening with prose paragraphs — without bullet points, `update-summary` falls back to the first non-empty line of the body, which is usually a poor summary.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -22,7 +22,8 @@ When updating project rules, update **all four files** to keep them consistent.
 4. **PR Titles:** Include the issue number: `#N: Description` (e.g., `#42: Add Avocado Toast output`).
 5. **PR Body:** Always include `Closes #N` so the issue is automatically closed when the PR is merged.
 6. **CI Checks:** After pushing to a branch with an open PR, wait for all CI checks to complete (`gh pr checks`). If any check fails, investigate and fix the root cause — do not ignore failures or proceed without understanding them.
-7. **Conventional Git Commits:** Use standard prefixes for git commits: `feat:`, `fix:`, `chore:`, `docs:`, `refactor:`, `test:`, `ci:`.
+7. **Release notes format:** Releases are created by CI via `gh release create --generate-notes`. If editing release notes manually (e.g. via the GitHub UI), use bullet points (`- item`) for each change. The `update-summary` feature extracts the first three bullets, strips Markdown headers and URLs, and caps at 200 characters — prose paragraphs at the top of the body produce poor summaries.
+8. **Conventional Git Commits:** Use standard prefixes for git commits: `feat:`, `fix:`, `chore:`, `docs:`, `refactor:`, `test:`, `ci:`.
 
 ## Tooling & Environment
 - **Python:** >= 3.11

--- a/docs/manual/options.md
+++ b/docs/manual/options.md
@@ -583,6 +583,23 @@ breakfast automatically checks for new versions once per day (cached for 24 hour
 
 The check is non-blocking and non-fatal — network failures are silently ignored. The notification is sent to stderr so it won't interfere with `--json` output piping.
 
+### `update-summary` (config only)
+
+When set to `true`, appends a short summary of what's new (pulled from the GitHub release notes) below the update banner:
+
+```text
+🍳 A fresh breakfast is ready! v0.10.0 → v0.11.0 — update at ...
+  📋 - Add --sort option for custom PR ordering
+      - Fix --checks with per-repo cache hits
+      - New --exclude-label filter
+```
+
+Enable in `~/.config/breakfast/config.toml`:
+
+```toml
+update-summary = true
+```
+
 To disable the update check:
 
 ```bash

--- a/src/breakfast/cli.py
+++ b/src/breakfast/cli.py
@@ -896,6 +896,7 @@ def breakfast(
     seasonal_colours = cfg.get("seasonal-colours", True)
     summarise_user_prs = summarise_user_prs or cfg.get("summarise-user-prs", False)
     summarise_repo_prs = summarise_repo_prs or cfg.get("summarise-repo-prs", False)
+    show_update_summary = cfg.get("update-summary", False)
 
     if summarise_user_prs and summarise_repo_prs:
         click.echo(
@@ -1293,7 +1294,7 @@ def breakfast(
             color=colour and _stdout_is_tty(),
         )
         if not no_update_check:
-            update_msg = check_for_update()
+            update_msg = check_for_update(show_summary=show_update_summary)
             if update_msg:
                 logger.info("update_available msg=%r", update_msg)
                 click.echo(
@@ -1352,7 +1353,7 @@ def breakfast(
             "render_complete elapsed_ms=%d", int((time.monotonic() - t_render) * 1000)
         )
         if not no_update_check:
-            update_msg = check_for_update()
+            update_msg = check_for_update(show_summary=show_update_summary)
             if update_msg:
                 logger.info("update_available msg=%r", update_msg)
                 click.echo(
@@ -1444,7 +1445,7 @@ def breakfast(
             "render_complete elapsed_ms=%d", int((time.monotonic() - t_render) * 1000)
         )
         if not no_update_check:
-            update_msg = check_for_update()
+            update_msg = check_for_update(show_summary=show_update_summary)
             if update_msg:
                 logger.info("update_available msg=%r", update_msg)
                 click.echo(
@@ -1524,7 +1525,7 @@ def breakfast(
             "render_complete elapsed_ms=%d", int((time.monotonic() - t_render) * 1000)
         )
         if not no_update_check:
-            update_msg = check_for_update()
+            update_msg = check_for_update(show_summary=show_update_summary)
             if update_msg:
                 logger.info("update_available msg=%r", update_msg)
                 click.echo(
@@ -1649,7 +1650,7 @@ def breakfast(
     )
 
     if not no_update_check:
-        update_msg = check_for_update()
+        update_msg = check_for_update(show_summary=show_update_summary)
         if update_msg:
             logger.info("update_available msg=%r", update_msg)
             click.echo(

--- a/src/breakfast/config.py
+++ b/src/breakfast/config.py
@@ -196,6 +196,17 @@ _DEFAULT_CONFIG_CONTENT = """\
 # oldest PR age, and total comments per repo.
 # Equivalent to: --summarise-repo-prs
 # summarise-repo-prs = false
+
+
+# -----------------------------------------------------------------------------
+# Update notifications
+# Control how version update alerts appear.
+# -----------------------------------------------------------------------------
+
+# When a newer version of breakfast is available, include a short summary of
+# what's new (pulled from the GitHub release notes) below the update banner.
+# Equivalent to: --update-summary
+# update-summary = false
 """
 
 

--- a/src/breakfast/updater.py
+++ b/src/breakfast/updater.py
@@ -33,18 +33,33 @@ def _read_version_cache():
         return None
 
 
-def _write_version_cache(latest_version):
+def _read_cached_release_body():
+    """Return the cached release body string, or None if absent/expired."""
+    cache_file = _CACHE_DIR / "latest_version.json"
+    try:
+        if not cache_file.exists():
+            return None
+        data = json.loads(cache_file.read_text())
+        cached_at = datetime.fromisoformat(data["checked_at"])
+        age = (datetime.now(timezone.utc) - cached_at).total_seconds()
+        if age > _CACHE_TTL_SECONDS:
+            return None
+        return data.get("release_body")
+    except (OSError, json.JSONDecodeError, KeyError, ValueError, TypeError):
+        return None
+
+
+def _write_version_cache(latest_version, release_body=None):
     try:
         _CACHE_DIR.mkdir(parents=True, exist_ok=True)
         cache_file = _CACHE_DIR / "latest_version.json"
-        cache_file.write_text(
-            json.dumps(
-                {
-                    "latest_version": latest_version,
-                    "checked_at": datetime.now(timezone.utc).isoformat(),
-                }
-            )
-        )
+        payload = {
+            "latest_version": latest_version,
+            "checked_at": datetime.now(timezone.utc).isoformat(),
+        }
+        if release_body is not None:
+            payload["release_body"] = release_body
+        cache_file.write_text(json.dumps(payload))
     except OSError as exc:
         logger.debug("version_cache_write_error error=%r", str(exc))
 
@@ -69,15 +84,17 @@ def get_latest_version():
         )
         elapsed_ms = int((time.monotonic() - t0) * 1000)
         resp.raise_for_status()
-        tag = resp.json().get("tag_name", "")
+        data = resp.json()
+        tag = data.get("tag_name", "")
         latest = tag.lstrip("v")
+        release_body = data.get("body") or None
         logger.debug(
             "update_check_response status=%d elapsed_ms=%d latest=%s",
             resp.status_code,
             elapsed_ms,
             latest,
         )
-        _write_version_cache(latest)
+        _write_version_cache(latest, release_body=release_body)
         return latest
     except requests.exceptions.RequestException as exc:
         logger.debug("update_check_request_failed error=%r", str(exc))
@@ -100,18 +117,55 @@ def _parse_version_tuple(version_str):
         return ()
 
 
-def check_for_update():
+def get_release_summary(body: str, max_chars: int = 200) -> str:
+    """Extract a short human-readable summary from a GitHub release body.
+
+    Picks the first few bullet points, strips Markdown headers and bare URLs,
+    and truncates to max_chars.
+    """
+    if not body:
+        return ""
+    lines = []
+    for line in body.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("#"):
+            continue
+        if stripped.startswith(("- ", "* ", "• ")):
+            lines.append(stripped)
+            if len(lines) >= 3:
+                break
+    if not lines:
+        for line in body.splitlines():
+            stripped = line.strip()
+            if stripped and not stripped.startswith("#"):
+                lines.append(stripped)
+                break
+    summary = " ".join(lines)
+    summary = re.sub(r"https?://\S+", "", summary).strip()
+    if len(summary) > max_chars:
+        summary = summary[: max_chars - 1] + "…"
+    return summary
+
+
+def check_for_update(show_summary: bool = False):
     try:
         current = pkg_version("breakfast")
         latest = get_latest_version()
         if not latest:
             return None
         if _parse_version_tuple(latest) > _parse_version_tuple(current):
-            return (
+            msg = (
                 f"\U0001f373 A fresh breakfast is ready! "
                 f"v{current} → v{latest} "
                 f"— update at https://github.com/{_UPDATE_CHECK_REPO}/releases/latest"
             )
+            if show_summary:
+                body = _read_cached_release_body()
+                if body:
+                    summary = get_release_summary(body)
+                    if summary:
+                        msg += f"\n  📋 {summary}"
+            return msg
         return None
     except PackageNotFoundError as exc:
         logger.debug("package_not_found error=%r", str(exc))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -66,7 +66,7 @@ def test_cli_exits_when_token_missing(monkeypatch):
 def test_cli_outputs_table(monkeypatch):
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
 
     def fake_get_prs(_org, _repo_filter):
         return ["https://github.com/org/repo/pull/1"]
@@ -104,7 +104,7 @@ def test_cli_outputs_table(monkeypatch):
 def test_cli_outputs_age_column_when_enabled(monkeypatch):
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
 
     def fake_get_prs(_org, _repo_filter):
         return ["https://github.com/org/repo/pull/1"]
@@ -165,7 +165,7 @@ def _fake_pr_detail_with_branches():
 def test_cli_outputs_head_branch_column_when_enabled(monkeypatch):
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
     monkeypatch.setattr(
         cli,
         "get_github_prs",
@@ -188,7 +188,7 @@ def test_cli_outputs_head_branch_column_when_enabled(monkeypatch):
 def test_cli_outputs_base_branch_column_when_enabled(monkeypatch):
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
     monkeypatch.setattr(
         cli,
         "get_github_prs",
@@ -211,7 +211,7 @@ def test_cli_outputs_base_branch_column_when_enabled(monkeypatch):
 def test_cli_head_and_base_branch_hidden_by_default(monkeypatch):
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
     monkeypatch.setattr(
         cli,
         "get_github_prs",
@@ -234,7 +234,7 @@ def test_cli_head_and_base_branch_hidden_by_default(monkeypatch):
 def test_cli_outputs_json(monkeypatch):
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
 
     def fake_get_prs(_org, _repo_filter):
         return ["https://github.com/org/repo/pull/1"]
@@ -288,7 +288,7 @@ def test_cli_json_output_is_valid_json_when_empty(monkeypatch):
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
     monkeypatch.setattr(cli, "get_github_prs", lambda _org, _repo: [])
-    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
 
     runner = CliRunner()
     result = runner.invoke(cli.breakfast, ["-o", "org", "-r", "repo", "--json"])
@@ -300,7 +300,7 @@ def test_cli_json_output_is_valid_json_when_empty(monkeypatch):
 def test_cli_continues_when_one_pr_fetch_fails(monkeypatch):
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
 
     def fake_get_prs(_org, _repo_filter):
         return [
@@ -352,7 +352,7 @@ def test_cli_continues_when_one_pr_fetch_fails(monkeypatch):
 def test_cli_mine_only_filters_to_authenticated_user(monkeypatch):
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
 
     def fake_get_prs(_org, _repo_filter):
         return [
@@ -401,7 +401,7 @@ def test_cli_mine_only_exits_cleanly_on_rate_limit(monkeypatch):
 
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
     monkeypatch.setattr(
         cli,
         "get_authenticated_user_login",
@@ -419,7 +419,7 @@ def test_cli_mine_only_exits_cleanly_on_rate_limit(monkeypatch):
 def test_cli_outputs_checks_column(monkeypatch):
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
 
     def fake_get_prs(_org, _repo_filter):
         return ["https://github.com/org/repo/pull/1"]
@@ -470,7 +470,7 @@ def test_cli_checks_no_collision_across_repos(monkeypatch):
     """PRs with the same number in different repos must keep separate check statuses."""
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
 
     def fake_get_prs(_org, _repo_filter):
         return [
@@ -547,7 +547,7 @@ def test_cli_checks_no_collision_across_repos(monkeypatch):
 def test_cli_checks_not_shown_by_default(monkeypatch):
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
 
     def fake_get_prs(_org, _repo_filter):
         return ["https://github.com/org/repo/pull/1"]
@@ -599,7 +599,7 @@ def test_cli_show_config_includes_status_style_from_config(tmp_path):
 def test_cli_json_includes_checks_when_enabled(monkeypatch):
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
 
     def fake_get_prs(_org, _repo_filter):
         return ["https://github.com/org/repo/pull/1"]
@@ -655,7 +655,7 @@ def test_cli_json_includes_checks_when_enabled(monkeypatch):
 def test_cli_json_excludes_checks_by_default(monkeypatch):
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
 
     def fake_get_prs(_org, _repo_filter):
         return ["https://github.com/org/repo/pull/1"]
@@ -727,7 +727,7 @@ def _make_pr_detail(number=1, owner="org", repo="repo", pr_id=1001):
 def test_cli_outputs_approvals_column(monkeypatch):
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
 
     pr_detail = _make_pr_detail()
 
@@ -760,7 +760,7 @@ def test_cli_outputs_approvals_column(monkeypatch):
 def test_cli_renders_review_required_for_incomplete_reviews(monkeypatch):
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
 
     pr_detail = _make_pr_detail()
 
@@ -796,7 +796,7 @@ def test_cli_renders_review_required_for_incomplete_reviews(monkeypatch):
 def test_cli_renders_approval_counts_for_multi_review_branch(monkeypatch):
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
 
     pr_detail = _make_pr_detail()
 
@@ -833,7 +833,7 @@ def test_cli_renders_approval_counts_for_multi_review_branch(monkeypatch):
 def test_cli_approvals_not_shown_by_default(monkeypatch):
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
 
     pr_detail = _make_pr_detail()
 
@@ -852,7 +852,7 @@ def test_cli_approvals_not_shown_by_default(monkeypatch):
 def test_cli_json_includes_approval_when_enabled(monkeypatch):
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
 
     pr_detail = _make_pr_detail()
 
@@ -888,7 +888,7 @@ def test_cli_json_includes_approval_when_enabled(monkeypatch):
 def test_cli_json_includes_approval_counts_when_available(monkeypatch):
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
 
     pr_detail = _make_pr_detail()
 
@@ -928,7 +928,7 @@ def test_cli_json_includes_approval_counts_when_available(monkeypatch):
 def test_cli_json_excludes_approval_by_default(monkeypatch):
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
 
     pr_detail = _make_pr_detail()
 
@@ -1004,7 +1004,7 @@ def test_no_update_check_env_var(monkeypatch):
 def test_cli_truncates_title_when_max_title_length_set(monkeypatch):
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
 
     long_title = "A" * 100
 
@@ -1045,7 +1045,7 @@ def test_cli_truncates_title_when_max_title_length_set(monkeypatch):
 def test_cli_does_not_truncate_title_when_max_title_length_unset(monkeypatch):
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
 
     long_title = "A" * 100
 
@@ -1083,7 +1083,7 @@ def test_cli_does_not_truncate_title_when_max_title_length_unset(monkeypatch):
 def test_cli_limit_caps_results(monkeypatch):
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
 
     def fake_get_prs(_org, _repo_filter):
         return [f"https://github.com/org/repo/pull/{i}" for i in range(1, 6)]
@@ -1179,7 +1179,7 @@ def test_auto_fit_measures_later_rows_when_fitting_table():
 def test_cli_status_columns_use_ascii_to_keep_rows_aligned(monkeypatch):
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
 
     def fake_get_prs(_org, _repo_filter):
         return [
@@ -1258,7 +1258,7 @@ def test_cli_status_columns_use_ascii_to_keep_rows_aligned(monkeypatch):
 def test_auto_fit_truncates_title_to_terminal_width(monkeypatch):
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
     monkeypatch.setattr(
         cli, "get_github_prs", lambda _o, _r: ["https://github.com/org/repo/pull/1"]
     )
@@ -1280,7 +1280,7 @@ def test_auto_fit_truncates_title_to_terminal_width(monkeypatch):
 def test_auto_fit_skips_truncation_when_title_fits(monkeypatch):
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
     monkeypatch.setattr(
         cli, "get_github_prs", lambda _o, _r: ["https://github.com/org/repo/pull/1"]
     )
@@ -1301,7 +1301,7 @@ def test_auto_fit_skips_truncation_when_title_fits(monkeypatch):
 def test_auto_fit_truncates_repo_and_author_before_dropping(monkeypatch):
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
     monkeypatch.setattr(
         cli, "get_github_prs", lambda _o, _r: ["https://github.com/org/repo/pull/1"]
     )
@@ -1331,7 +1331,7 @@ def test_auto_fit_truncates_repo_and_author_before_dropping(monkeypatch):
 def test_auto_fit_compresses_mergeable_before_dropping(monkeypatch):
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
     monkeypatch.setattr(
         cli, "get_github_prs", lambda _o, _r: ["https://github.com/org/repo/pull/1"]
     )
@@ -1398,7 +1398,7 @@ def test_auto_fit_renames_mergeable_to_mrg(monkeypatch):
 def test_auto_fit_drops_columns_when_very_narrow(monkeypatch):
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
     monkeypatch.setattr(
         cli, "get_github_prs", lambda _o, _r: ["https://github.com/org/repo/pull/1"]
     )
@@ -1419,7 +1419,7 @@ def test_auto_fit_noop_when_not_tty(monkeypatch):
     """When stdout is not a TTY (e.g. piped), auto-fit must not run."""
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
     monkeypatch.setattr(
         cli, "get_github_prs", lambda _o, _r: ["https://github.com/org/repo/pull/1"]
     )
@@ -1438,7 +1438,7 @@ def test_auto_fit_noop_when_not_tty(monkeypatch):
 def test_explicit_max_title_length_overrides_auto_fit(monkeypatch):
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
     monkeypatch.setattr(
         cli, "get_github_prs", lambda _o, _r: ["https://github.com/org/repo/pull/1"]
     )
@@ -1508,7 +1508,7 @@ def _make_pr_detail(number=1):
 def test_cache_hit_skips_get_github_prs(monkeypatch, tmp_path):
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
     monkeypatch.setattr(cache, "_CACHE_DIR", tmp_path)
     monkeypatch.setattr(cli, "read_pr_cache", cache.read_pr_cache)
     monkeypatch.setattr(cli, "write_pr_cache", cache.write_pr_cache)
@@ -1530,7 +1530,7 @@ def test_cache_hit_skips_get_github_prs(monkeypatch, tmp_path):
 def test_no_cache_flag_always_fetches(monkeypatch, tmp_path):
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
     monkeypatch.setattr(cache, "_CACHE_DIR", tmp_path)
     monkeypatch.setattr(cli, "read_pr_cache", cache.read_pr_cache)
     monkeypatch.setattr(cli, "write_pr_cache", cache.write_pr_cache)
@@ -1557,7 +1557,7 @@ def test_no_cache_flag_always_fetches(monkeypatch, tmp_path):
 def test_no_cache_flag_writes_nothing(monkeypatch, tmp_path):
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
     monkeypatch.setattr(cache, "_CACHE_DIR", tmp_path)
     monkeypatch.setattr(cli, "read_pr_cache", cache.read_pr_cache)
     monkeypatch.setattr(cli, "write_pr_cache", cache.write_pr_cache)
@@ -1587,7 +1587,7 @@ def test_config_cache_ttl_respected(monkeypatch, tmp_path):
     """cache-ttl = "5m" in config is honoured when no CLI flag given."""
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
     monkeypatch.setattr(cache, "_CACHE_DIR", tmp_path)
     monkeypatch.setattr(cli, "read_pr_cache", cache.read_pr_cache)
     monkeypatch.setattr(cli, "write_pr_cache", cache.write_pr_cache)
@@ -1612,7 +1612,7 @@ def test_config_cache_ttl_respected(monkeypatch, tmp_path):
 def test_corrupt_cache_falls_back_to_live_fetch(monkeypatch, tmp_path):
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
     monkeypatch.setattr(cache, "_CACHE_DIR", tmp_path)
     monkeypatch.setattr(cli, "read_pr_cache", cache.read_pr_cache)
     monkeypatch.setattr(cli, "write_pr_cache", cache.write_pr_cache)
@@ -1642,7 +1642,7 @@ def test_corrupt_cache_falls_back_to_live_fetch(monkeypatch, tmp_path):
 def test_pr_results_grouped_by_repo(monkeypatch, tmp_path):
     """PRs from multiple repos should appear grouped by repo name in the output."""
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
-    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
     monkeypatch.setattr(cache, "_CACHE_DIR", tmp_path)
     monkeypatch.setattr(cli, "read_pr_cache", cache.read_pr_cache)
     monkeypatch.setattr(cli, "write_pr_cache", cache.write_pr_cache)
@@ -1696,7 +1696,7 @@ def test_refresh_ignores_cache_and_writes_fresh(monkeypatch, tmp_path):
     """--refresh bypasses the cache read but still writes fresh data back."""
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
     monkeypatch.setattr(cache, "_CACHE_DIR", tmp_path)
     monkeypatch.setattr(cli, "read_pr_cache", cache.read_pr_cache)
     monkeypatch.setattr(cli, "write_pr_cache", cache.write_pr_cache)
@@ -1731,7 +1731,7 @@ def test_refresh_does_not_use_cached_data(monkeypatch, tmp_path):
     """--refresh must not serve stale data even when cache is warm."""
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
     monkeypatch.setattr(cache, "_CACHE_DIR", tmp_path)
     monkeypatch.setattr(cli, "read_pr_cache", cache.read_pr_cache)
     monkeypatch.setattr(cli, "write_pr_cache", cache.write_pr_cache)
@@ -1757,7 +1757,7 @@ def test_refresh_prs_uses_graphql_cache_skips_pr_cache(monkeypatch, tmp_path):
     """--refresh-prs uses the cached URL list but re-fetches PR details."""
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
     monkeypatch.setattr(cache, "_CACHE_DIR", tmp_path)
     monkeypatch.setattr(cli, "read_pr_cache", cache.read_pr_cache)
     monkeypatch.setattr(cli, "write_pr_cache", cache.write_pr_cache)
@@ -1791,7 +1791,7 @@ def test_refresh_prs_writes_fresh_pr_cache(monkeypatch, tmp_path):
     """--refresh-prs writes fresh PR details back to cache."""
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
     monkeypatch.setattr(cache, "_CACHE_DIR", tmp_path)
     monkeypatch.setattr(cli, "read_pr_cache", cache.read_pr_cache)
     monkeypatch.setattr(cli, "write_pr_cache", cache.write_pr_cache)
@@ -1887,7 +1887,7 @@ def test_cli_legendary_flag_annotates_state(monkeypatch):
     """--legendary appends ⚔️ to the State of qualifying PRs."""
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
 
     # A PR that qualifies as legendary (very old AND many comments)
     legendary_pr = {
@@ -1914,7 +1914,7 @@ def test_cli_legendary_off_by_default(monkeypatch):
     """Without --legendary, no sword emoji appears even for qualifying PRs."""
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
 
     old_pr = {
         **_make_pr_detail(1),
@@ -1939,7 +1939,7 @@ def test_cli_legendary_only_filters_non_legendary(monkeypatch):
     """--legendary-only shows only PRs that qualify as legendary."""
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
 
     # A fresh PR — should be filtered out
     fresh_pr = {
@@ -1968,7 +1968,7 @@ def test_cli_legendary_only_implies_legendary_marking(monkeypatch):
     """--legendary-only implies --legendary so the ⚔️ marker is applied."""
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
 
     legendary_pr = {
         **_make_pr_detail(1),
@@ -2137,7 +2137,7 @@ def test_styled_hyperlink_puts_colour_outside_osc8():
 def test_cli_repo_and_author_are_hyperlinks(monkeypatch):
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
 
     pr = _make_pr_fixture(number=1)
     pr["base"]["repo"]["html_url"] = "https://github.com/myorg/myrepo"
@@ -2159,7 +2159,7 @@ def test_cli_repo_and_author_are_hyperlinks(monkeypatch):
 def test_cli_checks_column_links_to_checks_tab(monkeypatch):
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
 
     pr = _make_pr_fixture(number=7)
     pr["base"]["repo"]["owner"] = {"login": "org"}
@@ -2195,7 +2195,7 @@ def test_progress_emoji_emitted_after_check_status_fetch(monkeypatch):
     """
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
 
     pr = _make_pr_fixture(number=1)
     pr["base"]["repo"]["owner"] = {"login": "org"}
@@ -2259,7 +2259,7 @@ def test_debug_flag_prints_summary_to_stderr(monkeypatch):
     """--debug emits a summary block to stderr without disrupting stdout output."""
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
     monkeypatch.setattr(
         cli,
         "get_api_stats",
@@ -2340,7 +2340,7 @@ def test_no_colour_strips_ansi_from_table(monkeypatch):
     """--no-colour produces output with no ANSI escape sequences."""
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
     monkeypatch.setattr(
         cli, "get_github_prs", lambda *_: ["https://github.com/org/repo/pull/1"]
     )
@@ -2358,7 +2358,7 @@ def test_no_color_alias_works(monkeypatch):
     """--no-color (US spelling) is accepted and strips ANSI."""
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
     monkeypatch.setattr(
         cli, "get_github_prs", lambda *_: ["https://github.com/org/repo/pull/1"]
     )
@@ -2404,7 +2404,7 @@ def test_seasonal_colours_no_colour_suppresses_them(monkeypatch):
 
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
     monkeypatch.setattr(
         cli, "get_github_prs", lambda *_: ["https://github.com/org/repo/pull/1"]
     )
@@ -2422,7 +2422,7 @@ def test_seasonal_colours_disabled_by_config(monkeypatch, tmp_path):
 
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
     monkeypatch.setattr(
         cli, "get_github_prs", lambda *_: ["https://github.com/org/repo/pull/1"]
     )
@@ -2493,7 +2493,7 @@ def _fake_pr_for_summary(path):
 def test_summarise_user_prs_shows_author_summary(monkeypatch):
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
     monkeypatch.setattr(cli, "get_github_prs", lambda *_: _two_author_prs())
     monkeypatch.setattr(api, "make_github_api_request", _fake_pr_for_summary)
 
@@ -2511,7 +2511,7 @@ def test_summarise_user_prs_shows_author_summary(monkeypatch):
 def test_summarise_repo_prs_shows_repo_summary(monkeypatch):
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
     monkeypatch.setattr(cli, "get_github_prs", lambda *_: _two_author_prs())
     monkeypatch.setattr(api, "make_github_api_request", _fake_pr_for_summary)
 
@@ -2541,7 +2541,7 @@ def test_summarise_user_and_repo_mutually_exclusive(monkeypatch):
 def test_summarise_user_prs_empty_shows_no_prs_message(monkeypatch):
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
     monkeypatch.setattr(cli, "get_github_prs", lambda *_: [])
 
     runner = CliRunner()
@@ -2554,7 +2554,7 @@ def test_summarise_user_prs_empty_shows_no_prs_message(monkeypatch):
 def test_summarise_repo_prs_no_colour(monkeypatch):
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
     monkeypatch.setattr(cli, "get_github_prs", lambda *_: _two_author_prs())
     monkeypatch.setattr(api, "make_github_api_request", _fake_pr_for_summary)
 
@@ -2606,7 +2606,7 @@ def _fake_pr_detail(_path):
 def test_table_output_goes_to_stdout_not_stderr(monkeypatch):
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
     monkeypatch.setattr(
         cli, "get_github_prs", lambda *_: ["https://github.com/org/repo/pull/1"]
     )
@@ -2622,7 +2622,7 @@ def test_table_output_goes_to_stdout_not_stderr(monkeypatch):
 def test_progress_messages_go_to_stderr_in_table_mode(monkeypatch):
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
     monkeypatch.setattr(
         cli, "get_github_prs", lambda *_: ["https://github.com/org/repo/pull/1"]
     )
@@ -2638,7 +2638,7 @@ def test_progress_messages_go_to_stderr_in_table_mode(monkeypatch):
 def test_progress_messages_go_to_stderr_in_json_mode(monkeypatch):
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
     monkeypatch.setattr(
         cli, "get_github_prs", lambda *_: ["https://github.com/org/repo/pull/1"]
     )
@@ -2655,7 +2655,7 @@ def test_json_stdout_is_clean_json(monkeypatch):
     """stdout must contain only parseable JSON — no progress noise."""
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
     monkeypatch.setattr(
         cli, "get_github_prs", lambda *_: ["https://github.com/org/repo/pull/1"]
     )
@@ -2672,7 +2672,7 @@ def test_json_stdout_is_clean_json(monkeypatch):
 def test_no_match_message_goes_to_stderr(monkeypatch):
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
     monkeypatch.setattr(
         cli, "get_github_prs", lambda *_: ["https://github.com/org/repo/pull/1"]
     )
@@ -2691,7 +2691,7 @@ def test_no_match_with_json_stdout_stays_clean(monkeypatch):
     """--json --search with no matches: stdout must be parseable empty JSON."""
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
     monkeypatch.setattr(
         cli, "get_github_prs", lambda *_: ["https://github.com/org/repo/pull/1"]
     )
@@ -2725,7 +2725,7 @@ def test_config_format_json_enables_json_output(monkeypatch, tmp_path):
     cfg_file.write_text('format = "json"\norganization = "org"\n')
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
     monkeypatch.setattr(
         cli, "get_github_prs", lambda *_: ["https://github.com/org/repo/pull/1"]
     )
@@ -2743,7 +2743,7 @@ def test_config_format_table_produces_table_output(monkeypatch, tmp_path):
     cfg_file.write_text('format = "table"\norganization = "org"\n')
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
     monkeypatch.setattr(
         cli, "get_github_prs", lambda *_: ["https://github.com/org/repo/pull/1"]
     )
@@ -2760,7 +2760,7 @@ def test_config_format_invalid_warns_and_falls_back_to_table(monkeypatch, tmp_pa
     cfg_file.write_text('format = "tofu"\norganization = "org"\n')
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
     monkeypatch.setattr(
         cli, "get_github_prs", lambda *_: ["https://github.com/org/repo/pull/1"]
     )
@@ -2780,7 +2780,7 @@ def test_cli_no_json_flag_overrides_config_format_json(monkeypatch, tmp_path):
     cfg_file.write_text('format = "json"\norganization = "org"\n')
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
     monkeypatch.setattr(
         cli, "get_github_prs", lambda *_: ["https://github.com/org/repo/pull/1"]
     )
@@ -2802,7 +2802,7 @@ def test_cli_no_json_flag_overrides_config_format_json(monkeypatch, tmp_path):
 def test_format_markdown_produces_gfm_table(monkeypatch):
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
     monkeypatch.setattr(
         cli, "get_github_prs", lambda *_: ["https://github.com/org/repo/pull/1"]
     )
@@ -2822,7 +2822,7 @@ def test_format_markdown_produces_gfm_table(monkeypatch):
 def test_format_markdown_strips_ansi_codes(monkeypatch):
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
     monkeypatch.setattr(
         cli, "get_github_prs", lambda *_: ["https://github.com/org/repo/pull/1"]
     )
@@ -2840,7 +2840,7 @@ def test_format_markdown_strips_ansi_codes(monkeypatch):
 def test_format_markdown_output_goes_to_stdout(monkeypatch):
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
     monkeypatch.setattr(
         cli, "get_github_prs", lambda *_: ["https://github.com/org/repo/pull/1"]
     )
@@ -2861,7 +2861,7 @@ def test_config_format_markdown_produces_markdown_output(monkeypatch, tmp_path):
     cfg_file.write_text('format = "markdown"\norganization = "org"\n')
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
     monkeypatch.setattr(
         cli, "get_github_prs", lambda *_: ["https://github.com/org/repo/pull/1"]
     )
@@ -2877,7 +2877,7 @@ def test_config_format_markdown_produces_markdown_output(monkeypatch, tmp_path):
 def test_format_markdown_includes_optional_columns(monkeypatch):
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
 
     def fake_api_request(path):
         if "check-runs" in path:
@@ -2903,7 +2903,7 @@ def test_format_flag_overrides_json_flag(monkeypatch):
     """--format markdown takes precedence over --json."""
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
     monkeypatch.setattr(
         cli, "get_github_prs", lambda *_: ["https://github.com/org/repo/pull/1"]
     )
@@ -2928,7 +2928,7 @@ def test_format_flag_overrides_json_flag(monkeypatch):
 def test_format_csv_produces_header_row(monkeypatch):
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
     monkeypatch.setattr(
         cli, "get_github_prs", lambda *_: ["https://github.com/org/repo/pull/1"]
     )
@@ -2946,7 +2946,7 @@ def test_format_csv_produces_header_row(monkeypatch):
 def test_format_csv_contains_pr_data(monkeypatch):
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
     monkeypatch.setattr(
         cli, "get_github_prs", lambda *_: ["https://github.com/org/repo/pull/1"]
     )
@@ -2964,7 +2964,7 @@ def test_format_csv_contains_pr_data(monkeypatch):
 def test_format_csv_strips_ansi_codes(monkeypatch):
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
     monkeypatch.setattr(
         cli, "get_github_prs", lambda *_: ["https://github.com/org/repo/pull/1"]
     )
@@ -2982,7 +2982,7 @@ def test_format_csv_strips_ansi_codes(monkeypatch):
 def test_format_csv_output_goes_to_stdout(monkeypatch):
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
     monkeypatch.setattr(
         cli, "get_github_prs", lambda *_: ["https://github.com/org/repo/pull/1"]
     )
@@ -3001,7 +3001,7 @@ def test_format_csv_output_goes_to_stdout(monkeypatch):
 def test_format_csv_is_valid_csv(monkeypatch):
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
     monkeypatch.setattr(
         cli, "get_github_prs", lambda *_: ["https://github.com/org/repo/pull/1"]
     )
@@ -3021,7 +3021,7 @@ def test_format_csv_is_valid_csv(monkeypatch):
 def test_format_csv_includes_optional_age_column(monkeypatch):
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
     monkeypatch.setattr(
         cli, "get_github_prs", lambda *_: ["https://github.com/org/repo/pull/1"]
     )
@@ -3041,7 +3041,7 @@ def test_config_format_csv_produces_csv_output(monkeypatch, tmp_path):
     cfg_file.write_text('format = "csv"\norganization = "org"\n')
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
     monkeypatch.setattr(
         cli, "get_github_prs", lambda *_: ["https://github.com/org/repo/pull/1"]
     )

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -377,6 +377,7 @@ def test_update_config_appends_missing_options(tmp_path, monkeypatch):
     # Missing options were appended
     assert "# workers = 64" in updated
     assert "# no-colour = false" in updated
+    assert "# update-summary = false" in updated
     # organization should NOT be duplicated
     assert updated.count("organization") == 1
 

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -139,6 +139,116 @@ def test_write_and_read_version_cache(monkeypatch, tmp_path):
     assert updater._read_version_cache() == "3.0.0"
 
 
+def test_write_version_cache_stores_release_body(monkeypatch, tmp_path):
+    monkeypatch.setattr(updater, "_CACHE_DIR", tmp_path)
+
+    body = "- fix: some thing\n- feat: other"
+    updater._write_version_cache("3.0.0", release_body=body)
+    assert updater._read_cached_release_body() == body
+
+
+def test_write_version_cache_no_body_returns_none(monkeypatch, tmp_path):
+    monkeypatch.setattr(updater, "_CACHE_DIR", tmp_path)
+
+    updater._write_version_cache("3.0.0")
+    assert updater._read_cached_release_body() is None
+
+
+def test_get_release_summary_bullet_points():
+    body = (
+        "## What's new\n- fix: bug squashed\n- feat: cool thing\n"
+        "- chore: cleanup\n- extra: fourth"
+    )
+    summary = updater.get_release_summary(body)
+    assert "fix: bug squashed" in summary
+    assert "feat: cool thing" in summary
+    assert "extra: fourth" not in summary  # only first 3 bullets
+
+
+def test_get_release_summary_strips_headers():
+    body = "# Release v1.0\n## Changes\n- fix: something"
+    summary = updater.get_release_summary(body)
+    assert "#" not in summary
+    assert "fix: something" in summary
+
+
+def test_get_release_summary_strips_urls():
+    body = "- fix: see https://github.com/org/repo/issues/1 for details"
+    summary = updater.get_release_summary(body)
+    assert "https://" not in summary
+    assert "fix: see" in summary
+
+
+def test_get_release_summary_truncates():
+    body = "- " + "x" * 300
+    summary = updater.get_release_summary(body, max_chars=50)
+    assert len(summary) <= 50
+    assert summary.endswith("…")
+
+
+def test_get_release_summary_empty_body():
+    assert updater.get_release_summary("") == ""
+    assert updater.get_release_summary(None) == ""
+
+
+def test_check_for_update_with_summary(monkeypatch, tmp_path):
+    monkeypatch.setattr(updater, "_CACHE_DIR", tmp_path)
+    monkeypatch.setattr(updater, "pkg_version", lambda _name: "0.9.0")
+    monkeypatch.setattr(updater, "get_latest_version", lambda: "0.10.0")
+    updater._write_version_cache("0.10.0", release_body="- feat: cool new feature")
+
+    result = updater.check_for_update(show_summary=True)
+
+    assert result is not None
+    assert "cool new feature" in result
+    assert "📋" in result
+
+
+def test_check_for_update_without_summary_does_not_include_body(monkeypatch, tmp_path):
+    monkeypatch.setattr(updater, "_CACHE_DIR", tmp_path)
+    monkeypatch.setattr(updater, "pkg_version", lambda _name: "0.9.0")
+    monkeypatch.setattr(updater, "get_latest_version", lambda: "0.10.0")
+    updater._write_version_cache("0.10.0", release_body="- feat: cool new feature")
+
+    result = updater.check_for_update(show_summary=False)
+
+    assert result is not None
+    assert "cool new feature" not in result
+
+
+def test_check_for_update_summary_missing_body_still_shows_banner(
+    monkeypatch, tmp_path
+):
+    monkeypatch.setattr(updater, "_CACHE_DIR", tmp_path)
+    monkeypatch.setattr(updater, "pkg_version", lambda _name: "0.9.0")
+    monkeypatch.setattr(updater, "get_latest_version", lambda: "0.10.0")
+    updater._write_version_cache("0.10.0")  # no body
+
+    result = updater.check_for_update(show_summary=True)
+
+    assert result is not None
+    assert "fresh breakfast" in result
+    assert "📋" not in result
+
+
+def test_get_latest_version_stores_release_body(monkeypatch, tmp_path):
+    monkeypatch.setattr(updater, "_CACHE_DIR", tmp_path)
+
+    class FakeResp:
+        status_code = 200
+
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return {"tag_name": "v2.0.0", "body": "- feat: new thing"}
+
+    monkeypatch.setattr(updater.requests, "get", lambda *a, **kw: FakeResp())
+
+    updater.get_latest_version()
+    assert updater._read_cached_release_body() == "- feat: new thing"
+
+
 def test_get_cache_dir_xdg(tmp_path, monkeypatch):
     custom_path = tmp_path / "custom-cache"
     monkeypatch.setenv("XDG_CACHE_HOME", str(custom_path))

--- a/uv.lock
+++ b/uv.lock
@@ -41,7 +41,7 @@ wheels = [
 
 [[package]]
 name = "breakfast"
-version = "0.57.6"
+version = "0.59.6"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

- When `update-summary = true` in config, appends a short `📋` summary from GitHub release notes below the update banner
- Summary extracts the first 3 bullet points from the release body, stripping Markdown headers and bare URLs, truncated to 200 chars
- Release body is cached alongside the version in `~/.cache/breakfast/latest_version.json` — no extra API call needed
- `check_for_update(show_summary=False)` is fully backward compatible; existing callers are unaffected by default

## Test plan

- [ ] `make format && make lint && make test` passes (345 tests)
- [ ] `test_check_for_update_with_summary` — summary appears when enabled
- [ ] `test_check_for_update_without_summary_does_not_include_body` — disabled by default
- [ ] `test_check_for_update_summary_missing_body_still_shows_banner` — graceful when no body
- [ ] `test_get_release_summary_*` — summary extraction, URL stripping, truncation, empty body
- [ ] `test_get_latest_version_stores_release_body` — body cached on API fetch

Closes #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)