### PR TITLE
#292: Support per-org scoped repo filter with org:filter syntax

### DIFF
--- a/docs/manual/options.md
+++ b/docs/manual/options.md
@@ -7,13 +7,24 @@
 The GitHub organization to query for pull requests. Repeat the flag to query
 multiple organizations at once — their PRs are combined and deduplicated.
 
+You can optionally append a **scoped repo filter** to any org using a colon separator:
+
+| Flag form | Behaviour |
+| --- | --- |
+| `-o my-org` | Use the global `-r` filter (or all repos if no `-r`) |
+| `-o my-org:api` | Override: only repos matching `api` for this org |
+| `-o my-org:` | Override: all repos for this org, ignoring any global `-r` |
+
 ```bash
-breakfast -o my-org -r my-app
-breakfast -o my-org -o another-org                  # two orgs
-breakfast -o my-org -o another-org -r platform      # two orgs, repo filter
+breakfast -o my-org -r my-app                           # global filter
+breakfast -o my-org -o another-org                      # two orgs, no filter
+breakfast -o my-org -o another-org -r platform          # global filter for both orgs
+breakfast -o my-org:api -o another-org:platform         # per-org filters
+breakfast -o my-org:api -o another-org -r platform      # scoped for my-org, global for another-org
+breakfast -o my-org: -o another-org -r platform         # all repos for my-org; filtered for another-org
 ```
 
-Config key supports both a single string and a list:
+Config key supports both a single string and a list, with optional scoped filters:
 
 ```toml
 # Single org
@@ -21,6 +32,12 @@ organization = "my-org"
 
 # Multiple orgs
 organization = ["my-org", "another-org"]
+
+# Per-org scoped filters
+organization = ["my-org:api", "another-org:platform"]
+
+# Mixed: scoped for one, global -r for the other
+organization = ["my-org:api", "another-org"]
 ```
 
 ### `--repo-filter`, `-r`

--- a/src/breakfast/cli.py
+++ b/src/breakfast/cli.py
@@ -339,6 +339,20 @@ def _print_debug_summary(t0, pr_count, api_stats, graphql_rate_limit):
     click.echo("\n".join(lines), err=True)
 
 
+def _parse_org_spec(spec: str) -> tuple[str, list[str] | None]:
+    """Parse an org spec that may carry a scoped repo filter after a colon.
+
+    Returns (org_name, scoped_filters) where scoped_filters is:
+      - None  → no colon; defer to the global -r filters
+      - []    → colon present but no filter; match all repos for this org
+      - [str] → colon present with filter text; match only that pattern
+    """
+    if ":" not in spec:
+        return spec, None
+    org, _, filter_text = spec.partition(":")
+    return org, [filter_text] if filter_text else []
+
+
 def get_pr_age_days(pr_detail, now=None):
     from datetime import datetime, timezone
 
@@ -514,6 +528,9 @@ def _fetch_pr_bundle(url, fetch_checks, fetch_approvals):
     help=(
         "GitHub organization to query for PRs. Repeat for multiple"
         " organizations, e.g. -o my-org -o another-org."
+        " Optionally append a scoped repo filter with a colon:"
+        " -o my-org:api (only 'api' repos for that org),"
+        " -o my-org: (all repos for that org, ignoring global -r)."
     ),
 )
 @click.option(
@@ -856,6 +873,9 @@ def breakfast(
             organizations = [cfg_org]
         else:
             organizations = []
+    # Parse org:filter scoped syntax; rebuild organizations to plain names
+    org_specs = [_parse_org_spec(s) for s in organizations]
+    organizations = [org for org, _ in org_specs]
     # repo_filter is a tuple from multiple=True; merge with config
     if repo_filter:
         repo_filters = list(repo_filter)
@@ -990,7 +1010,10 @@ def breakfast(
     if show_config:
         click.echo("Resolved config:")
         resolved = {
-            "organization": organizations,
+            "organization": [
+                org if scoped is None else (org + ":" + (scoped[0] if scoped else ""))
+                for org, scoped in org_specs
+            ],
             "repo-filter": repo_filters,
             "ignore-author": ignore_author,
             "mine-only": mine_only,
@@ -1021,12 +1044,12 @@ def breakfast(
         sys.exit(0)
 
     logger.info(
-        "startup org=%s repo_filter=%r mine_only=%s ignore_author=%r"
+        "startup org_specs=%s repo_filters=%r mine_only=%s ignore_author=%r"
         " cache_enabled=%s cache_ttl=%ss refresh=%s refresh_prs=%s"
         " checks=%s approvals=%s age=%s legendary=%s legendary_only=%s"
         " limit=%s max_title_length=%s status_style=%s format=%s"
         " filter_state=%r filter_check=%r filter_approval=%r search=%r api_stats=%s",
-        organizations,
+        org_specs,
         repo_filters,
         mine_only,
         ignore_author,
@@ -1085,8 +1108,15 @@ def breakfast(
     pr_data = []
     t_acquire = time.monotonic()
 
-    # Combined cache key for all orgs (sorted for determinism)
-    org_cache_key = "|".join(sorted(o.lower() for o in organizations))
+    # Cache key encodes each org with its effective scoped filter for determinism
+    def _org_spec_cache_segment(org: str, scoped: list[str] | None) -> str:
+        if scoped is None:
+            return org.lower()
+        return org.lower() + ":" + (scoped[0].lower() if scoped else "")
+
+    org_cache_key = "|".join(
+        sorted(_org_spec_cache_segment(o, s) for o, s in org_specs)
+    )
 
     # --- Layer 1: full PR detail cache (skip on --refresh or --refresh-prs) ---
     pr_details = None
@@ -1121,9 +1151,12 @@ def breakfast(
 
         if prs is None:
             prs = []
-            for org in organizations:
+            for org, scoped_filters in org_specs:
+                effective_filters = (
+                    repo_filters if scoped_filters is None else scoped_filters
+                )
                 try:
-                    prs.extend(get_github_prs(org, repo_filters))
+                    prs.extend(get_github_prs(org, effective_filters))
                 except (
                     requests.exceptions.ConnectionError,
                     requests.exceptions.Timeout,
@@ -1131,7 +1164,7 @@ def breakfast(
                     logger.exception(
                         "graphql_fetch_failed org=%s repo_filters=%r error=%r",
                         org,
-                        repo_filters,
+                        effective_filters,
                         str(exc),
                     )
                     msg = (

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3233,3 +3233,112 @@ def test_multiple_repo_filters_config_list(monkeypatch, tmp_path):
 
     assert result.exit_code == 0
     assert set(captured) == {"api", "platform"}
+
+
+# ---------------------------------------------------------------------------
+# Per-org scoped repo filter — org:filter syntax (#292)
+# ---------------------------------------------------------------------------
+
+
+def test_parse_org_spec_no_colon():
+    assert cli._parse_org_spec("my-org") == ("my-org", None)
+
+
+def test_parse_org_spec_with_filter():
+    assert cli._parse_org_spec("my-org:api") == ("my-org", ["api"])
+
+
+def test_parse_org_spec_empty_filter():
+    assert cli._parse_org_spec("my-org:") == ("my-org", [])
+
+
+def test_parse_org_spec_degenerate_multiple_colons():
+    # partition stops at first colon; extra colons go into the filter text
+    assert cli._parse_org_spec("my-org:a:b") == ("my-org", ["a:b"])
+
+
+def test_scoped_filter_overrides_global_repo_filter(monkeypatch):
+    """When org has a scoped filter, it wins over the global -r flag."""
+    monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "tok")
+    monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
+    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+
+    captured = {}
+
+    def fake_get_prs(org, repo_filters):
+        captured[org] = list(repo_filters)
+        return []
+
+    monkeypatch.setattr(cli, "get_github_prs", fake_get_prs)
+
+    runner = CliRunner()
+    runner.invoke(cli.breakfast, ["-o", "my-org:api", "-r", "platform"])
+
+    assert captured["my-org"] == ["api"]
+
+
+def test_empty_scoped_filter_matches_all_ignoring_global(monkeypatch):
+    """org: (empty scoped) passes an empty filter list, matching all repos."""
+    monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "tok")
+    monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
+    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+
+    captured = {}
+
+    def fake_get_prs(org, repo_filters):
+        captured[org] = list(repo_filters)
+        return []
+
+    monkeypatch.setattr(cli, "get_github_prs", fake_get_prs)
+
+    runner = CliRunner()
+    runner.invoke(cli.breakfast, ["-o", "my-org:", "-r", "platform"])
+
+    assert captured["my-org"] == []
+
+
+def test_mixed_scoped_and_global_filters(monkeypatch):
+    """Scoped org uses its own filter; unscoped org defers to global -r."""
+    monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "tok")
+    monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
+    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+
+    captured = {}
+
+    def fake_get_prs(org, repo_filters):
+        captured[org] = list(repo_filters)
+        return []
+
+    monkeypatch.setattr(cli, "get_github_prs", fake_get_prs)
+
+    runner = CliRunner()
+    runner.invoke(cli.breakfast, ["-o", "org-a:api", "-o", "org-b", "-r", "platform"])
+
+    assert captured["org-a"] == ["api"]
+    assert captured["org-b"] == ["platform"]
+
+
+def test_scoped_filter_from_config(monkeypatch, tmp_path):
+    """Config file org:filter syntax routes per-org filters correctly."""
+    monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "tok")
+    monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
+    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+
+    config_file = tmp_path / "breakfast.toml"
+    config_file.write_text(
+        'organization = ["my-org:api", "other-org"]\nrepo-filter = "platform"\n'
+    )
+
+    captured = {}
+
+    def fake_get_prs(org, repo_filters):
+        captured[org] = list(repo_filters)
+        return []
+
+    monkeypatch.setattr(cli, "get_github_prs", fake_get_prs)
+
+    runner = CliRunner()
+    runner.invoke(cli.breakfast, ["--config", str(config_file)])
+
+    assert captured["my-org"] == ["api"]
+    assert captured["other-org"] == ["platform"]


### PR DESCRIPTION
## Summary

- `-o my-org:api` — scoped filter: only repos matching `api` for this org
- `-o my-org:` — match all repos for this org, ignoring any global `-r`
- `-o my-org` — unchanged: defers to global `-r` (fully backwards-compatible)
- Config file supports the syntax too: `organization = ["my-org:api", "another-org"]`
- Cache key encodes per-org scoped filters so different configurations produce different cache entries

## Examples

```bash
# All repos for my-org; api only for another-org
breakfast -o my-org: -o another-org:api

# Scoped for org-a, global -r platform for org-b
breakfast -o org-a:api -o org-b -r platform
```

## Test plan

- [x] `test_parse_org_spec_*` — unit tests for the parser (no colon / with filter / empty filter / degenerate)
- [x] `test_scoped_filter_overrides_global_repo_filter` — scoped wins over `-r`
- [x] `test_empty_scoped_filter_matches_all_ignoring_global` — `org:` passes empty filter list
- [x] `test_mixed_scoped_and_global_filters` — per-org routing with global fallback
- [x] `test_scoped_filter_from_config` — config file `org:filter` syntax
- [x] All existing 341 tests still pass (349 total)
- [x] `make format && make lint && make test` all pass

Closes #292

> Stacked on #291 (multiple repo filters) → #273 (multiple orgs). Base is `issue-290_multiple-repo-filters`; retarget to `main` after the stack merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)