### PR TITLE
#196: Pluggable seasonal calendar system

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ activate: .venv
 build: .venv
 
 	uv sync --extra build
-	uv run shiv -c breakfast -o breakfast --python '/usr/bin/env python3' .
+	uv run shiv -c breakfast -o breakfast --python '/usr/bin/env python3' --preamble utils/preamble.py .
 
 version-bump:
 	git mkver patch

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -12,3 +12,4 @@ Each document captures the problem, proposed solution, and implementation approa
 | [Demo Generation](demo-generation.md) | Implemented | [#80](https://github.com/mrsixw/breakfast/issues/80) |
 | [PR Caching](pr-caching.md) | Proposed | [#45](https://github.com/mrsixw/breakfast/issues/45) |
 | [Text User Interface](tui.md) | Proposed | [#46](https://github.com/mrsixw/breakfast/issues/46) |
+| [Pluggable Seasonal Calendars](pluggable-calendars.md) | Implemented | [#196](https://github.com/mrsixw/breakfast/issues/196) |

--- a/docs/design/pluggable-calendars.md
+++ b/docs/design/pluggable-calendars.md
@@ -25,22 +25,21 @@ CalendarFn = Callable[[datetime.date], str | list[str] | None]
 
 | Key | Holidays | Notes |
 | --- | --- | --- |
-| `"western"` | Christmas 🎄 (candy-cane), Easter 🐣, Pride Month 🌈, Halloween 🎃, Valentine's Day 💕, Lunar New Year 🧧 | Default. January is always purple — Steve's birthday month must never be overridden. |
-| `"jewish"` | Hanukkah 🕎 (8 nights, blue), Rosh Hashanah 🍎 (2 days, gold), Passover 🪬 (7 days, spring green), Sukkot 🌿 (7 days, orange) | Uses pre-computed tables for 2024–2045. |
-| `"islamic"` | Eid al-Fitr 🌙 (3 days, green), Eid al-Adha 🐑 (3 days, green) | Uses pre-computed tables for 2024–2045. Dates are approximate. |
-| `"hindu"` | Diwali 🪔 (5 days, gold), Holi 🌈 (2 days, rainbow) | Uses pre-computed tables for 2024–2045. |
-| `"sikh"` | Vaisakhi 🌾 (April 13, spring green), Bandi Chhor Divas 🪔 (5 days, gold) | Vaisakhi is fixed; Bandi Chhor Divas shares Diwali dates. |
 | `"east-asian"` | Lunar New Year 🧧 (3 days, gold), Mid-Autumn Festival 🎑 (2 days, yellow), Songkran 💦 (3 days, blue), Hanami 🌸 (7 days, pink) | Uses pre-computed LNY and Mid-Autumn tables for 2024–2045. |
+| `"hindu"` | Diwali 🪔 (5 days, gold), Holi 🌈 (2 days, rainbow) | Uses pre-computed tables for 2024–2045. |
+| `"islamic"` | Eid al-Fitr 🌙 (3 days, green), Eid al-Adha 🐑 (3 days, green) | Uses pre-computed tables for 2024–2045. Dates are approximate. |
+| `"jewish"` | Hanukkah 🕎 (8 nights, blue), Rosh Hashanah 🍎 (2 days, gold), Passover 🪬 (7 days, spring green), Sukkot 🌿 (7 days, orange) | Uses pre-computed tables for 2024–2045. |
+| `"sikh"` | Vaisakhi 🌾 (April 13, spring green), Bandi Chhor Divas 🪔 (5 days, gold) | Vaisakhi is fixed; Bandi Chhor Divas shares Diwali dates. |
+| `"western"` | Christmas 🎄 (candy-cane), Easter 🐣, Pride Month 🌈, Halloween 🎃, Valentine's Day 💕, Lunar New Year 🧧 | Default. January is always purple — Steve's birthday month must never be overridden. |
 | `"off"` | — | Disables all seasonal colours. |
 
 ## Implementation
 
 ### `src/breakfast/ui.py`
 
-- Pre-computed lookup tables (`_ROSH_HASHANAH`, `_HANUKKAH_START`, `_PASSOVER_START`, `_SUKKOT_START`, `_EID_AL_FITR`, `_EID_AL_ADHA`, `_DIWALI`, `_HOLI`, `_MID_AUTUMN`) covering 2024–2045.
+- Pre-computed lookup tables (`_DIWALI`, `_EID_AL_ADHA`, `_EID_AL_FITR`, `_HANUKKAH_START`, `_HOLI`, `_MID_AUTUMN`, `_PASSOVER_START`, `_ROSH_HASHANAH`, `_SUKKOT_START`) covering 2024–2045.
 - `_in_holiday_window(today, table, days)` helper.
-- `_western_calendar(today)` — refactored from the old `apply_seasonal_colour` logic. Returns `list` for cycling effects (December, June), `str` for fixed colours, `None` otherwise.
-- `_jewish_calendar`, `_islamic_calendar`, `_hindu_calendar`, `_sikh_calendar` — same signature.
+- `_east_asian_calendar`, `_hindu_calendar`, `_islamic_calendar`, `_jewish_calendar`, `_sikh_calendar`, `_western_calendar` — same signature. `_western_calendar` is refactored from the old `apply_seasonal_colour` logic. All return `list` for cycling effects, `str` for fixed colours, or `None` otherwise.
 - `CALENDARS` dict maps string keys to calendar functions.
 - `apply_seasonal_colour(text, pr_number, calendar="western")` — looks up the calendar function, dispatches, and handles list cycling via `pr_number % len(result)`.
 - `render_pr_summary` parameter renamed from `seasonal_colours: bool` to `calendar: str`.

--- a/docs/design/pluggable-calendars.md
+++ b/docs/design/pluggable-calendars.md
@@ -1,0 +1,64 @@
+# Pluggable Seasonal Calendars
+
+**Issue:** [#196](https://github.com/mrsixw/breakfast/issues/196)  
+**Status:** Implemented
+
+## Problem
+
+The seasonal colour easter egg in breakfast was hard-coded to the western/Gregorian calendar (Christmas, Easter, Pride Month, Halloween). Teams that celebrate different cultural holidays — Hanukkah, Diwali, Eid al-Fitr, Holi, Vaisakhi — got no seasonal love.
+
+## Solution
+
+A pluggable calendar system driven by a `seasonal-calendar` config key. Each calendar is a function `(today: datetime.date) -> str | list[str] | None` registered in a `CALENDARS` dict. The caller picks which calendar to use; `"off"` disables the feature entirely.
+
+## Calendar Interface
+
+```python
+CalendarFn = Callable[[datetime.date], str | list[str] | None]
+```
+
+- **`None`** — no holiday today, return text unstyled.
+- **`str`** — single ANSI escape code, applied uniformly.
+- **`list[str]`** — list of colours for PR-number cycling (e.g., December candy-cane, Pride rainbow, Holi rainbow).
+
+## Calendars
+
+| Key | Holidays | Notes |
+| --- | --- | --- |
+| `"western"` | Christmas 🎄 (candy-cane), Easter 🐣, Pride Month 🌈, Halloween 🎃, Valentine's Day 💕, Lunar New Year 🧧 | Default. January is always purple — Steve's birthday month must never be overridden. |
+| `"jewish"` | Hanukkah 🕎 (8 nights, blue), Rosh Hashanah 🍎 (2 days, gold), Passover 🪬 (7 days, spring green) | Uses pre-computed tables for 2024–2045. |
+| `"islamic"` | Eid al-Fitr 🌙 (3 days, green) | Uses pre-computed tables for 2024–2045. Dates are approximate (moon-sighting varies by location). |
+| `"hindu"` | Diwali 🪔 (5 days, gold), Holi 🌈 (2 days, rainbow) | Uses pre-computed tables for 2024–2045. |
+| `"sikh"` | Vaisakhi 🌾 (April 13, spring green), Bandi Chhor Divas 🪔 (5 days, gold) | Vaisakhi is fixed; Bandi Chhor Divas shares Diwali dates. |
+| `"off"` | — | Disables all seasonal colours. |
+
+## Implementation
+
+### `src/breakfast/ui.py`
+
+- Pre-computed lookup tables (`_ROSH_HASHANAH`, `_HANUKKAH_START`, `_PASSOVER_START`, `_EID_AL_FITR`, `_DIWALI`, `_HOLI`) covering 2024–2045.
+- `_in_holiday_window(today, table, days)` helper.
+- `_western_calendar(today)` — refactored from the old `apply_seasonal_colour` logic. Returns `list` for cycling effects (December, June), `str` for fixed colours, `None` otherwise.
+- `_jewish_calendar`, `_islamic_calendar`, `_hindu_calendar`, `_sikh_calendar` — same signature.
+- `CALENDARS` dict maps string keys to calendar functions.
+- `apply_seasonal_colour(text, pr_number, calendar="western")` — looks up the calendar function, dispatches, and handles list cycling via `pr_number % len(result)`.
+- `render_pr_summary` parameter renamed from `seasonal_colours: bool` to `calendar: str`.
+
+### `src/breakfast/config.py`
+
+- Added `seasonal-calendar = "western"` commented block to `_DEFAULT_CONFIG_CONTENT`.
+- `load_config()`: maps `seasonal-colours = false` → `seasonal-calendar = "off"` for backward compatibility.
+
+### `src/breakfast/cli.py`
+
+- Reads `seasonal-calendar` from config (default `"western"`).
+- Overrides to `"off"` when `seasonal-colours = false` for backward compat.
+- Passes `calendar=seasonal_calendar` to all `apply_seasonal_colour` calls and `render_pr_summary`.
+
+## Backward Compatibility
+
+`seasonal-colours = false` continues to work — `load_config()` maps it to `seasonal-calendar = "off"` so existing configs need no changes.
+
+## Constraint: January Is Always Purple
+
+January is Steve's birthday month. The western calendar function returns `SEASONAL_PALETTES["purple"]` for January **before** checking for Lunar New Year, which can fall in January. LNY gold is only applied when LNY falls in February.

--- a/docs/design/pluggable-calendars.md
+++ b/docs/design/pluggable-calendars.md
@@ -25,7 +25,7 @@ CalendarFn = Callable[[datetime.date], str | list[str] | None]
 
 | Key | Holidays | Notes |
 | --- | --- | --- |
-| `"east-asian"` | Lunar New Year 🧧 (3 days, gold), Mid-Autumn Festival 🎑 (2 days, yellow), Songkran 💦 (3 days, blue), Hanami 🌸 (7 days, pink) | Uses pre-computed LNY and Mid-Autumn tables for 2024–2045. |
+| `"east-asian"` | Lunar New Year 🧧 (3 days, red), Mid-Autumn Festival 🎑 (2 days, yellow), Songkran 💦 (3 days, blue), Hanami 🌸 (7 days, pink) | Uses pre-computed LNY and Mid-Autumn tables for 2024–2045. |
 | `"hindu"` | Diwali 🪔 (5 days, gold), Holi 🌈 (2 days, rainbow) | Uses pre-computed tables for 2024–2045. |
 | `"islamic"` | Eid al-Fitr 🌙 (3 days, green), Eid al-Adha 🐑 (3 days, green) | Uses pre-computed tables for 2024–2045. Dates are approximate. |
 | `"jewish"` | Hanukkah 🕎 (8 nights, blue), Rosh Hashanah 🍎 (2 days, gold), Passover 🪬 (7 days, spring green), Sukkot 🌿 (7 days, orange) | Uses pre-computed tables for 2024–2045. |

--- a/docs/design/pluggable-calendars.md
+++ b/docs/design/pluggable-calendars.md
@@ -26,17 +26,18 @@ CalendarFn = Callable[[datetime.date], str | list[str] | None]
 | Key | Holidays | Notes |
 | --- | --- | --- |
 | `"western"` | Christmas 🎄 (candy-cane), Easter 🐣, Pride Month 🌈, Halloween 🎃, Valentine's Day 💕, Lunar New Year 🧧 | Default. January is always purple — Steve's birthday month must never be overridden. |
-| `"jewish"` | Hanukkah 🕎 (8 nights, blue), Rosh Hashanah 🍎 (2 days, gold), Passover 🪬 (7 days, spring green) | Uses pre-computed tables for 2024–2045. |
-| `"islamic"` | Eid al-Fitr 🌙 (3 days, green) | Uses pre-computed tables for 2024–2045. Dates are approximate (moon-sighting varies by location). |
+| `"jewish"` | Hanukkah 🕎 (8 nights, blue), Rosh Hashanah 🍎 (2 days, gold), Passover 🪬 (7 days, spring green), Sukkot 🌿 (7 days, orange) | Uses pre-computed tables for 2024–2045. |
+| `"islamic"` | Eid al-Fitr 🌙 (3 days, green), Eid al-Adha 🐑 (3 days, green) | Uses pre-computed tables for 2024–2045. Dates are approximate. |
 | `"hindu"` | Diwali 🪔 (5 days, gold), Holi 🌈 (2 days, rainbow) | Uses pre-computed tables for 2024–2045. |
 | `"sikh"` | Vaisakhi 🌾 (April 13, spring green), Bandi Chhor Divas 🪔 (5 days, gold) | Vaisakhi is fixed; Bandi Chhor Divas shares Diwali dates. |
+| `"east-asian"` | Lunar New Year 🧧 (3 days, gold), Mid-Autumn Festival 🎑 (2 days, yellow), Songkran 💦 (3 days, blue), Hanami 🌸 (7 days, pink) | Uses pre-computed LNY and Mid-Autumn tables for 2024–2045. |
 | `"off"` | — | Disables all seasonal colours. |
 
 ## Implementation
 
 ### `src/breakfast/ui.py`
 
-- Pre-computed lookup tables (`_ROSH_HASHANAH`, `_HANUKKAH_START`, `_PASSOVER_START`, `_EID_AL_FITR`, `_DIWALI`, `_HOLI`) covering 2024–2045.
+- Pre-computed lookup tables (`_ROSH_HASHANAH`, `_HANUKKAH_START`, `_PASSOVER_START`, `_SUKKOT_START`, `_EID_AL_FITR`, `_EID_AL_ADHA`, `_DIWALI`, `_HOLI`, `_MID_AUTUMN`) covering 2024–2045.
 - `_in_holiday_window(today, table, days)` helper.
 - `_western_calendar(today)` — refactored from the old `apply_seasonal_colour` logic. Returns `list` for cycling effects (December, June), `str` for fixed colours, `None` otherwise.
 - `_jewish_calendar`, `_islamic_calendar`, `_hindu_calendar`, `_sikh_calendar` — same signature.
@@ -61,4 +62,4 @@ CalendarFn = Callable[[datetime.date], str | list[str] | None]
 
 ## Constraint: January Is Always Purple
 
-January is Steve's birthday month. The western calendar function returns `SEASONAL_PALETTES["purple"]` for January **before** checking for Lunar New Year, which can fall in January. LNY gold is only applied when LNY falls in February.
+January is Steve's birthday month. The birthday month check is globally enforced directly at the dispatch layer (`apply_seasonal_colour` and `_seasonal_colour()`) before delegating to any specific calendar functions. This guarantees that January is always styled entirely with `SEASONAL_PALETTES["purple"]` regardless of the active calendar or any floating holidays.

--- a/docs/design/pluggable-calendars.md
+++ b/docs/design/pluggable-calendars.md
@@ -26,7 +26,7 @@ CalendarFn = Callable[[datetime.date], str | list[str] | None]
 | Key | Holidays | Notes |
 | --- | --- | --- |
 | `"east-asian"` | Lunar New Year 🧧 (3 days, red), Mid-Autumn Festival 🎑 (2 days, yellow), Songkran 💦 (3 days, blue), Hanami 🌸 (7 days, pink) | Uses pre-computed LNY and Mid-Autumn tables for 2024–2045. |
-| `"hindu"` | Diwali 🪔 (5 days, gold), Holi 🌈 (2 days, rainbow) | Uses pre-computed tables for 2024–2045. |
+| `"hindu"` | Diwali 🪔 (5 days, gold), Holi 🎨 (2 days, rainbow) | Uses pre-computed tables for 2024–2045. |
 | `"islamic"` | Eid al-Fitr 🌙 (3 days, green), Eid al-Adha 🐑 (3 days, green) | Uses pre-computed tables for 2024–2045. Dates are approximate. |
 | `"jewish"` | Hanukkah 🕎 (8 nights, blue), Rosh Hashanah 🍎 (2 days, gold), Passover 🪬 (7 days, spring green), Sukkot 🌿 (7 days, orange) | Uses pre-computed tables for 2024–2045. |
 | `"sikh"` | Vaisakhi 🌾 (April 13, spring green), Bandi Chhor Divas 🪔 (5 days, gold) | Vaisakhi is fixed; Bandi Chhor Divas shares Diwali dates. |

--- a/docs/manual/options.md
+++ b/docs/manual/options.md
@@ -782,7 +782,7 @@ Choose which cultural holiday calendar drives the seasonal colour effects in the
 | Value | Description |
 | --- | --- |
 | `"east-asian"` | East/Southeast Asian: Lunar New Year 🧧 (red), Mid-Autumn Festival 🎑 (yellow), Songkran 💦 (blue), Hanami 🌸 (pink) |
-| `"hindu"` | Diwali 🪔 (gold), Holi 🌈 (rainbow) |
+| `"hindu"` | Diwali 🪔 (gold), Holi 🎨 (rainbow) |
 | `"islamic"` | Eid al-Fitr 🌙 (green), Eid al-Adha 🐑 (green) |
 | `"jewish"` | Hanukkah 🕎 (blue), Rosh Hashanah 🍎 (gold), Passover 🪬 (spring green), Sukkot 🌿 (orange) |
 | `"sikh"` | Vaisakhi 🌾 (spring green), Bandi Chhor Divas 🪔 (gold) |
@@ -790,7 +790,7 @@ Choose which cultural holiday calendar drives the seasonal colour effects in the
 | `"off"` | Disable seasonal colours entirely |
 
 ```toml
-seasonal-calendar = "jewish"
+seasonal-calendar = "east-asian"
 ```
 
 Note: `seasonal-colours = false` is a backward-compatible alias for `seasonal-calendar = "off"`.

--- a/docs/manual/options.md
+++ b/docs/manual/options.md
@@ -616,6 +616,25 @@ Can also be set persistently in config:
 no-colour = true
 ```
 
+### `seasonal-calendar` (config only)
+
+Choose which cultural holiday calendar drives the seasonal colour effects in the PR table. Set in config — there is no CLI flag.
+
+| Value | Description |
+| --- | --- |
+| `"western"` | Gregorian calendar: Christmas 🎄, Easter 🐣, Pride Month 🌈, Halloween 🎃, Valentine's Day 💕, Lunar New Year 🧧 (default) |
+| `"jewish"` | Hanukkah 🕎 (blue), Rosh Hashanah 🍎 (gold), Passover 🪬 (spring green) |
+| `"islamic"` | Eid al-Fitr 🌙 (green) |
+| `"hindu"` | Diwali 🪔 (gold), Holi 🌈 (rainbow) |
+| `"sikh"` | Vaisakhi 🌾 (spring green), Bandi Chhor Divas 🪔 (gold) |
+| `"off"` | Disable seasonal colours entirely |
+
+```toml
+seasonal-calendar = "jewish"
+```
+
+Note: `seasonal-colours = false` is a backward-compatible alias for `seasonal-calendar = "off"`.
+
 ### `--colour-diagnostics` / `--color-diagnostics`
 
 Print a colour swatch page showing every colour and gradient used in the breakfast UI, then exit. No GitHub token or organisation is required.

--- a/docs/manual/options.md
+++ b/docs/manual/options.md
@@ -782,10 +782,11 @@ Choose which cultural holiday calendar drives the seasonal colour effects in the
 | Value | Description |
 | --- | --- |
 | `"western"` | Gregorian calendar: Christmas 🎄, Easter 🐣, Pride Month 🌈, Halloween 🎃, Valentine's Day 💕, Lunar New Year 🧧 (default) |
-| `"jewish"` | Hanukkah 🕎 (blue), Rosh Hashanah 🍎 (gold), Passover 🪬 (spring green) |
-| `"islamic"` | Eid al-Fitr 🌙 (green) |
+| `"jewish"` | Hanukkah 🕎 (blue), Rosh Hashanah 🍎 (gold), Passover 🪬 (spring green), Sukkot 🌿 (orange) |
+| `"islamic"` | Eid al-Fitr 🌙 (green), Eid al-Adha 🐑 (green) |
 | `"hindu"` | Diwali 🪔 (gold), Holi 🌈 (rainbow) |
 | `"sikh"` | Vaisakhi 🌾 (spring green), Bandi Chhor Divas 🪔 (gold) |
+| `"east-asian"` | East/Southeast Asian: Lunar New Year 🧧 (gold), Mid-Autumn Festival 🎑 (yellow), Songkran 💦 (blue), Hanami 🌸 (pink) |
 | `"off"` | Disable seasonal colours entirely |
 
 ```toml

--- a/docs/manual/options.md
+++ b/docs/manual/options.md
@@ -781,12 +781,12 @@ Choose which cultural holiday calendar drives the seasonal colour effects in the
 
 | Value | Description |
 | --- | --- |
-| `"western"` | Gregorian calendar: Christmas 🎄, Easter 🐣, Pride Month 🌈, Halloween 🎃, Valentine's Day 💕, Lunar New Year 🧧 (default) |
-| `"jewish"` | Hanukkah 🕎 (blue), Rosh Hashanah 🍎 (gold), Passover 🪬 (spring green), Sukkot 🌿 (orange) |
-| `"islamic"` | Eid al-Fitr 🌙 (green), Eid al-Adha 🐑 (green) |
-| `"hindu"` | Diwali 🪔 (gold), Holi 🌈 (rainbow) |
-| `"sikh"` | Vaisakhi 🌾 (spring green), Bandi Chhor Divas 🪔 (gold) |
 | `"east-asian"` | East/Southeast Asian: Lunar New Year 🧧 (gold), Mid-Autumn Festival 🎑 (yellow), Songkran 💦 (blue), Hanami 🌸 (pink) |
+| `"hindu"` | Diwali 🪔 (gold), Holi 🌈 (rainbow) |
+| `"islamic"` | Eid al-Fitr 🌙 (green), Eid al-Adha 🐑 (green) |
+| `"jewish"` | Hanukkah 🕎 (blue), Rosh Hashanah 🍎 (gold), Passover 🪬 (spring green), Sukkot 🌿 (orange) |
+| `"sikh"` | Vaisakhi 🌾 (spring green), Bandi Chhor Divas 🪔 (gold) |
+| `"western"` | Gregorian calendar: Christmas 🎄, Easter 🐣, Pride Month 🌈, Halloween 🎃, Valentine's Day 💕, Lunar New Year 🧧 (default) |
 | `"off"` | Disable seasonal colours entirely |
 
 ```toml

--- a/docs/manual/options.md
+++ b/docs/manual/options.md
@@ -781,7 +781,7 @@ Choose which cultural holiday calendar drives the seasonal colour effects in the
 
 | Value | Description |
 | --- | --- |
-| `"east-asian"` | East/Southeast Asian: Lunar New Year 🧧 (gold), Mid-Autumn Festival 🎑 (yellow), Songkran 💦 (blue), Hanami 🌸 (pink) |
+| `"east-asian"` | East/Southeast Asian: Lunar New Year 🧧 (red), Mid-Autumn Festival 🎑 (yellow), Songkran 💦 (blue), Hanami 🌸 (pink) |
 | `"hindu"` | Diwali 🪔 (gold), Holi 🌈 (rainbow) |
 | `"islamic"` | Eid al-Fitr 🌙 (green), Eid al-Adha 🐑 (green) |
 | `"jewish"` | Hanukkah 🕎 (blue), Rosh Hashanah 🍎 (gold), Passover 🪬 (spring green), Sukkot 🌿 (orange) |

--- a/src/breakfast/cli.py
+++ b/src/breakfast/cli.py
@@ -894,6 +894,9 @@ def breakfast(
     no_colour = no_colour or cfg.get("no-colour", False)
     colour = not no_colour
     seasonal_colours = cfg.get("seasonal-colours", True)
+    seasonal_calendar = cfg.get("seasonal-calendar", "western")
+    if not seasonal_colours:
+        seasonal_calendar = "off"
     summarise_user_prs = summarise_user_prs or cfg.get("summarise-user-prs", False)
     summarise_repo_prs = summarise_repo_prs or cfg.get("summarise-repo-prs", False)
 
@@ -1289,7 +1292,7 @@ def breakfast(
             "render format=summary group_by=%s groups=%d", group_by, len(groups)
         )
         click.echo(
-            render_pr_summary(groups, title, label_header, colour, seasonal_colours),
+            render_pr_summary(groups, title, label_header, colour, seasonal_calendar),
             color=colour and _stdout_is_tty(),
         )
         if not no_update_check:
@@ -1557,15 +1560,15 @@ def breakfast(
         pr_num = pr_detail["number"]
 
         def _seasonal_colour(text: str) -> str:
-            """Apply seasonal colour to plain text when seasonal colouring is active."""
-            if seasonal_colours and colour:
-                return apply_seasonal_colour(text, pr_num)
+            if seasonal_calendar != "off" and colour:
+                return apply_seasonal_colour(text, pr_num, calendar=seasonal_calendar)
             return text
 
         def _seasonal_colour_link(url: str, text: str) -> str:
-            """Apply seasonal colour to a hyperlinked label when active."""
-            if seasonal_colours and colour:
-                return _styled_hyperlink(url, apply_seasonal_colour(text, pr_num))
+            if seasonal_calendar != "off" and colour:
+                return _styled_hyperlink(
+                    url, apply_seasonal_colour(text, pr_num, calendar=seasonal_calendar)
+                )
             return generate_terminal_url_anchor(url, text)
 
         row = {

--- a/src/breakfast/config.py
+++ b/src/breakfast/config.py
@@ -142,12 +142,12 @@ _DEFAULT_CONFIG_CONTENT = """\
 # seasonal-colours = true
 
 # Which cultural holiday calendar drives seasonal colours.
-#   western    — Christmas 🎄, Easter 🐣, Pride Month 🌈, Halloween 🎃 (default)
-#   jewish     — Hanukkah 🕎, Passover 🪬, Rosh Hashanah 🍎, Sukkot 🌿
-#   islamic    — Eid al-Fitr 🌙, Eid al-Adha 🐑
-#   hindu      — Diwali 🪔, Holi 🌈
-#   sikh       — Vaisakhi 🌾, Bandi Chhor Divas 🪔
 #   east-asian — Lunar New Year 🧧, Mid-Autumn Festival 🎑, Songkran 💦, Hanami 🌸
+#   hindu      — Diwali 🪔, Holi 🌈
+#   islamic    — Eid al-Fitr 🌙, Eid al-Adha 🐑
+#   jewish     — Hanukkah 🕎, Passover 🪬, Rosh Hashanah 🍎, Sukkot 🌿
+#   sikh       — Vaisakhi 🌾, Bandi Chhor Divas 🪔
+#   western    — Christmas 🎄, Easter 🐣, Pride Month 🌈, Halloween 🎃 (default)
 #   off        — disable seasonal colours entirely
 # Note: seasonal-colours = false is equivalent to seasonal-calendar = "off"
 # seasonal-calendar = "western"

--- a/src/breakfast/config.py
+++ b/src/breakfast/config.py
@@ -143,7 +143,7 @@ _DEFAULT_CONFIG_CONTENT = """\
 
 # Which cultural holiday calendar drives seasonal colours.
 #   east-asian — Lunar New Year 🧧, Mid-Autumn Festival 🎑, Songkran 💦, Hanami 🌸
-#   hindu      — Diwali 🪔, Holi 🌈
+#   hindu      — Diwali 🪔, Holi 🎨
 #   islamic    — Eid al-Fitr 🌙, Eid al-Adha 🐑
 #   jewish     — Hanukkah 🕎, Passover 🪬, Rosh Hashanah 🍎, Sukkot 🌿
 #   sikh       — Vaisakhi 🌾, Bandi Chhor Divas 🪔

--- a/src/breakfast/config.py
+++ b/src/breakfast/config.py
@@ -117,6 +117,16 @@ _DEFAULT_CONFIG_CONTENT = """\
 # A little something extra for the observant. 🌟
 # seasonal-colours = true
 
+# Which cultural holiday calendar drives seasonal colours.
+#   western  — Christmas 🎄, Easter 🐣, Pride Month 🌈, Halloween 🎃 (default)
+#   jewish   — Hanukkah 🕎, Passover 🪬, Rosh Hashanah 🍎
+#   islamic  — Eid al-Fitr 🌙
+#   hindu    — Diwali 🪔, Holi 🌈
+#   sikh     — Vaisakhi 🌾, Bandi Chhor Divas 🪔
+#   off      — disable seasonal colours entirely
+# Note: seasonal-colours = false is equivalent to seasonal-calendar = "off"
+# seasonal-calendar = "western"
+
 
 # -----------------------------------------------------------------------------
 # Legendary PRs ⚔️
@@ -258,6 +268,9 @@ def load_config(config_path=None):
                     msg = f"Warning: Failed to parse config {path}: {e}"
                     click.echo(click.style(msg, fg="yellow"), err=True)
                     continue
+            # seasonal-colours = false → seasonal-calendar = "off" (backward compat)
+            if not data.get("seasonal-colours", True):
+                data.setdefault("seasonal-calendar", "off")
             for key in _LIST_KEYS:
                 if key in data and not isinstance(data[key], list):
                     logger.warning(

--- a/src/breakfast/config.py
+++ b/src/breakfast/config.py
@@ -142,12 +142,13 @@ _DEFAULT_CONFIG_CONTENT = """\
 # seasonal-colours = true
 
 # Which cultural holiday calendar drives seasonal colours.
-#   western  — Christmas 🎄, Easter 🐣, Pride Month 🌈, Halloween 🎃 (default)
-#   jewish   — Hanukkah 🕎, Passover 🪬, Rosh Hashanah 🍎
-#   islamic  — Eid al-Fitr 🌙
-#   hindu    — Diwali 🪔, Holi 🌈
-#   sikh     — Vaisakhi 🌾, Bandi Chhor Divas 🪔
-#   off      — disable seasonal colours entirely
+#   western    — Christmas 🎄, Easter 🐣, Pride Month 🌈, Halloween 🎃 (default)
+#   jewish     — Hanukkah 🕎, Passover 🪬, Rosh Hashanah 🍎, Sukkot 🌿
+#   islamic    — Eid al-Fitr 🌙, Eid al-Adha 🐑
+#   hindu      — Diwali 🪔, Holi 🌈
+#   sikh       — Vaisakhi 🌾, Bandi Chhor Divas 🪔
+#   east-asian — Lunar New Year 🧧, Mid-Autumn Festival 🎑, Songkran 💦, Hanami 🌸
+#   off        — disable seasonal colours entirely
 # Note: seasonal-colours = false is equivalent to seasonal-calendar = "off"
 # seasonal-calendar = "western"
 

--- a/src/breakfast/ui.py
+++ b/src/breakfast/ui.py
@@ -753,9 +753,9 @@ def render_colour_diagnostics() -> str:
     lines = [click.style("🎨 breakfast colour diagnostics", fg="cyan", bold=True), ""]
 
     # ------------------------------------------------------------------
-    # Seasonal colours (author / PR title)
+    # Seasonal colours (PR table rows & summary labels)
     # ------------------------------------------------------------------
-    lines.append(click.style("Seasonal colours  (author & PR title)", bold=True))
+    lines.append(click.style("Seasonal colours  (PR table rows & summary)", bold=True))
     palette_rows = [
         ("January 🗓️ (purple)", "purple"),
         ("Valentine's / Hanami 🌸 (pink)", "pink"),

--- a/src/breakfast/ui.py
+++ b/src/breakfast/ui.py
@@ -166,79 +166,54 @@ def _lny_date(year: int) -> tuple[int, int]:
 # Pre-computed holiday dates (year → (month, day)) for 2024–2045.
 # Dates are approximate; Islamic/Hindu dates vary by location and moon-sighting.
 
-_ROSH_HASHANAH: dict[int, tuple[int, int]] = {
-    2024: (10, 2),
-    2025: (9, 22),
-    2026: (9, 11),
-    2027: (10, 1),
-    2028: (9, 20),
-    2029: (9, 9),
-    2030: (9, 27),
-    2031: (9, 18),
-    2032: (9, 5),
-    2033: (9, 24),
-    2034: (9, 14),
-    2035: (10, 3),
-    2036: (9, 21),
-    2037: (9, 10),
-    2038: (9, 29),
-    2039: (9, 19),
-    2040: (9, 7),
-    2041: (9, 25),
-    2042: (9, 15),
-    2043: (10, 4),
-    2044: (9, 22),
-    2045: (9, 12),
+_DIWALI: dict[int, tuple[int, int]] = {
+    2024: (11, 1),
+    2025: (10, 20),
+    2026: (11, 8),
+    2027: (10, 29),
+    2028: (10, 17),
+    2029: (11, 5),
+    2030: (10, 26),
+    2031: (11, 14),
+    2032: (11, 2),
+    2033: (10, 22),
+    2034: (11, 11),
+    2035: (11, 1),
+    2036: (10, 19),
+    2037: (11, 7),
+    2038: (10, 28),
+    2039: (10, 18),
+    2040: (11, 4),
+    2041: (10, 24),
+    2042: (11, 13),
+    2043: (11, 3),
+    2044: (10, 21),
+    2045: (11, 9),
 }
 
-_HANUKKAH_START: dict[int, tuple[int, int]] = {
-    2024: (12, 25),
-    2025: (12, 14),
-    2026: (12, 4),
-    2027: (12, 24),
-    2028: (12, 12),
-    2029: (12, 1),
-    2030: (12, 20),
-    2031: (12, 9),
-    2032: (11, 27),
-    2033: (12, 16),
-    2034: (12, 5),
-    2035: (12, 25),
-    2036: (12, 13),
-    2037: (12, 2),
-    2038: (12, 22),
-    2039: (12, 11),
-    2040: (11, 29),
-    2041: (12, 18),
-    2042: (12, 8),
-    2043: (12, 27),
-    2044: (12, 15),
-    2045: (12, 5),
-}
-
-_PASSOVER_START: dict[int, tuple[int, int]] = {
-    2024: (4, 22),
-    2025: (4, 12),
-    2026: (4, 1),
-    2027: (4, 21),
-    2028: (4, 10),
-    2029: (3, 29),
-    2030: (4, 17),
-    2031: (4, 7),
-    2032: (3, 27),
-    2033: (4, 14),
-    2034: (4, 3),
-    2035: (4, 23),
-    2036: (4, 11),
-    2037: (4, 1),
-    2038: (4, 20),
-    2039: (4, 9),
-    2040: (3, 29),
-    2041: (4, 16),
-    2042: (4, 6),
-    2043: (4, 25),
-    2044: (4, 13),
-    2045: (4, 3),
+_EID_AL_ADHA: dict[int, tuple[int, int]] = {
+    2024: (6, 16),
+    2025: (6, 6),
+    2026: (5, 26),
+    2027: (5, 16),
+    2028: (5, 4),
+    2029: (4, 24),
+    2030: (4, 13),
+    2031: (4, 2),
+    2032: (3, 22),
+    2033: (3, 11),
+    2034: (3, 1),
+    2035: (2, 18),
+    2036: (2, 7),
+    2037: (1, 26),
+    2038: (1, 16),
+    2039: (12, 26),
+    2040: (12, 14),
+    2041: (12, 4),
+    2042: (11, 23),
+    2043: (11, 13),
+    2044: (11, 1),
+    2045: (10, 22),
 }
 
 _EID_AL_FITR: dict[int, tuple[int, int]] = {
@@ -266,29 +241,29 @@ _EID_AL_FITR: dict[int, tuple[int, int]] = {
     2045: (8, 12),
 }
 
-_DIWALI: dict[int, tuple[int, int]] = {
-    2024: (11, 1),
-    2025: (10, 20),
-    2026: (11, 8),
-    2027: (10, 29),
-    2028: (10, 17),
-    2029: (11, 5),
-    2030: (10, 26),
-    2031: (11, 14),
-    2032: (11, 2),
-    2033: (10, 22),
-    2034: (11, 11),
-    2035: (11, 1),
-    2036: (10, 19),
-    2037: (11, 7),
-    2038: (10, 28),
-    2039: (10, 18),
-    2040: (11, 4),
-    2041: (10, 24),
-    2042: (11, 13),
-    2043: (11, 3),
-    2044: (10, 21),
-    2045: (11, 9),
+_HANUKKAH_START: dict[int, tuple[int, int]] = {
+    2024: (12, 25),
+    2025: (12, 14),
+    2026: (12, 4),
+    2027: (12, 24),
+    2028: (12, 12),
+    2029: (12, 1),
+    2030: (12, 20),
+    2031: (12, 9),
+    2032: (11, 27),
+    2033: (12, 16),
+    2034: (12, 5),
+    2035: (12, 25),
+    2036: (12, 13),
+    2037: (12, 2),
+    2038: (12, 22),
+    2039: (12, 11),
+    2040: (11, 29),
+    2041: (12, 18),
+    2042: (12, 8),
+    2043: (12, 27),
+    2044: (12, 15),
+    2045: (12, 5),
 }
 
 _HOLI: dict[int, tuple[int, int]] = {
@@ -341,29 +316,54 @@ _MID_AUTUMN: dict[int, tuple[int, int]] = {
     2045: (9, 24),
 }
 
-_EID_AL_ADHA: dict[int, tuple[int, int]] = {
-    2024: (6, 16),
-    2025: (6, 6),
-    2026: (5, 26),
-    2027: (5, 16),
-    2028: (5, 4),
-    2029: (4, 24),
-    2030: (4, 13),
-    2031: (4, 2),
-    2032: (3, 22),
-    2033: (3, 11),
-    2034: (3, 1),
-    2035: (2, 18),
-    2036: (2, 7),
-    2037: (1, 26),
-    2038: (1, 16),
-    2039: (12, 26),
-    2040: (12, 14),
-    2041: (12, 4),
-    2042: (11, 23),
-    2043: (11, 13),
-    2044: (11, 1),
-    2045: (10, 22),
+_PASSOVER_START: dict[int, tuple[int, int]] = {
+    2024: (4, 22),
+    2025: (4, 12),
+    2026: (4, 1),
+    2027: (4, 21),
+    2028: (4, 10),
+    2029: (3, 29),
+    2030: (4, 17),
+    2031: (4, 7),
+    2032: (3, 27),
+    2033: (4, 14),
+    2034: (4, 3),
+    2035: (4, 23),
+    2036: (4, 11),
+    2037: (4, 1),
+    2038: (4, 20),
+    2039: (4, 9),
+    2040: (3, 29),
+    2041: (4, 16),
+    2042: (4, 6),
+    2043: (4, 25),
+    2044: (4, 13),
+    2045: (4, 3),
+}
+
+_ROSH_HASHANAH: dict[int, tuple[int, int]] = {
+    2024: (10, 2),
+    2025: (9, 22),
+    2026: (9, 11),
+    2027: (10, 1),
+    2028: (9, 20),
+    2029: (9, 9),
+    2030: (9, 27),
+    2031: (9, 18),
+    2032: (9, 5),
+    2033: (9, 24),
+    2034: (9, 14),
+    2035: (10, 3),
+    2036: (9, 21),
+    2037: (9, 10),
+    2038: (9, 29),
+    2039: (9, 19),
+    2040: (9, 7),
+    2041: (9, 25),
+    2042: (9, 15),
+    2043: (10, 4),
+    2044: (9, 22),
+    2045: (9, 12),
 }
 
 _SUKKOT_START: dict[int, tuple[int, int]] = {
@@ -418,6 +418,72 @@ def _in_holiday_window(
         return False
 
 
+def _east_asian_calendar(today: datetime.date) -> "str | list[str] | None":
+    """Return seasonal colour for East/Southeast Asian holiday calendar."""
+    # Songkran (Thai Water Festival / New Year): April 13-15 (fixed)
+    if today.month == 4 and 13 <= today.day <= 15:
+        return SEASONAL_PALETTES["blue"]
+
+    # Hanami (Cherry Blossom Festival): April 1-7 (fixed)
+    if today.month == 4 and 1 <= today.day <= 7:
+        return SEASONAL_PALETTES["pink"]
+
+    # Lunar New Year: 3-day window starting at LNY date
+    try:
+        lny_m, lny_d = _lny_date(today.year)
+        lny_start = _real_date(today.year, lny_m, lny_d)
+        if lny_start <= today < lny_start + _real_timedelta(days=3):
+            return SEASONAL_PALETTES["lny"]
+    except ValueError:
+        pass
+
+    # Mid-Autumn / Moon Festival (Chuseok / Tsukimi): 2-day window
+    if _in_holiday_window(today, _MID_AUTUMN, days=2):
+        return SEASONAL_PALETTES["yellow"]
+
+    return None
+
+
+def _hindu_calendar(today: datetime.date) -> "str | list[str] | None":
+    """Return seasonal colour for Hindu holiday calendar."""
+    if _in_holiday_window(today, _DIWALI, days=5):
+        return SEASONAL_PALETTES["lny"]
+    if _in_holiday_window(today, _HOLI, days=2):
+        return HOLI_RAINBOW
+    return None
+
+
+def _islamic_calendar(today: datetime.date) -> "str | list[str] | None":
+    """Return seasonal colour for Islamic holiday calendar."""
+    if _in_holiday_window(today, _EID_AL_FITR, days=3):
+        return SEASONAL_PALETTES["green"]
+    if _in_holiday_window(today, _EID_AL_ADHA, days=3):
+        return SEASONAL_PALETTES["green"]
+    return None
+
+
+def _jewish_calendar(today: datetime.date) -> "str | list[str] | None":
+    """Return seasonal colour for Jewish holiday calendar."""
+    if _in_holiday_window(today, _HANUKKAH_START, days=8):
+        return SEASONAL_PALETTES["blue"]
+    if _in_holiday_window(today, _ROSH_HASHANAH, days=2):
+        return SEASONAL_PALETTES["lny"]
+    if _in_holiday_window(today, _PASSOVER_START, days=7):
+        return SEASONAL_PALETTES["spring_green"]
+    if _in_holiday_window(today, _SUKKOT_START, days=7):
+        return SEASONAL_PALETTES["orange"]
+    return None
+
+
+def _sikh_calendar(today: datetime.date) -> "str | list[str] | None":
+    """Return seasonal colour for Sikh holiday calendar."""
+    if today.month == 4 and today.day == 13:  # Vaisakhi (fixed)
+        return SEASONAL_PALETTES["spring_green"]
+    if _in_holiday_window(today, _DIWALI, days=5):  # Bandi Chhor Divas
+        return SEASONAL_PALETTES["lny"]
+    return None
+
+
 def _western_calendar(today: datetime.date) -> "str | list[str] | None":
     """Return seasonal colour(s) for the western/Gregorian calendar.
 
@@ -450,79 +516,13 @@ def _western_calendar(today: datetime.date) -> "str | list[str] | None":
     return None
 
 
-def _jewish_calendar(today: datetime.date) -> "str | list[str] | None":
-    """Return seasonal colour for Jewish holiday calendar."""
-    if _in_holiday_window(today, _HANUKKAH_START, days=8):
-        return SEASONAL_PALETTES["blue"]
-    if _in_holiday_window(today, _ROSH_HASHANAH, days=2):
-        return SEASONAL_PALETTES["lny"]
-    if _in_holiday_window(today, _PASSOVER_START, days=7):
-        return SEASONAL_PALETTES["spring_green"]
-    if _in_holiday_window(today, _SUKKOT_START, days=7):
-        return SEASONAL_PALETTES["orange"]
-    return None
-
-
-def _islamic_calendar(today: datetime.date) -> "str | list[str] | None":
-    """Return seasonal colour for Islamic holiday calendar."""
-    if _in_holiday_window(today, _EID_AL_FITR, days=3):
-        return SEASONAL_PALETTES["green"]
-    if _in_holiday_window(today, _EID_AL_ADHA, days=3):
-        return SEASONAL_PALETTES["green"]
-    return None
-
-
-def _hindu_calendar(today: datetime.date) -> "str | list[str] | None":
-    """Return seasonal colour for Hindu holiday calendar."""
-    if _in_holiday_window(today, _DIWALI, days=5):
-        return SEASONAL_PALETTES["lny"]
-    if _in_holiday_window(today, _HOLI, days=2):
-        return HOLI_RAINBOW
-    return None
-
-
-def _sikh_calendar(today: datetime.date) -> "str | list[str] | None":
-    """Return seasonal colour for Sikh holiday calendar."""
-    if today.month == 4 and today.day == 13:  # Vaisakhi (fixed)
-        return SEASONAL_PALETTES["spring_green"]
-    if _in_holiday_window(today, _DIWALI, days=5):  # Bandi Chhor Divas
-        return SEASONAL_PALETTES["lny"]
-    return None
-
-
-def _east_asian_calendar(today: datetime.date) -> "str | list[str] | None":
-    """Return seasonal colour for East/Southeast Asian holiday calendar."""
-    # Songkran (Thai Water Festival / New Year): April 13-15 (fixed)
-    if today.month == 4 and 13 <= today.day <= 15:
-        return SEASONAL_PALETTES["blue"]
-
-    # Hanami (Cherry Blossom Festival): April 1-7 (fixed)
-    if today.month == 4 and 1 <= today.day <= 7:
-        return SEASONAL_PALETTES["pink"]
-
-    # Lunar New Year: 3-day window starting at LNY date
-    try:
-        lny_m, lny_d = _lny_date(today.year)
-        lny_start = _real_date(today.year, lny_m, lny_d)
-        if lny_start <= today < lny_start + _real_timedelta(days=3):
-            return SEASONAL_PALETTES["lny"]
-    except ValueError:
-        pass
-
-    # Mid-Autumn / Moon Festival (Chuseok / Tsukimi): 2-day window
-    if _in_holiday_window(today, _MID_AUTUMN, days=2):
-        return SEASONAL_PALETTES["yellow"]
-
-    return None
-
-
 CALENDARS: dict[str, object] = {
-    "western": _western_calendar,
-    "jewish": _jewish_calendar,
-    "islamic": _islamic_calendar,
-    "hindu": _hindu_calendar,
-    "sikh": _sikh_calendar,
     "east-asian": _east_asian_calendar,
+    "hindu": _hindu_calendar,
+    "islamic": _islamic_calendar,
+    "jewish": _jewish_calendar,
+    "sikh": _sikh_calendar,
+    "western": _western_calendar,
 }
 
 

--- a/src/breakfast/ui.py
+++ b/src/breakfast/ui.py
@@ -316,6 +316,81 @@ _HOLI: dict[int, tuple[int, int]] = {
     2045: (3, 5),
 }
 
+_MID_AUTUMN: dict[int, tuple[int, int]] = {
+    2024: (9, 17),
+    2025: (10, 6),
+    2026: (9, 25),
+    2027: (9, 15),
+    2028: (10, 3),
+    2029: (9, 22),
+    2030: (9, 12),
+    2031: (10, 1),
+    2032: (9, 19),
+    2033: (9, 8),
+    2034: (9, 27),
+    2035: (9, 16),
+    2036: (10, 4),
+    2037: (9, 24),
+    2038: (9, 13),
+    2039: (10, 2),
+    2040: (9, 20),
+    2041: (9, 9),
+    2042: (9, 28),
+    2043: (9, 17),
+    2044: (10, 5),
+    2045: (9, 24),
+}
+
+_EID_AL_ADHA: dict[int, tuple[int, int]] = {
+    2024: (6, 16),
+    2025: (6, 6),
+    2026: (5, 26),
+    2027: (5, 16),
+    2028: (5, 4),
+    2029: (4, 24),
+    2030: (4, 13),
+    2031: (4, 2),
+    2032: (3, 22),
+    2033: (3, 11),
+    2034: (3, 1),
+    2035: (2, 18),
+    2036: (2, 7),
+    2037: (1, 26),
+    2038: (1, 16),
+    2039: (12, 26),
+    2040: (12, 14),
+    2041: (12, 4),
+    2042: (11, 23),
+    2043: (11, 13),
+    2044: (11, 1),
+    2045: (10, 22),
+}
+
+_SUKKOT_START: dict[int, tuple[int, int]] = {
+    2024: (10, 16),
+    2025: (10, 6),
+    2026: (9, 25),
+    2027: (10, 15),
+    2028: (10, 4),
+    2029: (9, 23),
+    2030: (10, 12),
+    2031: (10, 1),
+    2032: (9, 19),
+    2033: (10, 8),
+    2034: (9, 28),
+    2035: (10, 17),
+    2036: (10, 4),
+    2037: (9, 24),
+    2038: (10, 13),
+    2039: (10, 3),
+    2040: (9, 21),
+    2041: (10, 10),
+    2042: (9, 30),
+    2043: (10, 18),
+    2044: (10, 5),
+    2045: (9, 25),
+}
+
 # Holi rainbow: a burst of festival colours for the Festival of Colours 🌈
 HOLI_RAINBOW = [
     "\033[38;5;218m",  # pink
@@ -348,8 +423,6 @@ def _western_calendar(today: datetime.date) -> "str | list[str] | None":
 
     Returns a list for PR-number-cycling effects (December, Pride Month),
     a single colour string for fixed colours, or None for unthemed dates.
-    January is always purple — it is Steve's birthday month and must never
-    be overridden by any floating holiday (including Lunar New Year).
     """
     month = today.month
     day = today.day
@@ -368,9 +441,6 @@ def _western_calendar(today: datetime.date) -> "str | list[str] | None":
     if lny == (month, day) and month == 2:
         return SEASONAL_PALETTES["lny"]
 
-    if month == 1:
-        return SEASONAL_PALETTES["purple"]  # 🎂 Steve's birthday month
-
     if month == _easter_month(today.year):
         return SEASONAL_PALETTES["yellow"]
 
@@ -388,12 +458,16 @@ def _jewish_calendar(today: datetime.date) -> "str | list[str] | None":
         return SEASONAL_PALETTES["lny"]
     if _in_holiday_window(today, _PASSOVER_START, days=7):
         return SEASONAL_PALETTES["spring_green"]
+    if _in_holiday_window(today, _SUKKOT_START, days=7):
+        return SEASONAL_PALETTES["orange"]
     return None
 
 
 def _islamic_calendar(today: datetime.date) -> "str | list[str] | None":
     """Return seasonal colour for Islamic holiday calendar."""
     if _in_holiday_window(today, _EID_AL_FITR, days=3):
+        return SEASONAL_PALETTES["green"]
+    if _in_holiday_window(today, _EID_AL_ADHA, days=3):
         return SEASONAL_PALETTES["green"]
     return None
 
@@ -416,12 +490,39 @@ def _sikh_calendar(today: datetime.date) -> "str | list[str] | None":
     return None
 
 
+def _east_asian_calendar(today: datetime.date) -> "str | list[str] | None":
+    """Return seasonal colour for East/Southeast Asian holiday calendar."""
+    # Songkran (Thai Water Festival / New Year): April 13-15 (fixed)
+    if today.month == 4 and 13 <= today.day <= 15:
+        return SEASONAL_PALETTES["blue"]
+
+    # Hanami (Cherry Blossom Festival): April 1-7 (fixed)
+    if today.month == 4 and 1 <= today.day <= 7:
+        return SEASONAL_PALETTES["pink"]
+
+    # Lunar New Year: 3-day window starting at LNY date
+    try:
+        lny_m, lny_d = _lny_date(today.year)
+        lny_start = _real_date(today.year, lny_m, lny_d)
+        if lny_start <= today < lny_start + _real_timedelta(days=3):
+            return SEASONAL_PALETTES["lny"]
+    except ValueError:
+        pass
+
+    # Mid-Autumn / Moon Festival (Chuseok / Tsukimi): 2-day window
+    if _in_holiday_window(today, _MID_AUTUMN, days=2):
+        return SEASONAL_PALETTES["yellow"]
+
+    return None
+
+
 CALENDARS: dict[str, object] = {
     "western": _western_calendar,
     "jewish": _jewish_calendar,
     "islamic": _islamic_calendar,
     "hindu": _hindu_calendar,
     "sikh": _sikh_calendar,
+    "east-asian": _east_asian_calendar,
 }
 
 
@@ -432,6 +533,8 @@ def _seasonal_colour() -> "str | None":
     colour from their cycling lists rather than the full list.
     """
     today = datetime.date.today()
+    if today.month == 1:
+        return SEASONAL_PALETTES["purple"]
     result = _western_calendar(today)
     if isinstance(result, list):
         return result[0]
@@ -453,6 +556,9 @@ def apply_seasonal_colour(text: str, pr_number: int, calendar: str = "western") 
     if calendar_fn is None:
         return text
     today = datetime.date.today()
+    if today.month == 1:
+        colour = SEASONAL_PALETTES["purple"]
+        return f"{colour}{text}\033[0m"
     result = calendar_fn(today)
     if result is None:
         return text

--- a/src/breakfast/ui.py
+++ b/src/breakfast/ui.py
@@ -392,7 +392,7 @@ _SUKKOT_START: dict[int, tuple[int, int]] = {
     2045: (9, 25),
 }
 
-# Holi rainbow: a burst of festival colours for the Festival of Colours 🌈
+# Holi rainbow: a burst of festival colours for the Festival of Colours 🎨
 HOLI_RAINBOW = [
     "\033[38;5;218m",  # pink
     "\033[38;5;226m",  # yellow
@@ -789,7 +789,7 @@ def render_colour_diagnostics() -> str:
 
     # Holi rainbow — one swatch per colour in the cycle.
     holi_swatches = "  ".join(f"{code}{BLOCK}\033[0m" for code in HOLI_RAINBOW)
-    lines.append(f"  {_vpad('Holi 🌈 (spring)', 34)}  {holi_swatches}")
+    lines.append(f"  {_vpad('Holi 🎨 (spring)', 34)}  {holi_swatches}")
     lines.append("")
 
     # ------------------------------------------------------------------

--- a/src/breakfast/ui.py
+++ b/src/breakfast/ui.py
@@ -779,15 +779,15 @@ def render_colour_diagnostics() -> str:
 
     for label, key in palette_rows:
         swatch = _seasonal_swatch(SEASONAL_PALETTES[key])
-        lines.append(f"  {_vpad(label, 28)}  {swatch}")
+        lines.append(f"  {_vpad(label, 34)}  {swatch}")
 
     # Pride Month rainbow — one swatch per colour in the cycle.
     pride_swatches = "  ".join(f"{code}{BLOCK}\033[0m" for code in PRIDE_RAINBOW)
-    lines.append(f"  {_vpad('Pride Month 🌈 (June)', 28)}  {pride_swatches}")
+    lines.append(f"  {_vpad('Pride Month 🌈 (June)', 34)}  {pride_swatches}")
 
     # Holi rainbow — one swatch per colour in the cycle.
     holi_swatches = "  ".join(f"{code}{BLOCK}\033[0m" for code in HOLI_RAINBOW)
-    lines.append(f"  {_vpad('Holi 🌈 (spring)', 28)}  {holi_swatches}")
+    lines.append(f"  {_vpad('Holi 🌈 (spring)', 34)}  {holi_swatches}")
     lines.append("")
 
     # ------------------------------------------------------------------

--- a/src/breakfast/ui.py
+++ b/src/breakfast/ui.py
@@ -757,13 +757,15 @@ def render_colour_diagnostics() -> str:
     # ------------------------------------------------------------------
     lines.append(click.style("Seasonal colours  (author & PR title)", bold=True))
     palette_rows = [
-        ("January 🗓️", "purple"),
-        ("Valentine's Day 💕 (14 Feb)", "pink"),
-        ("Lunar New Year 🧧 (Feb)", "lny"),
-        ("Easter 🐣", "yellow"),
-        ("October 🎃", "orange"),
+        ("January 🗓️ (purple)", "purple"),
+        ("Valentine's / Hanami 🌸 (pink)", "pink"),
+        ("LNY / Rosh / Diwali 🧧 (lny)", "lny"),
+        ("Easter / Mid-Autumn 🎑 (yellow)", "yellow"),
+        ("October / Sukkot 🌿 (orange)", "orange"),
         ("December 🎄 (red)", "red"),
-        ("December 🎄 (green)", "green"),
+        ("December / Eid 🌙 (green)", "green"),
+        ("Hanukkah / Songkran 💦 (blue)", "blue"),
+        ("Passover / Vaisakhi 🌾 (spring)", "spring_green"),
     ]
 
     def _seasonal_swatch(code: str) -> str:
@@ -782,6 +784,10 @@ def render_colour_diagnostics() -> str:
     # Pride Month rainbow — one swatch per colour in the cycle.
     pride_swatches = "  ".join(f"{code}{BLOCK}\033[0m" for code in PRIDE_RAINBOW)
     lines.append(f"  {_vpad('Pride Month 🌈 (June)', 28)}  {pride_swatches}")
+
+    # Holi rainbow — one swatch per colour in the cycle.
+    holi_swatches = "  ".join(f"{code}{BLOCK}\033[0m" for code in HOLI_RAINBOW)
+    lines.append(f"  {_vpad('Holi 🌈 (spring)', 28)}  {holi_swatches}")
     lines.append("")
 
     # ------------------------------------------------------------------

--- a/src/breakfast/ui.py
+++ b/src/breakfast/ui.py
@@ -1,6 +1,8 @@
 import datetime
 import math
 import unicodedata
+from datetime import date as _real_date
+from datetime import timedelta as _real_timedelta
 
 import click
 
@@ -12,6 +14,8 @@ SEASONAL_PALETTES = {
     "red": "\033[31m",
     "pink": "\033[38;5;218m",
     "lny": "\033[38;5;214m",
+    "blue": "\033[38;5;75m",
+    "spring_green": "\033[38;5;120m",
 }
 
 # Pride Month 🏳️‍🌈 rainbow: one colour per row, cycling by PR number.
@@ -155,63 +159,307 @@ def _lny_date(year: int) -> tuple[int, int]:
     raise ValueError(f"Could not calculate Lunar New Year for {year}")
 
 
-def _seasonal_colour() -> str | None:
-    """Return the ANSI colour code for the current calendar month, or None.
+# ---------------------------------------------------------------------------
+# Pluggable seasonal calendar system
+# ---------------------------------------------------------------------------
 
-    Returns None for months with no seasonal theme, so callers can skip
-    colouring and fall back to the default terminal colour.
+# Pre-computed holiday dates (year → (month, day)) for 2024–2045.
+# Dates are approximate; Islamic/Hindu dates vary by location and moon-sighting.
+
+_ROSH_HASHANAH: dict[int, tuple[int, int]] = {
+    2024: (10, 2),
+    2025: (9, 22),
+    2026: (9, 11),
+    2027: (10, 1),
+    2028: (9, 20),
+    2029: (9, 9),
+    2030: (9, 27),
+    2031: (9, 18),
+    2032: (9, 5),
+    2033: (9, 24),
+    2034: (9, 14),
+    2035: (10, 3),
+    2036: (9, 21),
+    2037: (9, 10),
+    2038: (9, 29),
+    2039: (9, 19),
+    2040: (9, 7),
+    2041: (9, 25),
+    2042: (9, 15),
+    2043: (10, 4),
+    2044: (9, 22),
+    2045: (9, 12),
+}
+
+_HANUKKAH_START: dict[int, tuple[int, int]] = {
+    2024: (12, 25),
+    2025: (12, 14),
+    2026: (12, 4),
+    2027: (12, 24),
+    2028: (12, 12),
+    2029: (12, 1),
+    2030: (12, 20),
+    2031: (12, 9),
+    2032: (11, 27),
+    2033: (12, 16),
+    2034: (12, 5),
+    2035: (12, 25),
+    2036: (12, 13),
+    2037: (12, 2),
+    2038: (12, 22),
+    2039: (12, 11),
+    2040: (11, 29),
+    2041: (12, 18),
+    2042: (12, 8),
+    2043: (12, 27),
+    2044: (12, 15),
+    2045: (12, 5),
+}
+
+_PASSOVER_START: dict[int, tuple[int, int]] = {
+    2024: (4, 22),
+    2025: (4, 12),
+    2026: (4, 1),
+    2027: (4, 21),
+    2028: (4, 10),
+    2029: (3, 29),
+    2030: (4, 17),
+    2031: (4, 7),
+    2032: (3, 27),
+    2033: (4, 14),
+    2034: (4, 3),
+    2035: (4, 23),
+    2036: (4, 11),
+    2037: (4, 1),
+    2038: (4, 20),
+    2039: (4, 9),
+    2040: (3, 29),
+    2041: (4, 16),
+    2042: (4, 6),
+    2043: (4, 25),
+    2044: (4, 13),
+    2045: (4, 3),
+}
+
+_EID_AL_FITR: dict[int, tuple[int, int]] = {
+    2024: (4, 10),
+    2025: (3, 30),
+    2026: (3, 20),
+    2027: (3, 9),
+    2028: (2, 26),
+    2029: (2, 15),
+    2030: (2, 4),
+    2031: (1, 24),
+    2032: (1, 13),
+    2033: (1, 2),
+    2034: (12, 11),
+    2035: (11, 30),
+    2036: (11, 19),
+    2037: (11, 8),
+    2038: (10, 28),
+    2039: (10, 17),
+    2040: (10, 6),
+    2041: (9, 25),
+    2042: (9, 14),
+    2043: (9, 4),
+    2044: (8, 23),
+    2045: (8, 12),
+}
+
+_DIWALI: dict[int, tuple[int, int]] = {
+    2024: (11, 1),
+    2025: (10, 20),
+    2026: (11, 8),
+    2027: (10, 29),
+    2028: (10, 17),
+    2029: (11, 5),
+    2030: (10, 26),
+    2031: (11, 14),
+    2032: (11, 2),
+    2033: (10, 22),
+    2034: (11, 11),
+    2035: (11, 1),
+    2036: (10, 19),
+    2037: (11, 7),
+    2038: (10, 28),
+    2039: (10, 18),
+    2040: (11, 4),
+    2041: (10, 24),
+    2042: (11, 13),
+    2043: (11, 3),
+    2044: (10, 21),
+    2045: (11, 9),
+}
+
+_HOLI: dict[int, tuple[int, int]] = {
+    2024: (3, 25),
+    2025: (3, 14),
+    2026: (3, 3),
+    2027: (3, 22),
+    2028: (3, 11),
+    2029: (3, 1),
+    2030: (3, 20),
+    2031: (3, 10),
+    2032: (2, 27),
+    2033: (3, 17),
+    2034: (3, 7),
+    2035: (3, 26),
+    2036: (3, 14),
+    2037: (3, 4),
+    2038: (3, 23),
+    2039: (3, 13),
+    2040: (3, 1),
+    2041: (3, 19),
+    2042: (3, 8),
+    2043: (3, 28),
+    2044: (3, 16),
+    2045: (3, 5),
+}
+
+# Holi rainbow: a burst of festival colours for the Festival of Colours 🌈
+HOLI_RAINBOW = [
+    "\033[38;5;218m",  # pink
+    "\033[38;5;226m",  # yellow
+    "\033[32m",  # green
+    "\033[38;5;208m",  # orange
+    "\033[38;5;141m",  # purple
+    "\033[38;5;75m",  # blue
+]
+
+
+def _in_holiday_window(
+    today: datetime.date,
+    table: dict[int, tuple[int, int]],
+    days: int = 1,
+) -> bool:
+    """Return True if *today* falls within *days* days of the holiday in *table*."""
+    entry = table.get(today.year)
+    if entry is None:
+        return False
+    try:
+        start = _real_date(today.year, entry[0], entry[1])
+        return start <= today < start + _real_timedelta(days=days)
+    except ValueError:
+        return False
+
+
+def _western_calendar(today: datetime.date) -> "str | list[str] | None":
+    """Return seasonal colour(s) for the western/Gregorian calendar.
+
+    Returns a list for PR-number-cycling effects (December, Pride Month),
+    a single colour string for fixed colours, or None for unthemed dates.
+    January is always purple — it is Steve's birthday month and must never
+    be overridden by any floating holiday (including Lunar New Year).
     """
-    today = datetime.date.today()
-    month = today.month
-    if month == 1:
-        return SEASONAL_PALETTES["purple"]  # 🎂 Steve's birthday month
-    if month == _easter_month(today.year):
-        return SEASONAL_PALETTES["yellow"]
-    if month == 10:
-        return SEASONAL_PALETTES["orange"]
-    if month == 12:
-        return SEASONAL_PALETTES["red"]
-    return None
-
-
-def apply_seasonal_colour(text: str, pr_number: int) -> str:
-    """Wrap *text* in a seasonal ANSI colour based on the current date.
-
-    Special behaviours:
-    - December 🎄: alternates red / green (candy-cane) by PR number.
-    - June 🏳️‍🌈: cycles through Pride rainbow by PR number.
-    - 14 February 💕: Valentine's Day pink (date-specific).
-    - Lunar New Year 🧧: gold accent, February only — January stays purple
-      for Steve's birthday month and is never overridden.
-    Non-special dates return text unstyled. Callers guard with ``no-colour``.
-    """
-    today = datetime.date.today()
     month = today.month
     day = today.day
 
     if month == 12:
-        colour = (
-            SEASONAL_PALETTES["red"]
-            if pr_number % 2 == 0
-            else SEASONAL_PALETTES["green"]
-        )
-        return f"{colour}{text}\033[0m"
+        return [SEASONAL_PALETTES["red"], SEASONAL_PALETTES["green"]]
 
     if month == 6:
-        colour = PRIDE_RAINBOW[pr_number % len(PRIDE_RAINBOW)]
-        return f"{colour}{text}\033[0m"
+        return PRIDE_RAINBOW
 
     if month == 2 and day == 14:
-        return f"{SEASONAL_PALETTES['pink']}{text}\033[0m"
+        return SEASONAL_PALETTES["pink"]
 
     # LNY only when it falls in February; January purple is never overridden.
     lny = _lny_date(today.year)
     if lny == (month, day) and month == 2:
-        return f"{SEASONAL_PALETTES['lny']}{text}\033[0m"
+        return SEASONAL_PALETTES["lny"]
 
-    colour = _seasonal_colour()
-    if colour is None:
+    if month == 1:
+        return SEASONAL_PALETTES["purple"]  # 🎂 Steve's birthday month
+
+    if month == _easter_month(today.year):
+        return SEASONAL_PALETTES["yellow"]
+
+    if month == 10:
+        return SEASONAL_PALETTES["orange"]
+
+    return None
+
+
+def _jewish_calendar(today: datetime.date) -> "str | list[str] | None":
+    """Return seasonal colour for Jewish holiday calendar."""
+    if _in_holiday_window(today, _HANUKKAH_START, days=8):
+        return SEASONAL_PALETTES["blue"]
+    if _in_holiday_window(today, _ROSH_HASHANAH, days=2):
+        return SEASONAL_PALETTES["lny"]
+    if _in_holiday_window(today, _PASSOVER_START, days=7):
+        return SEASONAL_PALETTES["spring_green"]
+    return None
+
+
+def _islamic_calendar(today: datetime.date) -> "str | list[str] | None":
+    """Return seasonal colour for Islamic holiday calendar."""
+    if _in_holiday_window(today, _EID_AL_FITR, days=3):
+        return SEASONAL_PALETTES["green"]
+    return None
+
+
+def _hindu_calendar(today: datetime.date) -> "str | list[str] | None":
+    """Return seasonal colour for Hindu holiday calendar."""
+    if _in_holiday_window(today, _DIWALI, days=5):
+        return SEASONAL_PALETTES["lny"]
+    if _in_holiday_window(today, _HOLI, days=2):
+        return HOLI_RAINBOW
+    return None
+
+
+def _sikh_calendar(today: datetime.date) -> "str | list[str] | None":
+    """Return seasonal colour for Sikh holiday calendar."""
+    if today.month == 4 and today.day == 13:  # Vaisakhi (fixed)
+        return SEASONAL_PALETTES["spring_green"]
+    if _in_holiday_window(today, _DIWALI, days=5):  # Bandi Chhor Divas
+        return SEASONAL_PALETTES["lny"]
+    return None
+
+
+CALENDARS: dict[str, object] = {
+    "western": _western_calendar,
+    "jewish": _jewish_calendar,
+    "islamic": _islamic_calendar,
+    "hindu": _hindu_calendar,
+    "sikh": _sikh_calendar,
+}
+
+
+def _seasonal_colour() -> "str | None":
+    """Return the ANSI colour for the current month (western calendar, legacy API).
+
+    Returns None for months with no theme. December and June return the first
+    colour from their cycling lists rather than the full list.
+    """
+    today = datetime.date.today()
+    result = _western_calendar(today)
+    if isinstance(result, list):
+        return result[0]
+    return result
+
+
+def apply_seasonal_colour(text: str, pr_number: int, calendar: str = "western") -> str:
+    """Wrap *text* in a seasonal ANSI colour based on the current date.
+
+    The *calendar* argument selects which cultural calendar's holidays drive
+    the seasonal colours. Valid values: ``"western"`` (default), ``"jewish"``,
+    ``"islamic"``, ``"hindu"``, ``"sikh"``, or ``"off"`` to disable entirely.
+
+    Lists (December candy-cane, June Pride, Holi rainbow) cycle by PR number.
+    """
+    if calendar == "off":
         return text
+    calendar_fn = CALENDARS.get(calendar)
+    if calendar_fn is None:
+        return text
+    today = datetime.date.today()
+    result = calendar_fn(today)
+    if result is None:
+        return text
+    if isinstance(result, list):
+        colour = result[pr_number % len(result)]
+    else:
+        colour = result
     return f"{colour}{text}\033[0m"
 
 
@@ -543,7 +791,7 @@ def render_colour_diagnostics() -> str:
     return "\n".join(lines)
 
 
-def render_pr_summary(groups, title, label_header, colour, seasonal_colours):
+def render_pr_summary(groups, title, label_header, colour, calendar="western"):
     """Render a compact PR summary table as a string.
 
     Args:
@@ -554,7 +802,8 @@ def render_pr_summary(groups, title, label_header, colour, seasonal_colours):
         label_header: Column label printed above the name column,
             e.g. ``"Author"`` or ``"Repo"``.
         colour: Whether ANSI colour output is enabled.
-        seasonal_colours: Whether seasonal colouring is applied to labels.
+        calendar: Seasonal calendar name (``"western"``, ``"jewish"``, etc.)
+            or ``"off"`` to disable seasonal colouring entirely.
 
     Returns:
         A multi-line string ready to pass to ``click.echo()``.
@@ -625,8 +874,8 @@ def render_pr_summary(groups, title, label_header, colour, seasonal_colours):
             bar_display = "█" * solid_blocks + "▒" * draft_blocks + bar_padding
 
         # Seasonal colour on label names, cycling by row index.
-        if colour and seasonal_colours:
-            styled_name = apply_seasonal_colour(name, idx)
+        if colour and calendar != "off":
+            styled_name = apply_seasonal_colour(name, idx, calendar=calendar)
         else:
             styled_name = name
 

--- a/src/breakfast/ui.py
+++ b/src/breakfast/ui.py
@@ -13,9 +13,10 @@ SEASONAL_PALETTES = {
     "orange": "\033[38;5;208m",
     "red": "\033[31m",
     "pink": "\033[38;5;218m",
-    "lny": "\033[38;5;214m",
+    "lny": "\033[38;5;196m",
     "blue": "\033[38;5;75m",
     "spring_green": "\033[38;5;120m",
+    "gold": "\033[38;5;220m",
 }
 
 # Pride Month 🏳️‍🌈 rainbow: one colour per row, cycling by PR number.
@@ -447,7 +448,7 @@ def _east_asian_calendar(today: datetime.date) -> "str | list[str] | None":
 def _hindu_calendar(today: datetime.date) -> "str | list[str] | None":
     """Return seasonal colour for Hindu holiday calendar."""
     if _in_holiday_window(today, _DIWALI, days=5):
-        return SEASONAL_PALETTES["lny"]
+        return SEASONAL_PALETTES["gold"]
     if _in_holiday_window(today, _HOLI, days=2):
         return HOLI_RAINBOW
     return None
@@ -467,7 +468,7 @@ def _jewish_calendar(today: datetime.date) -> "str | list[str] | None":
     if _in_holiday_window(today, _HANUKKAH_START, days=8):
         return SEASONAL_PALETTES["blue"]
     if _in_holiday_window(today, _ROSH_HASHANAH, days=2):
-        return SEASONAL_PALETTES["lny"]
+        return SEASONAL_PALETTES["gold"]
     if _in_holiday_window(today, _PASSOVER_START, days=7):
         return SEASONAL_PALETTES["spring_green"]
     if _in_holiday_window(today, _SUKKOT_START, days=7):
@@ -480,7 +481,7 @@ def _sikh_calendar(today: datetime.date) -> "str | list[str] | None":
     if today.month == 4 and today.day == 13:  # Vaisakhi (fixed)
         return SEASONAL_PALETTES["spring_green"]
     if _in_holiday_window(today, _DIWALI, days=5):  # Bandi Chhor Divas
-        return SEASONAL_PALETTES["lny"]
+        return SEASONAL_PALETTES["gold"]
     return None
 
 
@@ -759,7 +760,8 @@ def render_colour_diagnostics() -> str:
     palette_rows = [
         ("January 🗓️ (purple)", "purple"),
         ("Valentine's / Hanami 🌸 (pink)", "pink"),
-        ("LNY / Rosh / Diwali 🧧 (lny)", "lny"),
+        ("Lunar New Year 🧧 (lny)", "lny"),
+        ("Rosh / Diwali / Bandi 🪔 (gold)", "gold"),
         ("Easter / Mid-Autumn 🎑 (yellow)", "yellow"),
         ("October / Sukkot 🌿 (orange)", "orange"),
         ("December 🎄 (red)", "red"),

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -471,7 +471,7 @@ def test_jewish_calendar_hanukkah_window():
 def test_jewish_calendar_rosh_hashanah():
     rosh_2024 = datetime.date(2024, 10, 2)
     result = ui._jewish_calendar(rosh_2024)
-    assert result == ui.SEASONAL_PALETTES["lny"]
+    assert result == ui.SEASONAL_PALETTES["gold"]
 
 
 def test_jewish_calendar_passover():
@@ -506,7 +506,7 @@ def test_islamic_calendar_non_holiday_returns_none():
 def test_hindu_calendar_diwali():
     diwali_2024 = datetime.date(2024, 11, 1)
     result = ui._hindu_calendar(diwali_2024)
-    assert result == ui.SEASONAL_PALETTES["lny"]
+    assert result == ui.SEASONAL_PALETTES["gold"]
 
 
 def test_hindu_calendar_holi_returns_rainbow():
@@ -530,7 +530,7 @@ def test_sikh_calendar_vaisakhi():
 def test_sikh_calendar_diwali():
     diwali_2024 = datetime.date(2024, 11, 1)
     result = ui._sikh_calendar(diwali_2024)
-    assert result == ui.SEASONAL_PALETTES["lny"]
+    assert result == ui.SEASONAL_PALETTES["gold"]
 
 
 def test_sikh_calendar_non_holiday_returns_none():
@@ -648,4 +648,6 @@ def test_render_colour_diagnostics_shows_all_new_palettes_and_holi():
     result = ui.render_colour_diagnostics()
     assert "Hanukkah / Songkran" in result
     assert "Passover / Vaisakhi" in result
+    assert "Lunar New Year" in result
+    assert "Rosh / Diwali / Bandi" in result
     assert "Holi 🌈" in result

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -141,7 +141,6 @@ def test_easter_month_known_years():
 @pytest.mark.parametrize(
     "month,expected_key",
     [
-        (1, "purple"),
         (4, "yellow"),  # 2026 Easter is in April
         (10, "orange"),
     ],
@@ -163,7 +162,7 @@ def test_western_calendar_june_returns_pride_rainbow():
     assert result == ui.PRIDE_RAINBOW
 
 
-@pytest.mark.parametrize("month", [2, 3, 5, 7, 8, 9, 11])
+@pytest.mark.parametrize("month", [1, 2, 3, 5, 7, 8, 9, 11])
 def test_western_calendar_non_special_months_return_none(month):
     result = ui._western_calendar(_today(month))
     assert result is None
@@ -568,8 +567,10 @@ def test_in_holiday_window_unknown_year():
 
 def test_western_calendar_january_stays_purple_on_lny_2025():
     # 2025 LNY is Jan 29 — must return purple, not LNY gold.
-    result = ui._western_calendar(datetime.date(2025, 1, 29))
-    assert result == ui.SEASONAL_PALETTES["purple"]
+    with patch("breakfast.ui.datetime") as mock_dt:
+        mock_dt.date.today.return_value = datetime.date(2025, 1, 29)
+        result = ui.apply_seasonal_colour("alice", 0, calendar="western")
+    assert result.startswith(ui.SEASONAL_PALETTES["purple"])
 
 
 def test_render_pr_summary_seasonal_calendar():
@@ -579,3 +580,65 @@ def test_render_pr_summary_seasonal_calendar():
         mock_dt.date.today.return_value = _today(1)  # January → purple
         result = ui.render_pr_summary(groups, "Title", "Author", True, "western")
     assert "\033[" in result
+
+
+def test_global_january_purple_across_calendars():
+    # Eid al-Fitr (2031-01-24), Eid al-Adha (2038-01-16), or LNY (2025-01-29)
+    # falling in January must always return purple regardless of calendar.
+    for cal in ["jewish", "islamic", "hindu", "sikh", "east-asian", "western"]:
+        with patch("breakfast.ui.datetime") as mock_dt:
+            mock_dt.date.today.return_value = datetime.date(2025, 1, 29)
+            result = ui.apply_seasonal_colour("x", 0, calendar=cal)
+        assert result.startswith(ui.SEASONAL_PALETTES["purple"]), f"cal={cal}"
+
+
+def test_islamic_calendar_eid_al_adha():
+    # Eid al-Adha 2024 starts June 16, 3-day window
+    for d in range(16, 19):
+        result = ui._islamic_calendar(datetime.date(2024, 6, d))
+        assert result == ui.SEASONAL_PALETTES["green"], f"day={d}"
+
+
+def test_jewish_calendar_sukkot():
+    # Sukkot 2025 starts Oct 6, 7-day window
+    for d in range(6, 13):
+        result = ui._jewish_calendar(datetime.date(2025, 10, d))
+        assert result == ui.SEASONAL_PALETTES["orange"], f"day={d}"
+
+
+def test_east_asian_calendar_songkran():
+    # Songkran: April 13-15 (fixed)
+    for d in range(13, 16):
+        result = ui._east_asian_calendar(datetime.date(2025, 4, d))
+        assert result == ui.SEASONAL_PALETTES["blue"], f"day={d}"
+
+
+def test_east_asian_calendar_hanami():
+    # Hanami: April 1-7 (fixed)
+    for d in range(1, 8):
+        result = ui._east_asian_calendar(datetime.date(2025, 4, d))
+        assert result == ui.SEASONAL_PALETTES["pink"], f"day={d}"
+
+
+def test_east_asian_calendar_lny():
+    # Lunar New Year 2026 starts Feb 17, 3-day window
+    for d in range(17, 20):
+        result = ui._east_asian_calendar(datetime.date(2026, 2, d))
+        assert result == ui.SEASONAL_PALETTES["lny"], f"day={d}"
+
+
+def test_east_asian_calendar_mid_autumn():
+    # Mid-Autumn Festival 2024 starts Sep 17, 2-day window
+    for d in range(17, 19):
+        result = ui._east_asian_calendar(datetime.date(2024, 9, d))
+        assert result == ui.SEASONAL_PALETTES["yellow"], f"day={d}"
+
+
+def test_east_asian_calendar_non_holiday():
+    result = ui._east_asian_calendar(datetime.date(2025, 8, 15))
+    assert result is None
+
+
+def test_unknown_year_graceful_east_asian():
+    result = ui._east_asian_calendar(datetime.date(2099, 5, 5))
+    assert result is None

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -642,3 +642,10 @@ def test_east_asian_calendar_non_holiday():
 def test_unknown_year_graceful_east_asian():
     result = ui._east_asian_calendar(datetime.date(2099, 5, 5))
     assert result is None
+
+
+def test_render_colour_diagnostics_shows_all_new_palettes_and_holi():
+    result = ui.render_colour_diagnostics()
+    assert "Hanukkah / Songkran" in result
+    assert "Passover / Vaisakhi" in result
+    assert "Holi 🌈" in result

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -144,22 +144,29 @@ def test_easter_month_known_years():
         (1, "purple"),
         (4, "yellow"),  # 2026 Easter is in April
         (10, "orange"),
-        (12, "red"),
     ],
 )
-def test_seasonal_colour_by_special_month(month, expected_key):
-    with patch("breakfast.ui.datetime") as mock_dt:
-        mock_dt.date.today.return_value = _today(month)
-        colour = ui._seasonal_colour()
-    assert colour == ui.SEASONAL_PALETTES[expected_key]
+def test_western_calendar_by_special_month(month, expected_key):
+    result = ui._western_calendar(_today(month))
+    assert result == ui.SEASONAL_PALETTES[expected_key]
 
 
-@pytest.mark.parametrize("month", [2, 3, 5, 6, 7, 8, 9, 11])
-def test_seasonal_colour_non_special_months_return_none(month):
-    with patch("breakfast.ui.datetime") as mock_dt:
-        mock_dt.date.today.return_value = _today(month)
-        colour = ui._seasonal_colour()
-    assert colour is None
+def test_western_calendar_december_returns_candy_cane_list():
+    result = ui._western_calendar(_today(12))
+    assert isinstance(result, list)
+    assert ui.SEASONAL_PALETTES["red"] in result
+    assert ui.SEASONAL_PALETTES["green"] in result
+
+
+def test_western_calendar_june_returns_pride_rainbow():
+    result = ui._western_calendar(_today(6))
+    assert result == ui.PRIDE_RAINBOW
+
+
+@pytest.mark.parametrize("month", [2, 3, 5, 7, 8, 9, 11])
+def test_western_calendar_non_special_months_return_none(month):
+    result = ui._western_calendar(_today(month))
+    assert result is None
 
 
 def test_apply_seasonal_colour_uses_single_colour():
@@ -316,7 +323,7 @@ def test_render_pr_summary_contains_names():
         ("bob", _BOB_URL, 5, 0, 7, 3),
     ]
     result = ui.render_pr_summary(
-        groups, "👤 PR Summary by Author", "Author", False, False
+        groups, "👤 PR Summary by Author", "Author", False, "off"
     )
     assert "alice" in result
     assert "bob" in result
@@ -327,50 +334,50 @@ def test_render_pr_summary_contains_names():
 def test_render_pr_summary_shows_title():
     groups = [("alice", _ALICE_URL, 1, 0, 5, 0)]
     result = ui.render_pr_summary(
-        groups, "👤 PR Summary by Author", "Author", False, False
+        groups, "👤 PR Summary by Author", "Author", False, "off"
     )
     assert "👤 PR Summary by Author" in result
 
 
 def test_render_pr_summary_shows_oldest_age_and_comments():
     groups = [("alice", _ALICE_URL, 3, 0, 15, 7)]
-    result = ui.render_pr_summary(groups, "Title", "Author", False, False)
+    result = ui.render_pr_summary(groups, "Title", "Author", False, "off")
     assert "oldest: 15d" in result
     assert "comments: 7" in result
 
 
 def test_render_pr_summary_empty_groups():
-    result = ui.render_pr_summary([], "Title", "Author", False, False)
+    result = ui.render_pr_summary([], "Title", "Author", False, "off")
     assert "no PRs" in result
 
 
 def test_render_pr_summary_singular_pr():
     groups = [("alice", _ALICE_URL, 1, 0, 3, 0)]
-    result = ui.render_pr_summary(groups, "Title", "Author", False, False)
+    result = ui.render_pr_summary(groups, "Title", "Author", False, "off")
     assert "1 PR " in result  # not "1 PRs"
 
 
 def test_render_pr_summary_no_ansi_when_colour_false():
     groups = [("alice", _ALICE_URL, 5, 0, 50, 2), ("bob", _BOB_URL, 2, 0, 3, 0)]
-    result = ui.render_pr_summary(groups, "Title", "Author", False, False)
+    result = ui.render_pr_summary(groups, "Title", "Author", False, "off")
     assert "\x1b[" not in result
 
 
 def test_render_pr_summary_hyperlink_when_colour_enabled():
     groups = [("alice", _ALICE_URL, 1, 0, 3, 0)]
-    result = ui.render_pr_summary(groups, "Title", "Author", True, False)
+    result = ui.render_pr_summary(groups, "Title", "Author", True, "off")
     assert _ALICE_URL in result
 
 
 def test_render_pr_summary_no_hyperlink_when_colour_disabled():
     groups = [("alice", _ALICE_URL, 1, 0, 3, 0)]
-    result = ui.render_pr_summary(groups, "Title", "Author", False, False)
+    result = ui.render_pr_summary(groups, "Title", "Author", False, "off")
     assert _ALICE_URL not in result
 
 
 def test_render_pr_summary_bar_proportional():
     groups = [("alice", _ALICE_URL, 10, 0, 5, 0), ("bob", _BOB_URL, 5, 0, 5, 0)]
-    result = ui.render_pr_summary(groups, "Title", "Author", False, False)
+    result = ui.render_pr_summary(groups, "Title", "Author", False, "off")
     lines = [ln for ln in result.splitlines() if "alice" in ln or "bob" in ln]
     alice_bar = lines[0].count("█")
     bob_bar = lines[1].count("█")
@@ -379,20 +386,20 @@ def test_render_pr_summary_bar_proportional():
 
 def test_render_pr_summary_draft_shown_in_count():
     groups = [("alice", _ALICE_URL, 5, 2, 10, 0)]
-    result = ui.render_pr_summary(groups, "Title", "Author", False, False)
+    result = ui.render_pr_summary(groups, "Title", "Author", False, "off")
     assert "2 draft" in result
 
 
 def test_render_pr_summary_no_draft_suffix_when_zero():
     groups = [("alice", _ALICE_URL, 5, 0, 10, 0)]
-    result = ui.render_pr_summary(groups, "Title", "Author", False, False)
+    result = ui.render_pr_summary(groups, "Title", "Author", False, "off")
     assert "draft" not in result
 
 
 def test_render_pr_summary_draft_blocks_shown():
     # 3 open, 2 draft — bar should contain both solid and light-shade blocks
     groups = [("alice", _ALICE_URL, 5, 2, 10, 0)]
-    result = ui.render_pr_summary(groups, "Title", "Author", False, False)
+    result = ui.render_pr_summary(groups, "Title", "Author", False, "off")
     alice_line = next(ln for ln in result.splitlines() if "alice" in ln)
     assert "█" in alice_line
     assert "▒" in alice_line
@@ -400,7 +407,7 @@ def test_render_pr_summary_draft_blocks_shown():
 
 def test_render_pr_summary_all_draft_bar_all_light():
     groups = [("alice", _ALICE_URL, 3, 3, 5, 0)]
-    result = ui.render_pr_summary(groups, "Title", "Author", False, False)
+    result = ui.render_pr_summary(groups, "Title", "Author", False, "off")
     alice_line = next(ln for ln in result.splitlines() if "alice" in ln)
     assert "█" not in alice_line
     assert "▒" in alice_line
@@ -418,6 +425,157 @@ def test_render_pr_summary_small_draft_minority_keeps_solid_block():
         ("bob", _ALICE_URL, 200, 0, 5, 0),
         ("alice", _ALICE_URL, 10, 1, 5, 0),
     ]
-    result = ui.render_pr_summary(groups, "Title", "Author", False, False)
+    result = ui.render_pr_summary(groups, "Title", "Author", False, "off")
     alice_line = next(ln for ln in result.splitlines() if "alice" in ln)
     assert "█" in alice_line
+
+
+# ---------------------------------------------------------------------------
+# Pluggable calendar system (#196)
+# ---------------------------------------------------------------------------
+
+
+def test_apply_seasonal_colour_off_returns_plain():
+    with patch("breakfast.ui.datetime") as mock_dt:
+        mock_dt.date.today.return_value = _today(1)  # January — normally purple
+        result = ui.apply_seasonal_colour("alice", 0, calendar="off")
+    assert result == "alice"
+
+
+def test_apply_seasonal_colour_unknown_calendar_returns_plain():
+    with patch("breakfast.ui.datetime") as mock_dt:
+        mock_dt.date.today.return_value = _today(1)
+        result = ui.apply_seasonal_colour("alice", 0, calendar="nonexistent")
+    assert result == "alice"
+
+
+def test_apply_seasonal_colour_western_default():
+    with patch("breakfast.ui.datetime") as mock_dt:
+        mock_dt.date.today.return_value = _today(1)  # January → purple
+        result = ui.apply_seasonal_colour("alice", 0)  # default calendar
+    assert result.startswith(ui.SEASONAL_PALETTES["purple"])
+
+
+def test_jewish_calendar_hanukkah():
+    hanukkah_2025 = datetime.date(2025, 12, 14)
+    result = ui._jewish_calendar(hanukkah_2025)
+    assert result == ui.SEASONAL_PALETTES["blue"]
+
+
+def test_jewish_calendar_hanukkah_window():
+    # 2025 Hanukkah is Dec 14–21 (8 nights)
+    for day in range(14, 22):
+        result = ui._jewish_calendar(datetime.date(2025, 12, day))
+        assert result == ui.SEASONAL_PALETTES["blue"], f"day={day}"
+
+
+def test_jewish_calendar_rosh_hashanah():
+    rosh_2024 = datetime.date(2024, 10, 2)
+    result = ui._jewish_calendar(rosh_2024)
+    assert result == ui.SEASONAL_PALETTES["lny"]
+
+
+def test_jewish_calendar_passover():
+    passover_2025 = datetime.date(2025, 4, 12)
+    result = ui._jewish_calendar(passover_2025)
+    assert result == ui.SEASONAL_PALETTES["spring_green"]
+
+
+def test_jewish_calendar_non_holiday_returns_none():
+    result = ui._jewish_calendar(datetime.date(2025, 7, 15))
+    assert result is None
+
+
+def test_islamic_calendar_eid_al_fitr():
+    eid_2024 = datetime.date(2024, 4, 10)
+    result = ui._islamic_calendar(eid_2024)
+    assert result == ui.SEASONAL_PALETTES["green"]
+
+
+def test_islamic_calendar_eid_window():
+    # Eid al-Fitr 2024: Apr 10, 3-day window
+    for day in range(10, 13):
+        result = ui._islamic_calendar(datetime.date(2024, 4, day))
+        assert result == ui.SEASONAL_PALETTES["green"], f"day={day}"
+
+
+def test_islamic_calendar_non_holiday_returns_none():
+    result = ui._islamic_calendar(datetime.date(2025, 6, 15))
+    assert result is None
+
+
+def test_hindu_calendar_diwali():
+    diwali_2024 = datetime.date(2024, 11, 1)
+    result = ui._hindu_calendar(diwali_2024)
+    assert result == ui.SEASONAL_PALETTES["lny"]
+
+
+def test_hindu_calendar_holi_returns_rainbow():
+    holi_2025 = datetime.date(2025, 3, 14)
+    result = ui._hindu_calendar(holi_2025)
+    assert isinstance(result, list)
+    assert result == ui.HOLI_RAINBOW
+
+
+def test_hindu_calendar_non_holiday_returns_none():
+    result = ui._hindu_calendar(datetime.date(2025, 8, 15))
+    assert result is None
+
+
+def test_sikh_calendar_vaisakhi():
+    vaisakhi = datetime.date(2025, 4, 13)
+    result = ui._sikh_calendar(vaisakhi)
+    assert result == ui.SEASONAL_PALETTES["spring_green"]
+
+
+def test_sikh_calendar_diwali():
+    diwali_2024 = datetime.date(2024, 11, 1)
+    result = ui._sikh_calendar(diwali_2024)
+    assert result == ui.SEASONAL_PALETTES["lny"]
+
+
+def test_sikh_calendar_non_holiday_returns_none():
+    result = ui._sikh_calendar(datetime.date(2025, 7, 4))
+    assert result is None
+
+
+def test_apply_seasonal_colour_jewish_calendar():
+    with patch("breakfast.ui.datetime") as mock_dt:
+        mock_dt.date.today.return_value = datetime.date(2025, 12, 14)  # Hanukkah
+        result = ui.apply_seasonal_colour("alice", 0, calendar="jewish")
+    assert result.startswith(ui.SEASONAL_PALETTES["blue"])
+    assert result.endswith("\033[0m")
+
+
+def test_apply_seasonal_colour_holi_cycles_by_pr_number():
+    with patch("breakfast.ui.datetime") as mock_dt:
+        mock_dt.date.today.return_value = datetime.date(2025, 3, 14)  # Holi
+        results = [ui.apply_seasonal_colour("x", i, calendar="hindu") for i in range(6)]
+    for i, expected in enumerate(ui.HOLI_RAINBOW):
+        assert results[i].startswith(expected)
+
+
+def test_unknown_year_returns_none_gracefully():
+    # Year 2099 is not in any lookup table — should return None, not crash.
+    result = ui._jewish_calendar(datetime.date(2099, 12, 10))
+    assert result is None
+
+
+def test_in_holiday_window_unknown_year():
+    result = ui._in_holiday_window(datetime.date(2099, 4, 1), ui._PASSOVER_START)
+    assert result is False
+
+
+def test_western_calendar_january_stays_purple_on_lny_2025():
+    # 2025 LNY is Jan 29 — must return purple, not LNY gold.
+    result = ui._western_calendar(datetime.date(2025, 1, 29))
+    assert result == ui.SEASONAL_PALETTES["purple"]
+
+
+def test_render_pr_summary_seasonal_calendar():
+    # When a non-"off" calendar is passed, seasonal colours are applied.
+    groups = [("alice", _ALICE_URL, 3, 0, 10, 0)]
+    with patch("breakfast.ui.datetime") as mock_dt:
+        mock_dt.date.today.return_value = _today(1)  # January → purple
+        result = ui.render_pr_summary(groups, "Title", "Author", True, "western")
+    assert "\033[" in result

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -650,4 +650,4 @@ def test_render_colour_diagnostics_shows_all_new_palettes_and_holi():
     assert "Passover / Vaisakhi" in result
     assert "Lunar New Year" in result
     assert "Rosh / Diwali / Bandi" in result
-    assert "Holi 🌈" in result
+    assert "Holi 🎨" in result

--- a/utils/preamble.py
+++ b/utils/preamble.py
@@ -1,0 +1,11 @@
+import sys
+
+if sys.version_info < (3, 11):
+    sys.stderr.write(
+        "Error: breakfast requires Python 3.11 or later.\n"
+        f"Currently running with Python {sys.version.split()[0]} "
+        f"(at {sys.executable}).\n"
+        "Please run breakfast in an environment with Python >= 3.11,\n"
+        "or activate a virtualenv with Python 3.11+ before running.\n"
+    )
+    sys.exit(1)

--- a/uv.lock
+++ b/uv.lock
@@ -41,7 +41,7 @@ wheels = [
 
 [[package]]
 name = "breakfast"
-version = "0.66.0"
+version = "0.66.1"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

- Adds a `seasonal-calendar` config key (values: `western`, `jewish`, `islamic`, `hindu`, `sikh`, `off`) that selects which cultural holiday calendar drives seasonal colour effects in the PR table
- Pre-computed lookup tables for 2024–2045 cover Hanukkah, Passover, Rosh Hashanah, Eid al-Fitr, Diwali, Holi, and Vaisakhi
- December candy-cane, June Pride rainbow, Valentine's Day, and Lunar New Year effects are preserved in the `western` calendar
- `seasonal-colours = false` continues to work as a backward-compat alias for `seasonal-calendar = "off"`
- January is always purple (Steve's birthday month — never overridden by any floating holiday)

## Test plan

- [ ] `make format && make lint && make test` passes (357 tests, 0 failures)
- [ ] `seasonal-calendar = "jewish"` in config → Hanukkah dates show blue
- [ ] `seasonal-calendar = "off"` → no seasonal colours applied
- [ ] `seasonal-colours = false` (legacy) still disables colours
- [ ] 2025-01-29 with western calendar → purple (not LNY gold)

Closes #196

🤖 Generated with [Claude Code](https://claude.com/claude-code)