### PR TITLE
#294: Update main README with multiple organization support

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ breakfast -o my-org -r my-app
 
 ```bash
 breakfast -o my-org -r my-app
+breakfast -o my-org -o another-org -r platform
+breakfast -o my-org:api -o another-org:platform
 breakfast -o my-org -r my-app --ignore-author dependabot[bot] --ignore-author renovate[bot]
 breakfast -o my-org -r my-app --mine-only
 breakfast -o my-org -r my-app --age
@@ -46,7 +48,7 @@ breakfast -o my-org -r my-app --legendary-only
 
 ### Display
 
-- `--organization`, `-o`: Organization to query for PRs.
+- `--organization`, `-o`: One or multiple organizations to query for PRs (repeatable). Supports scoped filters like `org:repo`.
 - `--repo-filter`, `-r`: Filter repos by name substring.
 - `--age`: Add an age column (days since creation).
 - `--checks`: Add a checks column showing CI status (✅ pass / ❌ fail / ⚠️ pending).

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ breakfast -o my-org -r my-app
 breakfast -o my-org -r my-app
 breakfast -o my-org -o another-org -r platform
 breakfast -o my-org:api -o another-org:platform
+breakfast -o my-org:api -o my-org:platform
 breakfast -o my-org -r my-app --ignore-author dependabot[bot] --ignore-author renovate[bot]
 breakfast -o my-org -r my-app --mine-only
 breakfast -o my-org -r my-app --age


### PR DESCRIPTION
Docs follow-up for #294 to document support for multiple organizations and scoped filters in the main README.