### PR TITLE
#294: Consolidate duplicate organization fetches

### DIFF
--- a/src/breakfast/cli.py
+++ b/src/breakfast/cli.py
@@ -363,9 +363,7 @@ def consolidate_org_specs(
 
     Preserves the order of first encounter and the casing of the first encounter.
     """
-    from collections import OrderedDict
-
-    grouped: OrderedDict[str, tuple[str, list[list[str] | None]]] = OrderedDict()
+    grouped: dict[str, tuple[str, list[list[str] | None]]] = {}
     for org, scoped in org_specs:
         low = org.lower()
         if low not in grouped:

--- a/src/breakfast/cli.py
+++ b/src/breakfast/cli.py
@@ -355,6 +355,55 @@ def _parse_org_spec(spec: str) -> tuple[str, list[str] | None]:
     return org, [filter_text] if filter_text else []
 
 
+def consolidate_org_specs(
+    org_specs: list[tuple[str, list[str] | None]],
+    global_repo_filters: list[str],
+) -> list[tuple[str, list[str] | None]]:
+    """Consolidate multiple org specs targeting the same organization.
+
+    Preserves the order of first encounter and the casing of the first encounter.
+    """
+    from collections import OrderedDict
+
+    grouped: OrderedDict[str, tuple[str, list[list[str] | None]]] = OrderedDict()
+    for org, scoped in org_specs:
+        low = org.lower()
+        if low not in grouped:
+            grouped[low] = (org, [])
+        grouped[low][1].append(scoped)
+
+    consolidated = []
+    for low, (org, scoped_list) in grouped.items():
+        # If all specs are None, keep it as None to preserve deferring to global filters
+        if all(s is None for s in scoped_list):
+            consolidated.append((org, None))
+            continue
+
+        # Resolve each scoped filter
+        effective_lists = []
+        for s in scoped_list:
+            if s is None:
+                effective_lists.append(global_repo_filters)
+            else:
+                effective_lists.append(s)
+
+        # If any resolved list is empty, it matches all repos unconditionally
+        if any(not lst for lst in effective_lists):
+            consolidated.append((org, []))
+        else:
+            # Combine and deduplicate preserving order
+            combined = []
+            seen = set()
+            for lst in effective_lists:
+                for item in lst:
+                    if item not in seen:
+                        seen.add(item)
+                        combined.append(item)
+            consolidated.append((org, combined))
+
+    return consolidated
+
+
 def get_pr_age_days(pr_detail, now=None):
     from datetime import datetime, timezone
 
@@ -890,9 +939,8 @@ def breakfast(
             organizations = [cfg_org]
         else:
             organizations = []
-    # Parse org:filter scoped syntax; rebuild organizations to plain names
+    # Parse org:filter scoped syntax
     org_specs = [_parse_org_spec(s) for s in organizations]
-    organizations = [org for org, _ in org_specs]
     # repo_filter is a tuple from multiple=True; merge with config
     if repo_filter:
         repo_filters = list(repo_filter)
@@ -904,6 +952,9 @@ def breakfast(
             repo_filters = [cfg_rf]
         else:
             repo_filters = []
+    # Consolidate duplicate organization fetches and group their scoped filters
+    org_specs = consolidate_org_specs(org_specs, repo_filters)
+    organizations = [org for org, _ in org_specs]
     repo_cache_key = (
         "|".join(sorted(f.lower() for f in repo_filters)) if repo_filters else ""
     )
@@ -1130,7 +1181,8 @@ def breakfast(
     def _org_spec_cache_segment(org: str, scoped: list[str] | None) -> str:
         if scoped is None:
             return org.lower()
-        return org.lower() + ":" + (scoped[0].lower() if scoped else "")
+        filter_str = ",".join(sorted(f.lower() for f in scoped)) if scoped else ""
+        return org.lower() + ":" + filter_str
 
     org_cache_key = "|".join(
         sorted(_org_spec_cache_segment(o, s) for o, s in org_specs)

--- a/src/breakfast/cli.py
+++ b/src/breakfast/cli.py
@@ -373,7 +373,7 @@ def consolidate_org_specs(
         grouped[low][1].append(scoped)
 
     consolidated = []
-    for low, (org, scoped_list) in grouped.items():
+    for _, (org, scoped_list) in grouped.items():
         # If all specs are None, keep it as None to preserve deferring to global filters
         if all(s is None for s in scoped_list):
             consolidated.append((org, None))
@@ -402,6 +402,14 @@ def consolidate_org_specs(
             consolidated.append((org, combined))
 
     return consolidated
+
+
+def _org_spec_cache_segment(org: str, scoped: list[str] | None) -> str:
+    """Cache key encodes each org with its effective scoped filter for determinism."""
+    if scoped is None:
+        return org.lower()
+    filter_str = ",".join(sorted(f.lower() for f in scoped)) if scoped else ""
+    return org.lower() + ":" + filter_str
 
 
 def get_pr_age_days(pr_detail, now=None):
@@ -1178,12 +1186,6 @@ def breakfast(
     t_acquire = time.monotonic()
 
     # Cache key encodes each org with its effective scoped filter for determinism
-    def _org_spec_cache_segment(org: str, scoped: list[str] | None) -> str:
-        if scoped is None:
-            return org.lower()
-        filter_str = ",".join(sorted(f.lower() for f in scoped)) if scoped else ""
-        return org.lower() + ":" + filter_str
-
     org_cache_key = "|".join(
         sorted(_org_spec_cache_segment(o, s) for o, s in org_specs)
     )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3391,3 +3391,84 @@ def test_scoped_filter_from_config(monkeypatch, tmp_path):
 
     assert captured["my-org"] == ["api"]
     assert captured["other-org"] == ["platform"]
+
+
+def test_consolidate_org_specs():
+    """Unit test for the consolidate_org_specs helper function."""
+    # Case 1: Simple combination
+    specs = [("org-a", ["filter-one"]), ("org-a", ["filter-two"])]
+    res = cli.consolidate_org_specs(specs, [])
+    assert res == [("org-a", ["filter-one", "filter-two"])]
+
+    # Case 2: Case insensitivity and preserving first casing
+    specs = [("ORG-A", ["filter-one"]), ("org-a", ["filter-two"])]
+    res = cli.consolidate_org_specs(specs, [])
+    assert res == [("ORG-A", ["filter-one", "filter-two"])]
+
+    # Case 3: Defer to global filters
+    specs = [("org-a", None), ("org-a", None)]
+    res = cli.consolidate_org_specs(specs, ["platform"])
+    assert res == [("org-a", None)]
+
+    # Case 4: Mixture of scoped and global where one has no scoped filter
+    specs = [("org-a", ["filter-one"]), ("org-a", None)]
+    res = cli.consolidate_org_specs(specs, ["platform"])
+    assert res == [("org-a", ["filter-one", "platform"])]
+
+    # Case 5: Mixture of scoped and global (empty global) resolves to []
+    specs = [("org-a", ["filter-one"]), ("org-a", None)]
+    res = cli.consolidate_org_specs(specs, [])
+    assert res == [("org-a", [])]
+
+    # Case 6: Explicitly empty scoped filter (colon with nothing) resolves to []
+    specs = [("org-a", ["filter-one"]), ("org-a", [])]
+    res = cli.consolidate_org_specs(specs, ["platform"])
+    assert res == [("org-a", [])]
+
+    # Case 7: Order of unique organizations is preserved
+    specs = [("org-b", None), ("org-a", ["f1"]), ("org-b", ["f2"])]
+    res = cli.consolidate_org_specs(specs, ["platform"])
+    assert res == [("org-b", ["platform", "f2"]), ("org-a", ["f1"])]
+
+
+def test_cli_duplicate_org_fetches_prevented(monkeypatch):
+    """CLI groups duplicate org definitions and calls get_github_prs once."""
+    monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "tok")
+    monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
+    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+
+    calls = []
+
+    def fake_get_prs(org, repo_filters):
+        filters = list(repo_filters) if repo_filters is not None else None
+        calls.append((org, filters))
+        return []
+
+    monkeypatch.setattr(cli, "get_github_prs", fake_get_prs)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli.breakfast,
+        [
+            "-o",
+            "org-a:filter-one",
+            "-o",
+            "ORG-A:filter-two",
+            "-o",
+            "org-b",
+            "-o",
+            "org-b:filter-three",
+            "-r",
+            "global-f",
+        ],
+    )
+
+    assert result.exit_code == 0
+    # org-a was specified twice, first as org-a:filter-one and ORG-A:filter-two.
+    # Its casing should be preserved as "org-a",
+    # and filters combined as ["filter-one", "filter-two"].
+    # org-b was specified as org-b (global-f) and org-b:filter-three.
+    # Its casing "org-b" preserved, filters combined as ["global-f", "filter-three"].
+    assert len(calls) == 2
+    assert calls[0] == ("org-a", ["filter-one", "filter-two"])
+    assert calls[1] == ("org-b", ["global-f", "filter-three"])

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3431,6 +3431,15 @@ def test_consolidate_org_specs():
     assert res == [("org-b", ["platform", "f2"]), ("org-a", ["f1"])]
 
 
+def test_org_spec_cache_segment_multi_filter():
+    """Verify _org_spec_cache_segment behavior with multiple filters."""
+    seg_ab = cli._org_spec_cache_segment("org", ["filter-b", "filter-a"])
+    seg_ba = cli._org_spec_cache_segment("org", ["filter-a", "filter-b"])
+    seg_one = cli._org_spec_cache_segment("org", ["filter-a"])
+    assert seg_ab == seg_ba  # order-independent
+    assert seg_ab != seg_one  # different filter sets differ
+
+
 def test_cli_duplicate_org_fetches_prevented(monkeypatch):
     """CLI groups duplicate org definitions and calls get_github_prs once."""
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "tok")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3433,11 +3433,11 @@ def test_consolidate_org_specs():
 
 def test_org_spec_cache_segment_multi_filter():
     """Verify _org_spec_cache_segment behavior with multiple filters."""
-    seg_ab = cli._org_spec_cache_segment("org", ["filter-b", "filter-a"])
-    seg_ba = cli._org_spec_cache_segment("org", ["filter-a", "filter-b"])
+    seg_first = cli._org_spec_cache_segment("org", ["filter-b", "filter-a"])
+    seg_second = cli._org_spec_cache_segment("org", ["filter-a", "filter-b"])
     seg_one = cli._org_spec_cache_segment("org", ["filter-a"])
-    assert seg_ab == seg_ba  # order-independent
-    assert seg_ab != seg_one  # different filter sets differ
+    assert seg_first == seg_second  # order-independent
+    assert seg_first != seg_one  # different filter sets differ
 
 
 def test_cli_duplicate_org_fetches_prevented(monkeypatch):

--- a/uv.lock
+++ b/uv.lock
@@ -41,7 +41,7 @@ wheels = [
 
 [[package]]
 name = "breakfast"
-version = "0.59.7"
+version = "0.61.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Closes #294. This PR groups duplicate organization/user targets and combines their scoped filters using OR logic, preventing duplicate fetches.