### PR TITLE
Stacked PRs: filters, fetch-state, template format, caching, calendars, README & working style

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -81,3 +81,9 @@ When updating project rules, update **all four files** to keep them consistent.
 - If CLI options, features, or user-visible behaviors change, you MUST update the relevant manual pages in `docs/manual/` (`options.md`, `usage.md`, etc.).
 - If the project structure or developer workflow changes, you MUST update `CONTRIBUTING.md`.
 - These updates should be in the same PR.
+
+## Working Style
+- **Narrate intent before acting.** If a task would take the work beyond the literal ask, say so first and wait for confirmation. Never expand scope silently.
+- **Surface, don't solve.** If related work is spotted (missing docs, adjacent bugs, cleanup opportunities), flag it as an observation and ask before doing anything. "I notice X — want me to address that too?"
+- **Ask when scope is ambiguous.** When an instruction could mean a narrow or a broad thing, ask which is wanted before writing a single line of code or docs.
+- **Pause at natural checkpoints on large changes.** For multi-step or multi-file work, describe the plan and confirm before committing and pushing. That way the user can redirect early rather than unpicking completed work.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -98,3 +98,9 @@ When updating project rules, update **all four files** to keep them consistent.
 - **When adding, changing, or removing CLI options, features, or user-visible behaviour, you MUST update the relevant manual pages in `docs/manual/` in the same commit or PR.** This includes `options.md`, `usage.md`, `output-formats.md`, and `troubleshooting.md` as appropriate.
 - **If the project structure or developer workflow changes, you MUST update `CONTRIBUTING.md`.**
 - When adding a new feature design, create a document in `docs/design/` and add it to the table in `docs/design/README.md`.
+
+## Working Style
+- **Narrate intent before acting.** If a task would take the work beyond the literal ask, say so first and wait for confirmation. Never expand scope silently.
+- **Surface, don't solve.** If related work is spotted (missing docs, adjacent bugs, cleanup opportunities), flag it as an observation and ask before doing anything. "I notice X — want me to address that too?"
+- **Ask when scope is ambiguous.** When an instruction could mean a narrow or a broad thing, ask which is wanted before writing a single line of code or docs.
+- **Pause at natural checkpoints on large changes.** For multi-step or multi-file work, describe the plan and confirm before committing and pushing. That way the user can redirect early rather than unpicking completed work.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,3 +98,9 @@ When updating project rules, update **all four files** to keep them consistent.
 - **When adding, changing, or removing CLI options, features, or user-visible behaviour, you MUST update the relevant manual pages in `docs/manual/` in the same commit or PR.** This includes `options.md`, `usage.md`, `output-formats.md`, and `troubleshooting.md` as appropriate.
 - **If the project structure or developer workflow changes, you MUST update `CONTRIBUTING.md`.**
 - When adding a new feature design, create a document in `docs/design/` and add it to the table in `docs/design/README.md`.
+
+## Working Style
+- **Narrate intent before acting.** If a task would take the work beyond the literal ask, say so first and wait for confirmation. Never expand scope silently.
+- **Surface, don't solve.** If related work is spotted (missing docs, adjacent bugs, cleanup opportunities), flag it as an observation and ask before doing anything. "I notice X — want me to address that too?"
+- **Ask when scope is ambiguous.** When an instruction could mean a narrow or a broad thing, ask which is wanted before writing a single line of code or docs.
+- **Pause at natural checkpoints on large changes.** For multi-step or multi-file work, describe the plan and confirm before committing and pushing. That way the user can redirect early rather than unpicking completed work.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -46,3 +46,9 @@ When updating project rules, update **all four files** to keep them consistent.
 - **Testing with Cache:** Since caching is implemented, all manual testing must be performed both *with* the cache enabled and *without* the cache (e.g., clearing the cache or disabling it).
 - **Real App Testing:** Always perform a real, end-to-end test of the CLI application in the terminal, not just unit tests.
 - **Documentation:** If CLI options, features, or user-visible behaviors change, you MUST update the relevant manual pages in `docs/manual/` (`options.md`, `usage.md`, etc.). If the project structure or developer workflow changes, you MUST update `CONTRIBUTING.md`. These updates should be in the same PR.
+
+## Working Style
+- **Narrate intent before acting.** If a task would take the work beyond the literal ask, say so first and wait for confirmation. Never expand scope silently.
+- **Surface, don't solve.** If related work is spotted (missing docs, adjacent bugs, cleanup opportunities), flag it as an observation and ask before doing anything. "I notice X — want me to address that too?"
+- **Ask when scope is ambiguous.** When an instruction could mean a narrow or a broad thing, ask which is wanted before writing a single line of code or docs.
+- **Pause at natural checkpoints on large changes.** For multi-step or multi-file work, describe the plan and confirm before committing and pushing. That way the user can redirect early rather than unpicking completed work.

--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ breakfast -o my-org -r my-app --checks --status-style ascii
 breakfast -o my-org -r my-app --filter-state open
 breakfast -o my-org -r my-app --filter-check fail --filter-check pending
 breakfast -o my-org -r my-app --filter-approval approved
+breakfast -o my-org -r my-app --label bug --label enhancement
+breakfast -o my-org -r my-app --exclude-label wip
 breakfast -o my-org -r my-app --json
 breakfast -o my-org -r my-app --cache
 breakfast -o my-org -r my-app --cache --refresh
@@ -67,6 +69,8 @@ breakfast -o my-org -r my-app --legendary-only
 - `--filter-state`: Only show PRs with this state (`open`, `closed`). Repeatable.
 - `--filter-check`: Only show PRs with this CI result (`pass`, `fail`, `pending`, `none`). Repeatable. Implies `--checks`.
 - `--filter-approval`: Only show PRs with this review status (`approved`, `pending`, `changes`). Repeatable.
+- `--label`: Only show PRs that have this label (case-insensitive, repeatable — OR logic).
+- `--exclude-label`: Hide PRs that have this label (case-insensitive, repeatable).
 
 ### Caching
 

--- a/README.md
+++ b/README.md
@@ -37,79 +37,36 @@ breakfast -o my-org -r my-app --checks --status-style ascii
 breakfast -o my-org -r my-app --filter-state open
 breakfast -o my-org -r my-app --filter-check fail --filter-check pending
 breakfast -o my-org -r my-app --filter-approval approved
-breakfast -o my-org -r my-app --label bug --label enhancement
-breakfast -o my-org -r my-app --exclude-label wip
-breakfast -o my-org -r my-app --filter-reviewer alice
-breakfast -o my-org -r my-app --filter-stale 30
-breakfast -o my-org -r my-app --filter-inactive 7
-breakfast -o my-org -r my-app --fetch-state all
-breakfast -o my-org -r my-app --sort age
-breakfast -o my-org -r my-app --sort comments --reverse
-breakfast -o my-org -r my-app --search "hotfix"
-breakfast -o my-org -r my-app --format json
-breakfast -o my-org -r my-app --format markdown
-breakfast -o my-org -r my-app --format csv
-breakfast -o my-org -r my-app --format template --template "{repo}: {title} ({url})"
+breakfast -o my-org -r my-app --json
 breakfast -o my-org -r my-app --cache
 breakfast -o my-org -r my-app --cache --refresh
 breakfast -o my-org -r my-app --cache --refresh-prs
 breakfast -o my-org -r my-app --legendary
 breakfast -o my-org -r my-app --legendary-only
-breakfast -o my-org -r my-app --summarise-user-prs
-breakfast -o my-org -r my-app --summarise-repo-prs
 ```
 
 ## Options
 
-### Target
-
-- `--organization`, `-o`: One or multiple organizations to query for PRs (repeatable). Supports scoped repo filters: `-o my-org:api` limits that org to repos matching `api`.
-- `--repo-filter`, `-r`: Filter repos by name (substring or glob, repeatable).
-- `--exclude-repo`: Exclude repos matching a name pattern (substring or glob, repeatable).
-
 ### Display
 
+- `--organization`, `-o`: One or multiple organizations to query for PRs (repeatable). Supports scoped filters like `org:repo`.
+- `--repo-filter`, `-r`: Filter repos by name substring.
 - `--age`: Add an age column (days since creation).
 - `--checks`: Add a checks column showing CI status (✅ pass / ❌ fail / ⚠️ pending).
-- `--approvals`: Add an approvals column showing review status.
-- `--head-branch`: Add a head branch column.
-- `--base-branch`: Add a base branch column.
+- `--approvals`: Add an approvals column showing review status (✅ approved / ✅ 1/2 approvals / ❌ changes / ⏳ pending).
 - `--status-style`: Render status cells with `emoji` (default) or `ascii` labels.
+- `--json`: Output as JSON instead of a table.
 - `--limit`: Cap the number of PRs shown.
 - `--max-title-length`: Truncate PR titles to this many characters.
-
-### Output format
-
-- `--format`: Output format: `table` (default), `json`, `markdown`, `csv`, `template`.
-- `--template`: Format string used with `--format template`. Available fields: `{repo}`, `{title}`, `{author}`, `{url}`, `{state}`, `{number}`, `{created_at}`, `{updated_at}`, `{additions}`, `{deletions}`, `{changed_files}`, `{commits}`, `{review_comments}`, `{labels}`, `{requested_reviewers}`.
 
 ### Filtering
 
 - `--ignore-author`: Exclude PRs by author (case-insensitive, repeatable).
 - `--no-ignore-author`: Clear `ignore-author` config defaults for this run.
 - `--mine-only`: Show only your own PRs.
-- `--no-drafts`: Hide draft PRs.
-- `--drafts-only`: Show only draft PRs.
-- `--fetch-state`: Which PR states to fetch from GitHub: `open` (default), `closed`, `merged`, `all`.
-- `--filter-state`: Only show PRs with this state (`open`, `closed`, `draft`). Repeatable.
+- `--filter-state`: Only show PRs with this state (`open`, `closed`). Repeatable.
 - `--filter-check`: Only show PRs with this CI result (`pass`, `fail`, `pending`, `none`). Repeatable. Implies `--checks`.
 - `--filter-approval`: Only show PRs with this review status (`approved`, `pending`, `changes`). Repeatable.
-- `--label`: Only show PRs that have this label (case-insensitive, repeatable — OR logic).
-- `--exclude-label`: Hide PRs that have this label (case-insensitive, repeatable).
-- `--filter-reviewer`: Only show PRs with this user as a requested reviewer (case-insensitive, repeatable — OR logic).
-- `--filter-stale`: Only show PRs older than N days.
-- `--filter-inactive`: Only show PRs not updated in the last N days.
-- `--search`, `-s`: Filter PRs by title (plain string or regex, case-insensitive).
-
-### Sorting
-
-- `--sort`: Sort by field: `repo` (default), `age`, `updated`, `author`, `comments`, `reviews`.
-- `--reverse`: Reverse the sort order.
-
-### Summary views
-
-- `--summarise-user-prs`: Print a per-author PR count summary instead of the full table.
-- `--summarise-repo-prs`: Print a per-repo PR count summary instead of the full table.
 
 ### Caching
 
@@ -125,11 +82,9 @@ breakfast -o my-org -r my-app --summarise-repo-prs
 
 ### Other
 
-- `--workers`: Number of parallel workers for fetching PR details (default: 10).
 - `--config`: Path to a config file.
 - `--show-config`: Print resolved config and exit.
 - `--init-config`: Generate a default config file.
-- `--update-config`: Update an existing config file with new defaults.
 - `--no-update-check`: Disable the automatic update check.
 - `--version`: Show version.
 

--- a/README.md
+++ b/README.md
@@ -39,12 +39,21 @@ breakfast -o my-org -r my-app --filter-check fail --filter-check pending
 breakfast -o my-org -r my-app --filter-approval approved
 breakfast -o my-org -r my-app --label bug --label enhancement
 breakfast -o my-org -r my-app --exclude-label wip
-breakfast -o my-org -r my-app --json
+breakfast -o my-org -r my-app --filter-reviewer alice
+breakfast -o my-org -r my-app --filter-stale 30
+breakfast -o my-org -r my-app --filter-inactive 7
+breakfast -o my-org -r my-app --fetch-state all
+breakfast -o my-org -r my-app --search "hotfix"
+breakfast -o my-org -r my-app --format json
+breakfast -o my-org -r my-app --format markdown
+breakfast -o my-org -r my-app --format template --template "{repo}: {title} ({url})"
 breakfast -o my-org -r my-app --cache
 breakfast -o my-org -r my-app --cache --refresh
 breakfast -o my-org -r my-app --cache --refresh-prs
 breakfast -o my-org -r my-app --legendary
 breakfast -o my-org -r my-app --legendary-only
+breakfast -o my-org -r my-app --summarise-user-prs
+breakfast -o my-org -r my-app --summarise-repo-prs
 ```
 
 ## Options
@@ -56,21 +65,39 @@ breakfast -o my-org -r my-app --legendary-only
 - `--age`: Add an age column (days since creation).
 - `--checks`: Add a checks column showing CI status (✅ pass / ❌ fail / ⚠️ pending).
 - `--approvals`: Add an approvals column showing review status (✅ approved / ✅ 1/2 approvals / ❌ changes / ⏳ pending).
+- `--head-branch`: Add a head branch column.
+- `--base-branch`: Add a base branch column.
 - `--status-style`: Render status cells with `emoji` (default) or `ascii` labels.
-- `--json`: Output as JSON instead of a table.
 - `--limit`: Cap the number of PRs shown.
 - `--max-title-length`: Truncate PR titles to this many characters.
+
+### Output format
+
+- `--format`: Output format: `table` (default), `json`, `markdown`, `csv`, `template`.
+- `--template`: Format string used with `--format template`. Available fields: `{repo}`, `{title}`, `{author}`, `{url}`, `{state}`, `{number}`, `{created_at}`, `{updated_at}`, `{additions}`, `{deletions}`, `{changed_files}`, `{commits}`, `{review_comments}`, `{labels}`, `{requested_reviewers}`.
 
 ### Filtering
 
 - `--ignore-author`: Exclude PRs by author (case-insensitive, repeatable).
 - `--no-ignore-author`: Clear `ignore-author` config defaults for this run.
 - `--mine-only`: Show only your own PRs.
-- `--filter-state`: Only show PRs with this state (`open`, `closed`). Repeatable.
+- `--no-drafts`: Hide draft PRs.
+- `--drafts-only`: Show only draft PRs.
+- `--fetch-state`: Which PR states to fetch from GitHub: `open` (default), `closed`, `merged`, `all`.
+- `--filter-state`: Only show PRs with this state (`open`, `closed`, `draft`). Repeatable.
 - `--filter-check`: Only show PRs with this CI result (`pass`, `fail`, `pending`, `none`). Repeatable. Implies `--checks`.
 - `--filter-approval`: Only show PRs with this review status (`approved`, `pending`, `changes`). Repeatable.
 - `--label`: Only show PRs that have this label (case-insensitive, repeatable — OR logic).
 - `--exclude-label`: Hide PRs that have this label (case-insensitive, repeatable).
+- `--filter-reviewer`: Only show PRs with this user as a requested reviewer (case-insensitive, repeatable — OR logic).
+- `--filter-stale`: Only show PRs older than N days.
+- `--filter-inactive`: Only show PRs not updated in the last N days.
+- `--search`, `-s`: Filter PRs by title (plain string or regex, case-insensitive).
+
+### Summary views
+
+- `--summarise-user-prs`: Print a per-author PR count summary instead of the full table.
+- `--summarise-repo-prs`: Print a per-repo PR count summary instead of the full table.
 
 ### Caching
 

--- a/README.md
+++ b/README.md
@@ -37,36 +37,79 @@ breakfast -o my-org -r my-app --checks --status-style ascii
 breakfast -o my-org -r my-app --filter-state open
 breakfast -o my-org -r my-app --filter-check fail --filter-check pending
 breakfast -o my-org -r my-app --filter-approval approved
-breakfast -o my-org -r my-app --json
+breakfast -o my-org -r my-app --label bug --label enhancement
+breakfast -o my-org -r my-app --exclude-label wip
+breakfast -o my-org -r my-app --filter-reviewer alice
+breakfast -o my-org -r my-app --filter-stale 30
+breakfast -o my-org -r my-app --filter-inactive 7
+breakfast -o my-org -r my-app --fetch-state all
+breakfast -o my-org -r my-app --sort age
+breakfast -o my-org -r my-app --sort comments --reverse
+breakfast -o my-org -r my-app --search "hotfix"
+breakfast -o my-org -r my-app --format json
+breakfast -o my-org -r my-app --format markdown
+breakfast -o my-org -r my-app --format csv
+breakfast -o my-org -r my-app --format template --template "{repo}: {title} ({url})"
 breakfast -o my-org -r my-app --cache
 breakfast -o my-org -r my-app --cache --refresh
 breakfast -o my-org -r my-app --cache --refresh-prs
 breakfast -o my-org -r my-app --legendary
 breakfast -o my-org -r my-app --legendary-only
+breakfast -o my-org -r my-app --summarise-user-prs
+breakfast -o my-org -r my-app --summarise-repo-prs
 ```
 
 ## Options
 
+### Target
+
+- `--organization`, `-o`: One or multiple organizations to query for PRs (repeatable). Supports scoped repo filters: `-o my-org:api` limits that org to repos matching `api`.
+- `--repo-filter`, `-r`: Filter repos by name (substring or glob, repeatable).
+- `--exclude-repo`: Exclude repos matching a name pattern (substring or glob, repeatable).
+
 ### Display
 
-- `--organization`, `-o`: One or multiple organizations to query for PRs (repeatable). Supports scoped filters like `org:repo`.
-- `--repo-filter`, `-r`: Filter repos by name substring.
 - `--age`: Add an age column (days since creation).
 - `--checks`: Add a checks column showing CI status (✅ pass / ❌ fail / ⚠️ pending).
-- `--approvals`: Add an approvals column showing review status (✅ approved / ✅ 1/2 approvals / ❌ changes / ⏳ pending).
+- `--approvals`: Add an approvals column showing review status.
+- `--head-branch`: Add a head branch column.
+- `--base-branch`: Add a base branch column.
 - `--status-style`: Render status cells with `emoji` (default) or `ascii` labels.
-- `--json`: Output as JSON instead of a table.
 - `--limit`: Cap the number of PRs shown.
 - `--max-title-length`: Truncate PR titles to this many characters.
+
+### Output format
+
+- `--format`: Output format: `table` (default), `json`, `markdown`, `csv`, `template`.
+- `--template`: Format string used with `--format template`. Available fields: `{repo}`, `{title}`, `{author}`, `{url}`, `{state}`, `{number}`, `{created_at}`, `{updated_at}`, `{additions}`, `{deletions}`, `{changed_files}`, `{commits}`, `{review_comments}`, `{labels}`, `{requested_reviewers}`.
 
 ### Filtering
 
 - `--ignore-author`: Exclude PRs by author (case-insensitive, repeatable).
 - `--no-ignore-author`: Clear `ignore-author` config defaults for this run.
 - `--mine-only`: Show only your own PRs.
-- `--filter-state`: Only show PRs with this state (`open`, `closed`). Repeatable.
+- `--no-drafts`: Hide draft PRs.
+- `--drafts-only`: Show only draft PRs.
+- `--fetch-state`: Which PR states to fetch from GitHub: `open` (default), `closed`, `merged`, `all`.
+- `--filter-state`: Only show PRs with this state (`open`, `closed`, `draft`). Repeatable.
 - `--filter-check`: Only show PRs with this CI result (`pass`, `fail`, `pending`, `none`). Repeatable. Implies `--checks`.
 - `--filter-approval`: Only show PRs with this review status (`approved`, `pending`, `changes`). Repeatable.
+- `--label`: Only show PRs that have this label (case-insensitive, repeatable — OR logic).
+- `--exclude-label`: Hide PRs that have this label (case-insensitive, repeatable).
+- `--filter-reviewer`: Only show PRs with this user as a requested reviewer (case-insensitive, repeatable — OR logic).
+- `--filter-stale`: Only show PRs older than N days.
+- `--filter-inactive`: Only show PRs not updated in the last N days.
+- `--search`, `-s`: Filter PRs by title (plain string or regex, case-insensitive).
+
+### Sorting
+
+- `--sort`: Sort by field: `repo` (default), `age`, `updated`, `author`, `comments`, `reviews`.
+- `--reverse`: Reverse the sort order.
+
+### Summary views
+
+- `--summarise-user-prs`: Print a per-author PR count summary instead of the full table.
+- `--summarise-repo-prs`: Print a per-repo PR count summary instead of the full table.
 
 ### Caching
 
@@ -82,9 +125,11 @@ breakfast -o my-org -r my-app --legendary-only
 
 ### Other
 
+- `--workers`: Number of parallel workers for fetching PR details (default: 10).
 - `--config`: Path to a config file.
 - `--show-config`: Print resolved config and exit.
 - `--init-config`: Generate a default config file.
+- `--update-config`: Update an existing config file with new defaults.
 - `--no-update-check`: Disable the automatic update check.
 - `--version`: Show version.
 

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -12,3 +12,4 @@ Each document captures the problem, proposed solution, and implementation approa
 | [Demo Generation](demo-generation.md) | Implemented | [#80](https://github.com/mrsixw/breakfast/issues/80) |
 | [PR Caching](pr-caching.md) | Proposed | [#45](https://github.com/mrsixw/breakfast/issues/45) |
 | [Text User Interface](tui.md) | Proposed | [#46](https://github.com/mrsixw/breakfast/issues/46) |
+| [Pluggable Seasonal Calendars](pluggable-calendars.md) | Implemented | [#196](https://github.com/mrsixw/breakfast/issues/196) |

--- a/docs/design/pluggable-calendars.md
+++ b/docs/design/pluggable-calendars.md
@@ -1,0 +1,64 @@
+# Pluggable Seasonal Calendars
+
+**Issue:** [#196](https://github.com/mrsixw/breakfast/issues/196)  
+**Status:** Implemented
+
+## Problem
+
+The seasonal colour easter egg in breakfast was hard-coded to the western/Gregorian calendar (Christmas, Easter, Pride Month, Halloween). Teams that celebrate different cultural holidays — Hanukkah, Diwali, Eid al-Fitr, Holi, Vaisakhi — got no seasonal love.
+
+## Solution
+
+A pluggable calendar system driven by a `seasonal-calendar` config key. Each calendar is a function `(today: datetime.date) -> str | list[str] | None` registered in a `CALENDARS` dict. The caller picks which calendar to use; `"off"` disables the feature entirely.
+
+## Calendar Interface
+
+```python
+CalendarFn = Callable[[datetime.date], str | list[str] | None]
+```
+
+- **`None`** — no holiday today, return text unstyled.
+- **`str`** — single ANSI escape code, applied uniformly.
+- **`list[str]`** — list of colours for PR-number cycling (e.g., December candy-cane, Pride rainbow, Holi rainbow).
+
+## Calendars
+
+| Key | Holidays | Notes |
+| --- | --- | --- |
+| `"western"` | Christmas 🎄 (candy-cane), Easter 🐣, Pride Month 🌈, Halloween 🎃, Valentine's Day 💕, Lunar New Year 🧧 | Default. January is always purple — Steve's birthday month must never be overridden. |
+| `"jewish"` | Hanukkah 🕎 (8 nights, blue), Rosh Hashanah 🍎 (2 days, gold), Passover 🪬 (7 days, spring green) | Uses pre-computed tables for 2024–2045. |
+| `"islamic"` | Eid al-Fitr 🌙 (3 days, green) | Uses pre-computed tables for 2024–2045. Dates are approximate (moon-sighting varies by location). |
+| `"hindu"` | Diwali 🪔 (5 days, gold), Holi 🌈 (2 days, rainbow) | Uses pre-computed tables for 2024–2045. |
+| `"sikh"` | Vaisakhi 🌾 (April 13, spring green), Bandi Chhor Divas 🪔 (5 days, gold) | Vaisakhi is fixed; Bandi Chhor Divas shares Diwali dates. |
+| `"off"` | — | Disables all seasonal colours. |
+
+## Implementation
+
+### `src/breakfast/ui.py`
+
+- Pre-computed lookup tables (`_ROSH_HASHANAH`, `_HANUKKAH_START`, `_PASSOVER_START`, `_EID_AL_FITR`, `_DIWALI`, `_HOLI`) covering 2024–2045.
+- `_in_holiday_window(today, table, days)` helper.
+- `_western_calendar(today)` — refactored from the old `apply_seasonal_colour` logic. Returns `list` for cycling effects (December, June), `str` for fixed colours, `None` otherwise.
+- `_jewish_calendar`, `_islamic_calendar`, `_hindu_calendar`, `_sikh_calendar` — same signature.
+- `CALENDARS` dict maps string keys to calendar functions.
+- `apply_seasonal_colour(text, pr_number, calendar="western")` — looks up the calendar function, dispatches, and handles list cycling via `pr_number % len(result)`.
+- `render_pr_summary` parameter renamed from `seasonal_colours: bool` to `calendar: str`.
+
+### `src/breakfast/config.py`
+
+- Added `seasonal-calendar = "western"` commented block to `_DEFAULT_CONFIG_CONTENT`.
+- `load_config()`: maps `seasonal-colours = false` → `seasonal-calendar = "off"` for backward compatibility.
+
+### `src/breakfast/cli.py`
+
+- Reads `seasonal-calendar` from config (default `"western"`).
+- Overrides to `"off"` when `seasonal-colours = false` for backward compat.
+- Passes `calendar=seasonal_calendar` to all `apply_seasonal_colour` calls and `render_pr_summary`.
+
+## Backward Compatibility
+
+`seasonal-colours = false` continues to work — `load_config()` maps it to `seasonal-calendar = "off"` so existing configs need no changes.
+
+## Constraint: January Is Always Purple
+
+January is Steve's birthday month. The western calendar function returns `SEASONAL_PALETTES["purple"]` for January **before** checking for Lunar New Year, which can fall in January. LNY gold is only applied when LNY falls in February.

--- a/docs/manual/options.md
+++ b/docs/manual/options.md
@@ -583,6 +583,23 @@ breakfast automatically checks for new versions once per day (cached for 24 hour
 
 The check is non-blocking and non-fatal — network failures are silently ignored. The notification is sent to stderr so it won't interfere with `--json` output piping.
 
+### `update-summary` (config only)
+
+When set to `true`, appends a short summary of what's new (pulled from the GitHub release notes) below the update banner:
+
+```text
+🍳 A fresh breakfast is ready! v0.10.0 → v0.11.0 — update at ...
+  📋 - Add --sort option for custom PR ordering
+      - Fix --checks with per-repo cache hits
+      - New --exclude-label filter
+```
+
+Enable in `~/.config/breakfast/config.toml`:
+
+```toml
+update-summary = true
+```
+
 To disable the update check:
 
 ```bash

--- a/docs/manual/options.md
+++ b/docs/manual/options.md
@@ -94,6 +94,15 @@ breakfast -o my-org -r my-app --filter-approval pending --filter-approval change
 
 > **Note:** Review and check statuses are cached alongside PR details, so repeated runs with these flags skip redundant API calls.
 
+### `--filter-reviewer`
+
+Only show PRs that have a specific user listed as a requested reviewer. Matching is **case-insensitive**. Repeat the flag to include any of the given reviewers (OR logic).
+
+```bash
+breakfast -o my-org --filter-reviewer alice              # PRs requesting review from alice
+breakfast -o my-org --filter-reviewer alice --filter-reviewer bob
+```
+
 ### `--search`, `-s`
 
 Filter PRs by title. Accepts a plain string or a regular expression pattern; matching is always **case-insensitive**.

--- a/docs/manual/options.md
+++ b/docs/manual/options.md
@@ -94,6 +94,24 @@ breakfast -o my-org -r my-app --filter-approval pending --filter-approval change
 
 > **Note:** Review and check statuses are cached alongside PR details, so repeated runs with these flags skip redundant API calls.
 
+### `--label`
+
+Only show PRs that have a specific label. Matching is **case-insensitive**. Repeat the flag to require any of the given labels (OR logic).
+
+```bash
+breakfast -o my-org --label bug                          # only PRs labelled "bug"
+breakfast -o my-org --label bug --label enhancement      # PRs with "bug" OR "enhancement"
+```
+
+### `--exclude-label`
+
+Exclude PRs that have a specific label. Matching is **case-insensitive**. Repeat to exclude any of the given labels.
+
+```bash
+breakfast -o my-org --exclude-label wip                  # hide WIP PRs
+breakfast -o my-org --exclude-label wip --exclude-label blocked
+```
+
 ### `--search`, `-s`
 
 Filter PRs by title. Accepts a plain string or a regular expression pattern; matching is always **case-insensitive**.

--- a/docs/manual/options.md
+++ b/docs/manual/options.md
@@ -713,6 +713,40 @@ Config key: `summarise-repo-prs = true`
 > exclusive. All standard filter flags (`--author`, `--repo-filter`,
 > `--filter-state`, etc.) apply before the summary is computed.
 
+## Sorting
+
+### `--sort`
+
+Sort the PR list by a named field. By default PRs are grouped by repository
+(`repo`). Available choices:
+
+| Value      | Sorts by                                      |
+|------------|-----------------------------------------------|
+| `repo`     | Repository name (default)                     |
+| `age`      | Days since the PR was opened (oldest first)   |
+| `updated`  | Last-updated timestamp (most-recently first)  |
+| `author`   | PR author login (alphabetical)                |
+| `comments` | Total comment count (issue + review comments) |
+| `reviews`  | Review comment count only                     |
+
+```bash
+breakfast -o my-org --sort age          # oldest PRs first
+breakfast -o my-org --sort comments     # most commented first
+```
+
+Config key: `sort = "repo"`
+
+### `--reverse`
+
+Reverse the sort order imposed by `--sort`.
+
+```bash
+breakfast -o my-org --sort age --reverse    # newest PRs first
+breakfast -o my-org --sort author --reverse # Z→A author order
+```
+
+Config key: `sort-reverse = false`
+
 ## Other options
 
 ### `--version`

--- a/docs/manual/options.md
+++ b/docs/manual/options.md
@@ -176,12 +176,13 @@ Processing platform PRs...🍩🧇...Done
 
 ### `--format`
 
-Choose the output format. Accepted values: `table` (default), `json`, `markdown`, `csv`.
+Choose the output format. Accepted values: `table` (default), `json`, `markdown`, `csv`, `template`.
 
 ```text
 breakfast -o my-org -r platform --format markdown
 breakfast -o my-org -r platform --format json
 breakfast -o my-org -r platform --format csv
+breakfast -o my-org -r platform --format template --template "{repo}: {title}"
 ```
 
 You can also set a persistent default in your config file:
@@ -191,6 +192,39 @@ format = "csv"
 ```
 
 See [Output Formats](output-formats.md) for full details on each format.
+
+### `--template`
+
+A Python format string used when `--format template` is active. One line is printed per PR with the template fields substituted.
+
+Available fields:
+
+| Field                    | Description                          |
+|--------------------------|--------------------------------------|
+| `{repo}`                 | Repository name                      |
+| `{title}`                | PR title                             |
+| `{author}`               | Author GitHub login                  |
+| `{url}`                  | PR URL                               |
+| `{state}`                | PR state (`open`, `closed`)          |
+| `{number}`               | PR number                            |
+| `{created_at}`           | ISO 8601 creation timestamp          |
+| `{updated_at}`           | ISO 8601 last-updated timestamp      |
+| `{additions}`            | Lines added                          |
+| `{deletions}`            | Lines deleted                        |
+| `{changed_files}`        | Files changed                        |
+| `{commits}`              | Commit count                         |
+| `{review_comments}`      | Review comment count                 |
+| `{labels}`               | Pipe-separated label names           |
+| `{requested_reviewers}`  | Pipe-separated reviewer logins       |
+
+```bash
+breakfast -o my-org --format template --template "{repo}: {title} by {author} — {url}"
+breakfast -o my-org --format template --template "{number}\t{title}\t{url}"
+```
+
+If an unknown field is used, breakfast exits with an error message.
+
+Config keys: `format = "template"` and `template = "{repo}: {title} ({url})"`
 
 ### `--markdown`
 

--- a/docs/manual/options.md
+++ b/docs/manual/options.md
@@ -94,6 +94,24 @@ breakfast -o my-org -r my-app --filter-approval pending --filter-approval change
 
 > **Note:** Review and check statuses are cached alongside PR details, so repeated runs with these flags skip redundant API calls.
 
+### `--filter-stale`
+
+Only show PRs that have been open for more than N days (based on creation date). Pairs naturally with `--age` to see the age column.
+
+```bash
+breakfast -o my-org --filter-stale 14         # PRs open for more than 14 days
+breakfast -o my-org --filter-stale 30 --age   # stale PRs with age column visible
+```
+
+### `--filter-inactive`
+
+Only show PRs that have not been updated in the last N days. Useful for surfacing PRs that need a nudge.
+
+```bash
+breakfast -o my-org --filter-inactive 7       # not updated in the last 7 days
+breakfast -o my-org --filter-stale 14 --filter-inactive 3
+```
+
 ### `--search`, `-s`
 
 Filter PRs by title. Accepts a plain string or a regular expression pattern; matching is always **case-insensitive**.

--- a/docs/manual/options.md
+++ b/docs/manual/options.md
@@ -616,6 +616,25 @@ Can also be set persistently in config:
 no-colour = true
 ```
 
+### `seasonal-calendar` (config only)
+
+Choose which cultural holiday calendar drives the seasonal colour effects in the PR table. Set in config — there is no CLI flag.
+
+| Value | Description |
+| --- | --- |
+| `"western"` | Gregorian calendar: Christmas 🎄, Easter 🐣, Pride Month 🌈, Halloween 🎃, Valentine's Day 💕, Lunar New Year 🧧 (default) |
+| `"jewish"` | Hanukkah 🕎 (blue), Rosh Hashanah 🍎 (gold), Passover 🪬 (spring green) |
+| `"islamic"` | Eid al-Fitr 🌙 (green) |
+| `"hindu"` | Diwali 🪔 (gold), Holi 🌈 (rainbow) |
+| `"sikh"` | Vaisakhi 🌾 (spring green), Bandi Chhor Divas 🪔 (gold) |
+| `"off"` | Disable seasonal colours entirely |
+
+```toml
+seasonal-calendar = "jewish"
+```
+
+Note: `seasonal-colours = false` is a backward-compatible alias for `seasonal-calendar = "off"`.
+
 ### `--colour-diagnostics` / `--color-diagnostics`
 
 Print a colour swatch page showing every colour and gradient used in the breakfast UI, then exit. No GitHub token or organisation is required.

--- a/docs/manual/options.md
+++ b/docs/manual/options.md
@@ -61,6 +61,25 @@ With `--ignore-author dependabot[bot]`, the bot PR is excluded:
 +---------+----------------+-----------------+--------+---------+-------+---------+------------+----------+--------------+--------+
 ```
 
+### `--fetch-state`
+
+Control which PR states are **fetched** from GitHub. By default only open PRs are
+retrieved. Use this flag to include closed or merged PRs in your results.
+
+Accepted values: `open` (default), `closed`, `merged`, `all`.
+
+```bash
+breakfast -o my-org -r platform --fetch-state closed    # closed PRs only
+breakfast -o my-org -r platform --fetch-state merged    # merged PRs only
+breakfast -o my-org -r platform --fetch-state all       # every state
+```
+
+> **Note:** Fetching closed or merged PRs can be significantly slower since
+> there are usually many more of them. Combine with `--limit` to keep output
+> manageable.
+
+Config key: `fetch-state = "open"`
+
 ### `--filter-state`
 
 Only show PRs with a specific state. Accepted values: `open`, `closed`, `draft`. Repeat the flag to match multiple states.

--- a/src/breakfast/api.py
+++ b/src/breakfast/api.py
@@ -523,3 +523,28 @@ def get_check_status(owner, repo, sha):
         return "fail"
 
     return "pass"
+
+
+def _pr_days_since(timestamp_str, now=None):
+    """Return the number of days since the given ISO 8601 timestamp, or 0 on error."""
+    if not timestamp_str:
+        return 0
+    try:
+        dt = datetime.datetime.fromisoformat(timestamp_str.replace("Z", "+00:00"))
+    except ValueError:
+        return 0
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=datetime.timezone.utc)
+    if now is None:
+        now = datetime.datetime.now(datetime.timezone.utc)
+    return max((now - dt).days, 0)
+
+
+def get_pr_age_days(pr_detail, now=None):
+    """Return the age in days of a PR since it was created."""
+    return _pr_days_since(pr_detail.get("created_at"), now=now)
+
+
+def get_pr_inactive_days(pr_detail, now=None):
+    """Return the number of days since a PR was last updated."""
+    return _pr_days_since(pr_detail.get("updated_at"), now=now)

--- a/src/breakfast/api.py
+++ b/src/breakfast/api.py
@@ -249,26 +249,36 @@ def _match_repo_filter(repo_name, repo_filter):
     return repo_filter in repo_name
 
 
-def get_github_prs(organization, repo_filter):
-    base_query = """
-    query($organization: String!, $cursor: String){
-      organization(login: $organization){
-        repositories(after: $cursor, first:100){
-          nodes{
+_FETCH_STATE_MAP = {
+    "open": ["OPEN"],
+    "closed": ["CLOSED"],
+    "merged": ["MERGED"],
+    "all": ["OPEN", "CLOSED", "MERGED"],
+}
+
+
+def get_github_prs(organization, repo_filter, fetch_state="open"):
+    states_list = _FETCH_STATE_MAP.get(fetch_state.lower(), ["OPEN"])
+    states_gql = ", ".join(states_list)
+    base_query = f"""
+    query($organization: String!, $cursor: String){{
+      organization(login: $organization){{
+        repositories(after: $cursor, first:100){{
+          nodes{{
             name
-            pullRequests(first:100,states: [OPEN]){
-                nodes{
+            pullRequests(first:100,states: [{states_gql}]){{
+                nodes{{
                     url
-                 }
-            }
-          }
-          pageInfo {
+                 }}
+            }}
+          }}
+          pageInfo {{
             endCursor
             hasNextPage
-          }
-        }
-      }
-    }
+          }}
+        }}
+      }}
+    }}
         """
     variables = {"organization": organization}
 

--- a/src/breakfast/cache.py
+++ b/src/breakfast/cache.py
@@ -206,6 +206,113 @@ def read_pr_cache(org: str, repo_filter: str, ttl: int) -> dict | None:
         return None
 
 
+def repo_pr_cache_path(org: str, repo_name: str) -> Path:
+    raw = f"{org.lower()}:{repo_name.lower()}"
+    key = hashlib.sha256(raw.encode()).hexdigest()[:16]
+    return _CACHE_DIR / f"pr_repo_{key}.json"
+
+
+def read_repo_pr_cache(org: str, repo_name: str, ttl: int) -> dict | None:
+    """Return cached PR details for a single repo, or None on miss/expiry."""
+    path = repo_pr_cache_path(org, repo_name)
+    try:
+        if not path.exists():
+            logger.debug("cache_miss layer=repo_pr path=%s reason=file_not_found", path)
+            return None
+        data = json.loads(path.read_text())
+        fetched_at = datetime.fromisoformat(data["fetched_at"])
+        age = (datetime.now(timezone.utc) - fetched_at).total_seconds()
+        if age > ttl:
+            logger.debug(
+                "cache_miss layer=repo_pr path=%s reason=expired age=%.0fs ttl=%ss",
+                path,
+                age,
+                ttl,
+            )
+            return None
+        raw_checks = data.get("check_statuses")
+        raw_approvals = data.get("approval_statuses")
+        raw_approval_details = data.get("approval_details")
+        logger.debug(
+            "cache_hit layer=repo_pr path=%s age=%.0fs pr_count=%d",
+            path,
+            age,
+            len(data["prs"]),
+        )
+        return {
+            "prs": data["prs"],
+            "check_statuses": (
+                {int(k): v for k, v in raw_checks.items()}
+                if raw_checks is not None
+                else None
+            ),
+            "approval_statuses": (
+                {int(k): v for k, v in raw_approvals.items()}
+                if raw_approvals is not None
+                else None
+            ),
+            "approval_details": (
+                {int(k): v for k, v in raw_approval_details.items()}
+                if raw_approval_details is not None
+                else None
+            ),
+        }
+    except (OSError, json.JSONDecodeError, KeyError, ValueError, TypeError) as exc:
+        logger.warning(
+            "cache_read_error layer=repo_pr path=%s error=%r", path, str(exc)
+        )
+        click.echo(
+            click.style(f"Warning: failed to read repo PR cache: {exc}", fg="yellow"),
+            err=True,
+        )
+        return None
+
+
+def write_repo_pr_cache(
+    org: str,
+    repo_name: str,
+    pr_details: list,
+    check_statuses: dict | None = None,
+    approval_statuses: dict | None = None,
+    approval_details: dict | None = None,
+) -> None:
+    """Write PR details for a single repo to disk cache."""
+    try:
+        _CACHE_DIR.mkdir(parents=True, exist_ok=True)
+        path = repo_pr_cache_path(org, repo_name)
+        payload = {
+            "fetched_at": datetime.now(timezone.utc).isoformat(),
+            "organization": org,
+            "repo": repo_name,
+            "pr_count": len(pr_details),
+            "prs": pr_details,
+        }
+        if check_statuses is not None:
+            payload["check_statuses"] = {str(k): v for k, v in check_statuses.items()}
+        if approval_statuses is not None:
+            payload["approval_statuses"] = {
+                str(k): v for k, v in approval_statuses.items()
+            }
+        if approval_details is not None:
+            payload["approval_details"] = {
+                str(k): v for k, v in approval_details.items()
+            }
+        _atomic_write_text(path, json.dumps(payload))
+        logger.debug(
+            "cache_write layer=repo_pr path=%s pr_count=%d", path, len(pr_details)
+        )
+    except OSError as exc:
+        logger.warning(
+            "cache_write_error layer=repo_pr path=%s error=%r",
+            repo_pr_cache_path(org, repo_name),
+            str(exc),
+        )
+        click.echo(
+            click.style(f"Warning: failed to write repo PR cache: {exc}", fg="yellow"),
+            err=True,
+        )
+
+
 def write_pr_cache(
     org: str,
     repo_filter: str,

--- a/src/breakfast/cli.py
+++ b/src/breakfast/cli.py
@@ -896,6 +896,7 @@ def breakfast(
     seasonal_colours = cfg.get("seasonal-colours", True)
     summarise_user_prs = summarise_user_prs or cfg.get("summarise-user-prs", False)
     summarise_repo_prs = summarise_repo_prs or cfg.get("summarise-repo-prs", False)
+    show_update_summary = cfg.get("update-summary", False)
 
     if summarise_user_prs and summarise_repo_prs:
         click.echo(
@@ -1293,7 +1294,7 @@ def breakfast(
             color=colour and _stdout_is_tty(),
         )
         if not no_update_check:
-            update_msg = check_for_update()
+            update_msg = check_for_update(show_summary=show_update_summary)
             if update_msg:
                 logger.info("update_available msg=%r", update_msg)
                 click.echo(
@@ -1352,7 +1353,7 @@ def breakfast(
             "render_complete elapsed_ms=%d", int((time.monotonic() - t_render) * 1000)
         )
         if not no_update_check:
-            update_msg = check_for_update()
+            update_msg = check_for_update(show_summary=show_update_summary)
             if update_msg:
                 logger.info("update_available msg=%r", update_msg)
                 click.echo(
@@ -1444,7 +1445,7 @@ def breakfast(
             "render_complete elapsed_ms=%d", int((time.monotonic() - t_render) * 1000)
         )
         if not no_update_check:
-            update_msg = check_for_update()
+            update_msg = check_for_update(show_summary=show_update_summary)
             if update_msg:
                 logger.info("update_available msg=%r", update_msg)
                 click.echo(
@@ -1524,7 +1525,7 @@ def breakfast(
             "render_complete elapsed_ms=%d", int((time.monotonic() - t_render) * 1000)
         )
         if not no_update_check:
-            update_msg = check_for_update()
+            update_msg = check_for_update(show_summary=show_update_summary)
             if update_msg:
                 logger.info("update_available msg=%r", update_msg)
                 click.echo(
@@ -1649,7 +1650,7 @@ def breakfast(
     )
 
     if not no_update_check:
-        update_msg = check_for_update()
+        update_msg = check_for_update(show_summary=show_update_summary)
         if update_msg:
             logger.info("update_available msg=%r", update_msg)
             click.echo(

--- a/src/breakfast/cli.py
+++ b/src/breakfast/cli.py
@@ -654,6 +654,16 @@ def _fetch_pr_bundle(url, fetch_checks, fetch_approvals):
     ),
 )
 @click.option(
+    "--fetch-state",
+    type=click.Choice(["open", "closed", "merged", "all"], case_sensitive=False),
+    default="open",
+    show_default=True,
+    help=(
+        "Which PR states to fetch from GitHub. 'open' fetches only open PRs"
+        " (default). Use 'closed', 'merged', or 'all' to include other states."
+    ),
+)
+@click.option(
     "--filter-state",
     type=click.Choice(["open", "closed", "draft"], case_sensitive=False),
     multiple=True,
@@ -785,6 +795,7 @@ def breakfast(
     cache,
     refresh,
     refresh_prs,
+    fetch_state,
     filter_state,
     filter_check,
     filter_approval,
@@ -884,6 +895,9 @@ def breakfast(
         else cfg.get("max-title-length")
     )
     workers = workers if workers is not None else cfg.get("workers", 64)
+    fetch_state = (
+        fetch_state if fetch_state != "open" else cfg.get("fetch-state", "open")
+    )
     if status_style not in {"emoji", "ascii"}:
         status_style = "emoji"
     legendary = legendary if legendary is not None else cfg.get("legendary", False)
@@ -1079,7 +1093,7 @@ def breakfast(
 
         if prs is None:
             try:
-                prs = get_github_prs(organization, repo_filter)
+                prs = get_github_prs(organization, repo_filter, fetch_state)
             except (
                 requests.exceptions.ConnectionError,
                 requests.exceptions.Timeout,

--- a/src/breakfast/cli.py
+++ b/src/breakfast/cli.py
@@ -894,6 +894,9 @@ def breakfast(
     no_colour = no_colour or cfg.get("no-colour", False)
     colour = not no_colour
     seasonal_colours = cfg.get("seasonal-colours", True)
+    seasonal_calendar = cfg.get("seasonal-calendar", "western")
+    if not seasonal_colours:
+        seasonal_calendar = "off"
     summarise_user_prs = summarise_user_prs or cfg.get("summarise-user-prs", False)
     summarise_repo_prs = summarise_repo_prs or cfg.get("summarise-repo-prs", False)
 
@@ -1289,7 +1292,7 @@ def breakfast(
             "render format=summary group_by=%s groups=%d", group_by, len(groups)
         )
         click.echo(
-            render_pr_summary(groups, title, label_header, colour, seasonal_colours),
+            render_pr_summary(groups, title, label_header, colour, seasonal_calendar),
             color=colour and _stdout_is_tty(),
         )
         if not no_update_check:
@@ -1557,15 +1560,15 @@ def breakfast(
         pr_num = pr_detail["number"]
 
         def _seasonal_colour(text: str) -> str:
-            """Apply seasonal colour to plain text when seasonal colouring is active."""
-            if seasonal_colours and colour:
-                return apply_seasonal_colour(text, pr_num)
+            if seasonal_calendar != "off" and colour:
+                return apply_seasonal_colour(text, pr_num, calendar=seasonal_calendar)
             return text
 
         def _seasonal_colour_link(url: str, text: str) -> str:
-            """Apply seasonal colour to a hyperlinked label when active."""
-            if seasonal_colours and colour:
-                return _styled_hyperlink(url, apply_seasonal_colour(text, pr_num))
+            if seasonal_calendar != "off" and colour:
+                return _styled_hyperlink(
+                    url, apply_seasonal_colour(text, pr_num, calendar=seasonal_calendar)
+                )
             return generate_terminal_url_anchor(url, text)
 
         row = {

--- a/src/breakfast/cli.py
+++ b/src/breakfast/cli.py
@@ -701,6 +701,26 @@ def _fetch_pr_bundle(url, fetch_checks, fetch_approvals):
     ),
 )
 @click.option(
+    "--sort",
+    "sort_by",
+    type=click.Choice(
+        ["repo", "age", "updated", "author", "comments", "reviews"],
+        case_sensitive=False,
+    ),
+    default=None,
+    help=(
+        "Sort PRs by field. Choices: repo (default), age, updated,"
+        " author, comments, reviews."
+    ),
+)
+@click.option(
+    "--reverse",
+    "sort_reverse",
+    is_flag=True,
+    default=False,
+    help="Reverse the sort order.",
+)
+@click.option(
     "--api-stats",
     is_flag=True,
     default=False,
@@ -796,6 +816,8 @@ def breakfast(
     colour_diagnostics,
     summarise_user_prs,
     summarise_repo_prs,
+    sort_by,
+    sort_reverse,
 ):
     t0_total = time.monotonic()
     configure_logging()
@@ -896,6 +918,8 @@ def breakfast(
     seasonal_colours = cfg.get("seasonal-colours", True)
     summarise_user_prs = summarise_user_prs or cfg.get("summarise-user-prs", False)
     summarise_repo_prs = summarise_repo_prs or cfg.get("summarise-repo-prs", False)
+    sort_by = sort_by if sort_by is not None else cfg.get("sort", "repo")
+    sort_reverse = sort_reverse or cfg.get("sort-reverse", False)
 
     if summarise_user_prs and summarise_repo_prs:
         click.echo(
@@ -1272,7 +1296,18 @@ def breakfast(
             err=True,
             color=colour,
         )
-    pr_details.sort(key=lambda pr: pr["base"]["repo"]["name"])
+    _SORT_KEYS = {
+        "repo": lambda pr: pr["base"]["repo"]["name"],
+        "age": lambda pr: get_pr_age_days(pr),
+        "updated": lambda pr: pr.get("updated_at", ""),
+        "author": lambda pr: pr.get("user", {}).get("login", "").lower(),
+        "comments": lambda pr: pr.get("comments", 0) + pr.get("review_comments", 0),
+        "reviews": lambda pr: pr.get("review_comments", 0),
+    }
+    pr_details.sort(
+        key=_SORT_KEYS.get(sort_by or "repo", _SORT_KEYS["repo"]),
+        reverse=sort_reverse,
+    )
     if legendary_only:
         pr_details = [pr for pr in pr_details if is_legendary(pr)]
     if limit is not None:

--- a/src/breakfast/cli.py
+++ b/src/breakfast/cli.py
@@ -136,16 +136,25 @@ def _styled_hyperlink(url, styled_text):
 
 
 def _table_width(rows):
-    """Return visual table width via the border line (ANSI-stripped for accuracy)."""
-    plain_rows = [{k: _strip_ansi(v) for k, v in row.items()} for row in rows]
-    table_str = tabulate(
-        plain_rows,
-        headers="keys",
-        showindex="always",
-        tablefmt="outline",
-        disable_numparse=True,
-    )
-    return len(table_str.splitlines()[0])
+    """Return visual table width without rendering the full table.
+
+    Replicates the border line width of tabulate's outline format.
+    Each column contributes max(header_len+4, cell_max+2) dashes plus
+    a leading '+'. The index column uses header_len=0.
+    """
+    if not rows:
+        return 0
+    headers = list(rows[0].keys())
+    idx_width = len(str(len(rows) - 1))
+    # Index column: header is empty, content is the row number
+    total = 1 + max(4, idx_width + 2) + 1
+    for h in headers:
+        cell_max = max(
+            (len(_strip_ansi(str(row.get(h, "")))) for row in rows),
+            default=0,
+        )
+        total += max(len(h) + 4, cell_max + 2) + 1
+    return total
 
 
 def _truncate_col(pr_data, key, terminal_width, min_len=8):

--- a/src/breakfast/cli.py
+++ b/src/breakfast/cli.py
@@ -22,6 +22,7 @@ from .api import (
     get_check_status,
     get_github_prs,
     get_graphql_rate_limit,
+    get_pr_age_days,
 )
 from .cache import (
     parse_ttl,
@@ -339,27 +340,6 @@ def _print_debug_summary(t0, pr_count, api_stats, graphql_rate_limit):
     click.echo("\n".join(lines), err=True)
 
 
-def get_pr_age_days(pr_detail, now=None):
-    from datetime import datetime, timezone
-
-    created_at = pr_detail.get("created_at")
-    if not created_at:
-        return 0
-
-    try:
-        created_dt = datetime.fromisoformat(created_at.replace("Z", "+00:00"))
-    except ValueError:
-        logger.debug("get_pr_age_days invalid_date created_at=%r", created_at)
-        return 0
-
-    if created_dt.tzinfo is None:
-        created_dt = created_dt.replace(tzinfo=timezone.utc)
-    if now is None:
-        now = datetime.now(timezone.utc)
-
-    return max((now - created_dt).days, 0)
-
-
 _LEGENDARY_COMMENT_THRESHOLD = 100
 _LEGENDARY_AGE_THRESHOLD_DAYS = 30
 _LEGENDARY_EMOJI = "⚔️"
@@ -673,6 +653,18 @@ def _fetch_pr_bundle(url, fetch_checks, fetch_approvals):
     help="Only show PRs with this review approval status. Repeat for multiple values.",
 )
 @click.option(
+    "--filter-stale",
+    type=int,
+    default=None,
+    help="Only show PRs older than N days (by creation date).",
+)
+@click.option(
+    "--filter-inactive",
+    type=int,
+    default=None,
+    help="Only show PRs not updated in the last N days.",
+)
+@click.option(
     "--legendary/--no-legendary",
     default=None,
     help=(
@@ -786,6 +778,8 @@ def breakfast(
     filter_state,
     filter_check,
     filter_approval,
+    filter_stale,
+    filter_inactive,
     legendary,
     legendary_only,
     search,
@@ -1254,6 +1248,8 @@ def breakfast(
         check_statuses=check_statuses,
         approval_statuses=approval_statuses,
         search_title=search,
+        filter_stale=filter_stale,
+        filter_inactive=filter_inactive,
     )
     logger.info(
         "filter_result before=%d after=%d",

--- a/src/breakfast/cli.py
+++ b/src/breakfast/cli.py
@@ -7,6 +7,7 @@ import shutil
 import sys
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
+from urllib.parse import urlparse
 
 import click
 import requests
@@ -27,8 +28,10 @@ from .cache import (
     parse_ttl,
     read_graphql_cache,
     read_pr_cache,
+    read_repo_pr_cache,
     write_graphql_cache,
     write_pr_cache,
+    write_repo_pr_cache,
 )
 from .config import (
     filter_pr_details,
@@ -1104,28 +1107,77 @@ def breakfast(
         else:
             click.echo(f"Fetching {organization} PRs...⚡...Done", err=True)
 
+        # --- Layer 2.5: per-repo PR cache ---
+        # Group URLs by repo so we can check per-repo cache before fetching.
+        urls_to_fetch = list(prs) if prs else []
+        repo_hit_prs: list = []
+        repo_hit_checks: dict = {}
+        repo_hit_approvals: dict = {}
+        repo_hit_approval_details: dict = {}
+
+        if cache_enabled and not refresh_prs and prs:
+            repos_to_urls: dict[str, list[str]] = {}
+            for url in prs:
+                parts = urlparse(url).path.strip("/").split("/")
+                if len(parts) >= 4:
+                    repos_to_urls.setdefault(parts[1], []).append(url)
+
+            uncached_urls: list[str] = []
+            for rname, repo_urls in repos_to_urls.items():
+                cached = read_repo_pr_cache(organization, rname, cache_ttl_seconds)
+                if cached is not None:
+                    repo_hit_prs.extend(cached["prs"])
+                    if cached["check_statuses"]:
+                        repo_hit_checks.update(cached["check_statuses"])
+                    if cached["approval_statuses"]:
+                        repo_hit_approvals.update(cached["approval_statuses"])
+                    if cached["approval_details"]:
+                        repo_hit_approval_details.update(cached["approval_details"])
+                else:
+                    uncached_urls.extend(repo_urls)
+            urls_to_fetch = uncached_urls
+
         pr_details = []
         failed_urls = []
+        newly_fetched_by_repo: dict[str, dict] = {}
         click.echo(f"Processing {repo_filter} PRs...", nl=False, err=True)
-        if prs:
-            max_workers = min(workers, len(prs))
+
+        if not urls_to_fetch and repo_hit_prs:
+            click.echo("⚡", nl=False, err=True)
+
+        if urls_to_fetch:
+            max_workers = min(workers, len(urls_to_fetch))
             with ThreadPoolExecutor(max_workers=max_workers) as executor:
                 future_to_url = {
                     executor.submit(_fetch_pr_bundle, url, checks, approvals): url
-                    for url in prs
+                    for url in urls_to_fetch
                 }
                 for future in as_completed(future_to_url):
                     url = future_to_url[future]
                     try:
                         pr_detail, check_status, approval_detail = future.result()
                         pr_details.append(pr_detail)
+                        rname = pr_detail["base"]["repo"]["name"]
+                        rd = newly_fetched_by_repo.setdefault(
+                            rname,
+                            {
+                                "prs": [],
+                                "checks": {},
+                                "approvals": {},
+                                "approval_details": {},
+                            },
+                        )
+                        rd["prs"].append(pr_detail)
                         if check_status is not None:
                             check_statuses[pr_detail["id"]] = check_status
+                            rd["checks"][pr_detail["id"]] = check_status
                         if approval_detail is not None:
                             approval_statuses[pr_detail["id"]] = approval_detail[
                                 "status"
                             ]
                             approval_details[pr_detail["id"]] = approval_detail
+                            rd["approvals"][pr_detail["id"]] = approval_detail["status"]
+                            rd["approval_details"][pr_detail["id"]] = approval_detail
                         click.echo(
                             random.choices(BREAKFAST_ITEMS)[0],
                             nl=False,
@@ -1139,7 +1191,32 @@ def breakfast(
                             "pr_detail_fetch_failed url=%s error=%r", url, str(exc)
                         )
                         failed_urls.append(url)
-        statuses_from_bundle = True
+
+        # Write per-repo cache for repos fetched in this run
+        if cache_enabled and newly_fetched_by_repo:
+            for rname, rdata in newly_fetched_by_repo.items():
+                write_repo_pr_cache(
+                    organization,
+                    rname,
+                    rdata["prs"],
+                    check_statuses=rdata["checks"] or None,
+                    approval_statuses=rdata["approvals"] or None,
+                    approval_details=rdata["approval_details"] or None,
+                )
+
+        # Merge per-repo cache hits into the main collections
+        pr_details.extend(repo_hit_prs)
+        check_statuses.update(repo_hit_checks)
+        approval_statuses.update(repo_hit_approvals)
+        approval_details.update(repo_hit_approval_details)
+
+        # When all PRs came from per-repo cache, use cached statuses path
+        statuses_from_bundle = bool(urls_to_fetch)
+        if not statuses_from_bundle and repo_hit_prs:
+            cached_check_statuses = repo_hit_checks or None
+            cached_approval_statuses = repo_hit_approvals or None
+            cached_approval_details = repo_hit_approval_details or None
+
         click.echo("...Done", err=True)
         if failed_urls:
             examples = ", ".join(failed_urls[:3])

--- a/src/breakfast/cli.py
+++ b/src/breakfast/cli.py
@@ -673,6 +673,14 @@ def _fetch_pr_bundle(url, fetch_checks, fetch_approvals):
     help="Only show PRs with this review approval status. Repeat for multiple values.",
 )
 @click.option(
+    "--filter-reviewer",
+    multiple=True,
+    help=(
+        "Only show PRs that have this user as a requested reviewer"
+        " (repeatable, case-insensitive). e.g. --filter-reviewer alice"
+    ),
+)
+@click.option(
     "--legendary/--no-legendary",
     default=None,
     help=(
@@ -786,6 +794,7 @@ def breakfast(
     filter_state,
     filter_check,
     filter_approval,
+    filter_reviewer,
     legendary,
     legendary_only,
     search,
@@ -1254,6 +1263,7 @@ def breakfast(
         check_statuses=check_statuses,
         approval_statuses=approval_statuses,
         search_title=search,
+        filter_reviewer=filter_reviewer,
     )
     logger.info(
         "filter_result before=%d after=%d",

--- a/src/breakfast/cli.py
+++ b/src/breakfast/cli.py
@@ -656,8 +656,7 @@ def _fetch_pr_bundle(url, fetch_checks, fetch_approvals):
 @click.option(
     "--fetch-state",
     type=click.Choice(["open", "closed", "merged", "all"], case_sensitive=False),
-    default="open",
-    show_default=True,
+    default=None,
     help=(
         "Which PR states to fetch from GitHub. 'open' fetches only open PRs"
         " (default). Use 'closed', 'merged', or 'all' to include other states."
@@ -896,7 +895,7 @@ def breakfast(
     )
     workers = workers if workers is not None else cfg.get("workers", 64)
     fetch_state = (
-        fetch_state if fetch_state != "open" else cfg.get("fetch-state", "open")
+        fetch_state if fetch_state is not None else cfg.get("fetch-state", "open")
     )
     if status_style not in {"emoji", "ascii"}:
         status_style = "emoji"

--- a/src/breakfast/cli.py
+++ b/src/breakfast/cli.py
@@ -560,10 +560,24 @@ def _fetch_pr_bundle(url, fetch_checks, fetch_approvals):
     "--format",
     "output_format",
     default=None,
-    type=click.Choice(["table", "json", "markdown", "csv"], case_sensitive=False),
+    type=click.Choice(
+        ["table", "json", "markdown", "csv", "template"], case_sensitive=False
+    ),
     help=(
-        "Output format: table (default), json, or markdown. "
+        "Output format: table (default), json, markdown, csv, or template. "
         "Overrides --json/--no-json/--markdown when both are given."
+    ),
+)
+@click.option(
+    "--template",
+    "template_str",
+    default=None,
+    help=(
+        "Format string for --format template. "
+        "Fields: {repo}, {title}, {author}, {url}, {state}, {number},"
+        " {created_at}, {updated_at}, {additions}, {deletions},"
+        " {changed_files}, {commits}, {review_comments}, {labels},"
+        " {requested_reviewers}."
     ),
 )
 @click.option(
@@ -772,6 +786,7 @@ def breakfast(
     json_output,
     markdown_flag,
     output_format,
+    template_str,
     checks,
     approvals,
     head_branch,
@@ -855,11 +870,12 @@ def breakfast(
             "json",
             "markdown",
             "csv",
+            "template",
         }:
             click.echo(
                 click.style(
                     f"Warning: unrecognised format '{cfg_format}' in config"
-                    " — expected 'table', 'json', 'markdown', or 'csv'."
+                    " — expected 'table', 'json', 'markdown', 'csv', or 'template'."
                     " Falling back to 'table'.",
                     fg="yellow",
                 ),
@@ -868,6 +884,7 @@ def breakfast(
             cfg_format = "table"
         fmt = cfg_format or "table"
     json_output = fmt == "json"
+    template_str = template_str if template_str is not None else cfg.get("template")
     checks = checks if checks is not None else cfg.get("checks", False)
     approvals = approvals if approvals is not None else cfg.get("approvals", False)
     head_branch = (
@@ -1527,6 +1544,66 @@ def breakfast(
             update_msg = check_for_update()
             if update_msg:
                 logger.info("update_available msg=%r", update_msg)
+                click.echo(
+                    click.style(update_msg, fg="cyan", bold=True),
+                    err=True,
+                    color=colour,
+                )
+        if api_stats:
+            _print_debug_summary(
+                t0_total, len(pr_details), get_api_stats(), get_graphql_rate_limit()
+            )
+        return
+
+    if fmt == "template":
+        if not template_str:
+            click.echo(
+                click.style(
+                    "Error: --template is required when using --format template.",
+                    fg="red",
+                    bold=True,
+                ),
+                err=True,
+                color=colour,
+            )
+            sys.exit(1)
+        for pr_detail in pr_details:
+            fields = {
+                "repo": pr_detail["base"]["repo"]["name"],
+                "title": pr_detail.get("title", ""),
+                "author": pr_detail.get("user", {}).get("login", ""),
+                "url": pr_detail.get("html_url", ""),
+                "state": pr_detail.get("state", ""),
+                "number": pr_detail.get("number", ""),
+                "created_at": pr_detail.get("created_at", ""),
+                "updated_at": pr_detail.get("updated_at", ""),
+                "additions": pr_detail.get("additions", 0),
+                "deletions": pr_detail.get("deletions", 0),
+                "changed_files": pr_detail.get("changed_files", 0),
+                "commits": pr_detail.get("commits", 0),
+                "review_comments": pr_detail.get("review_comments", 0),
+                "labels": "|".join(lb["name"] for lb in pr_detail.get("labels", [])),
+                "requested_reviewers": "|".join(
+                    r["login"] for r in pr_detail.get("requested_reviewers", [])
+                ),
+            }
+            try:
+                click.echo(template_str.format_map(fields))
+            except KeyError as e:
+                click.echo(
+                    click.style(
+                        f"Error: unknown template field {e}. "
+                        "See --help for available fields.",
+                        fg="red",
+                        bold=True,
+                    ),
+                    err=True,
+                    color=colour,
+                )
+                sys.exit(1)
+        if not no_update_check:
+            update_msg = check_for_update()
+            if update_msg:
                 click.echo(
                     click.style(update_msg, fg="cyan", bold=True),
                     err=True,

--- a/src/breakfast/cli.py
+++ b/src/breakfast/cli.py
@@ -673,6 +673,23 @@ def _fetch_pr_bundle(url, fetch_checks, fetch_approvals):
     help="Only show PRs with this review approval status. Repeat for multiple values.",
 )
 @click.option(
+    "--label",
+    "filter_label",
+    multiple=True,
+    help=(
+        "Only show PRs that have this label (repeatable, case-insensitive)."
+        " e.g. --label bug --label enhancement"
+    ),
+)
+@click.option(
+    "--exclude-label",
+    multiple=True,
+    help=(
+        "Exclude PRs that have this label (repeatable, case-insensitive)."
+        " e.g. --exclude-label wip"
+    ),
+)
+@click.option(
     "--legendary/--no-legendary",
     default=None,
     help=(
@@ -786,6 +803,8 @@ def breakfast(
     filter_state,
     filter_check,
     filter_approval,
+    filter_label,
+    exclude_label,
     legendary,
     legendary_only,
     search,
@@ -1254,6 +1273,8 @@ def breakfast(
         check_statuses=check_statuses,
         approval_statuses=approval_statuses,
         search_title=search,
+        filter_label=filter_label,
+        exclude_label=exclude_label,
     )
     logger.info(
         "filter_result before=%d after=%d",

--- a/src/breakfast/config.py
+++ b/src/breakfast/config.py
@@ -393,6 +393,7 @@ def filter_pr_details(
     check_statuses=None,
     approval_statuses=None,
     search_title=None,
+    filter_reviewer=None,
 ):
     ignore_set = normalize_ignore_authors(ignore_authors)
     current_user_login_normalized = (
@@ -438,6 +439,12 @@ def filter_pr_details(
         if search_title is not None:
             title = pr_detail.get("title", "")
             if not re.search(search_title, title, re.IGNORECASE):
+                continue
+        if filter_reviewer:
+            reviewers = {
+                r["login"].lower() for r in pr_detail.get("requested_reviewers", [])
+            }
+            if not any(rv.lower() in reviewers for rv in filter_reviewer):
                 continue
 
         filtered.append(pr_detail)

--- a/src/breakfast/config.py
+++ b/src/breakfast/config.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import click
 
+from .api import get_pr_age_days, get_pr_inactive_days
 from .logger import logger
 from .xdg import get_config_dir, get_config_paths
 
@@ -393,6 +394,8 @@ def filter_pr_details(
     check_statuses=None,
     approval_statuses=None,
     search_title=None,
+    filter_stale=None,
+    filter_inactive=None,
 ):
     ignore_set = normalize_ignore_authors(ignore_authors)
     current_user_login_normalized = (
@@ -438,6 +441,11 @@ def filter_pr_details(
         if search_title is not None:
             title = pr_detail.get("title", "")
             if not re.search(search_title, title, re.IGNORECASE):
+                continue
+        if filter_stale is not None and get_pr_age_days(pr_detail) < filter_stale:
+            continue
+        if filter_inactive is not None:
+            if get_pr_inactive_days(pr_detail) < filter_inactive:
                 continue
 
         filtered.append(pr_detail)

--- a/src/breakfast/config.py
+++ b/src/breakfast/config.py
@@ -105,8 +105,17 @@ _DEFAULT_CONFIG_CONTENT = """\
 # Output format. "table" renders a coloured terminal table (default).
 # "json" outputs machine-readable JSON — useful for scripting or piping.
 # "markdown" renders a GitHub-flavoured Markdown table — great for pasting into docs.
-# Equivalent to: --format table|json|markdown
+# "csv" outputs comma-separated values for spreadsheet import.
+# "template" renders each PR using a custom format string (see template below).
+# Equivalent to: --format table|json|markdown|csv|template
 # format = "table"
+
+# Custom format string for --format template.
+# Available fields: {repo}, {title}, {author}, {url}, {state}, {number},
+#   {created_at}, {updated_at}, {additions}, {deletions}, {changed_files},
+#   {commits}, {review_comments}, {labels}, {requested_reviewers}
+# Equivalent to: --template <value>
+# template = "{repo}: {title} ({url})"
 
 # How status columns (Checks, Approved, Mergeable?) are rendered.
 #   emoji  — colourful emoji labels, e.g. ✅ pass, ❌ fail  (default)

--- a/src/breakfast/config.py
+++ b/src/breakfast/config.py
@@ -45,6 +45,11 @@ _DEFAULT_CONFIG_CONTENT = """\
 # Control which PRs appear in the output.
 # -----------------------------------------------------------------------------
 
+# Which PR states to fetch from GitHub. Default: open.
+# Choices: open, closed, merged, all.
+# Equivalent to: --fetch-state <value>
+# fetch-state = "open"
+
 # Authors to exclude from the output (case-insensitive). Useful for hiding
 # bot PRs. List format — add as many entries as you like.
 # Equivalent to: --ignore-author dependabot[bot] --ignore-author renovate[bot]

--- a/src/breakfast/config.py
+++ b/src/breakfast/config.py
@@ -393,6 +393,8 @@ def filter_pr_details(
     check_statuses=None,
     approval_statuses=None,
     search_title=None,
+    filter_label=None,
+    exclude_label=None,
 ):
     ignore_set = normalize_ignore_authors(ignore_authors)
     current_user_login_normalized = (
@@ -438,6 +440,14 @@ def filter_pr_details(
         if search_title is not None:
             title = pr_detail.get("title", "")
             if not re.search(search_title, title, re.IGNORECASE):
+                continue
+        if filter_label:
+            pr_labels = {lb["name"].lower() for lb in pr_detail.get("labels", [])}
+            if not any(lbl.lower() in pr_labels for lbl in filter_label):
+                continue
+        if exclude_label:
+            pr_labels = {lb["name"].lower() for lb in pr_detail.get("labels", [])}
+            if any(lbl.lower() in pr_labels for lbl in exclude_label):
                 continue
 
         filtered.append(pr_detail)

--- a/src/breakfast/config.py
+++ b/src/breakfast/config.py
@@ -196,6 +196,17 @@ _DEFAULT_CONFIG_CONTENT = """\
 # oldest PR age, and total comments per repo.
 # Equivalent to: --summarise-repo-prs
 # summarise-repo-prs = false
+
+
+# -----------------------------------------------------------------------------
+# Update notifications
+# Control how version update alerts appear.
+# -----------------------------------------------------------------------------
+
+# When a newer version of breakfast is available, include a short summary of
+# what's new (pulled from the GitHub release notes) below the update banner.
+# Equivalent to: --update-summary
+# update-summary = false
 """
 
 

--- a/src/breakfast/config.py
+++ b/src/breakfast/config.py
@@ -117,6 +117,16 @@ _DEFAULT_CONFIG_CONTENT = """\
 # A little something extra for the observant. 🌟
 # seasonal-colours = true
 
+# Which cultural holiday calendar drives seasonal colours.
+#   western  — Christmas 🎄, Easter 🐣, Pride Month 🌈, Halloween 🎃 (default)
+#   jewish   — Hanukkah 🕎, Passover 🪬, Rosh Hashanah 🍎
+#   islamic  — Eid al-Fitr 🌙
+#   hindu    — Diwali 🪔, Holi 🌈
+#   sikh     — Vaisakhi 🌾, Bandi Chhor Divas 🪔
+#   off      — disable seasonal colours entirely
+# Note: seasonal-colours = false is equivalent to seasonal-calendar = "off"
+# seasonal-calendar = "western"
+
 
 # -----------------------------------------------------------------------------
 # Legendary PRs ⚔️
@@ -258,6 +268,9 @@ def load_config(config_path=None):
                     msg = f"Warning: Failed to parse config {path}: {e}"
                     click.echo(click.style(msg, fg="yellow"), err=True)
                     continue
+            # seasonal-colours = false → seasonal-calendar = "off" (backward compat)
+            if not data.get("seasonal-colours", True):
+                data.setdefault("seasonal-calendar", "off")
             for key in _LIST_KEYS:
                 if key in data and not isinstance(data[key], list):
                     logger.warning(

--- a/src/breakfast/config.py
+++ b/src/breakfast/config.py
@@ -196,6 +196,20 @@ _DEFAULT_CONFIG_CONTENT = """\
 # oldest PR age, and total comments per repo.
 # Equivalent to: --summarise-repo-prs
 # summarise-repo-prs = false
+
+
+# -----------------------------------------------------------------------------
+# Sorting
+# Control how the PR list is ordered.
+# -----------------------------------------------------------------------------
+
+# Sort PRs by field. Choices: repo (default), age, updated, author, comments, reviews.
+# Equivalent to: --sort <field>
+# sort = "repo"
+
+# Reverse the sort order.
+# Equivalent to: --reverse
+# sort-reverse = false
 """
 
 

--- a/src/breakfast/ui.py
+++ b/src/breakfast/ui.py
@@ -1,6 +1,8 @@
 import datetime
 import math
 import unicodedata
+from datetime import date as _real_date
+from datetime import timedelta as _real_timedelta
 
 import click
 
@@ -12,6 +14,8 @@ SEASONAL_PALETTES = {
     "red": "\033[31m",
     "pink": "\033[38;5;218m",
     "lny": "\033[38;5;214m",
+    "blue": "\033[38;5;75m",
+    "spring_green": "\033[38;5;120m",
 }
 
 # Pride Month 🏳️‍🌈 rainbow: one colour per row, cycling by PR number.
@@ -155,63 +159,307 @@ def _lny_date(year: int) -> tuple[int, int]:
     raise ValueError(f"Could not calculate Lunar New Year for {year}")
 
 
-def _seasonal_colour() -> str | None:
-    """Return the ANSI colour code for the current calendar month, or None.
+# ---------------------------------------------------------------------------
+# Pluggable seasonal calendar system
+# ---------------------------------------------------------------------------
 
-    Returns None for months with no seasonal theme, so callers can skip
-    colouring and fall back to the default terminal colour.
+# Pre-computed holiday dates (year → (month, day)) for 2024–2045.
+# Dates are approximate; Islamic/Hindu dates vary by location and moon-sighting.
+
+_ROSH_HASHANAH: dict[int, tuple[int, int]] = {
+    2024: (10, 2),
+    2025: (9, 22),
+    2026: (9, 11),
+    2027: (10, 1),
+    2028: (9, 20),
+    2029: (9, 9),
+    2030: (9, 27),
+    2031: (9, 18),
+    2032: (9, 5),
+    2033: (9, 24),
+    2034: (9, 14),
+    2035: (10, 3),
+    2036: (9, 21),
+    2037: (9, 10),
+    2038: (9, 29),
+    2039: (9, 19),
+    2040: (9, 7),
+    2041: (9, 25),
+    2042: (9, 15),
+    2043: (10, 4),
+    2044: (9, 22),
+    2045: (9, 12),
+}
+
+_HANUKKAH_START: dict[int, tuple[int, int]] = {
+    2024: (12, 25),
+    2025: (12, 14),
+    2026: (12, 4),
+    2027: (12, 24),
+    2028: (12, 12),
+    2029: (12, 1),
+    2030: (12, 20),
+    2031: (12, 9),
+    2032: (11, 27),
+    2033: (12, 16),
+    2034: (12, 5),
+    2035: (12, 25),
+    2036: (12, 13),
+    2037: (12, 2),
+    2038: (12, 22),
+    2039: (12, 11),
+    2040: (11, 29),
+    2041: (12, 18),
+    2042: (12, 8),
+    2043: (12, 27),
+    2044: (12, 15),
+    2045: (12, 5),
+}
+
+_PASSOVER_START: dict[int, tuple[int, int]] = {
+    2024: (4, 22),
+    2025: (4, 12),
+    2026: (4, 1),
+    2027: (4, 21),
+    2028: (4, 10),
+    2029: (3, 29),
+    2030: (4, 17),
+    2031: (4, 7),
+    2032: (3, 27),
+    2033: (4, 14),
+    2034: (4, 3),
+    2035: (4, 23),
+    2036: (4, 11),
+    2037: (4, 1),
+    2038: (4, 20),
+    2039: (4, 9),
+    2040: (3, 29),
+    2041: (4, 16),
+    2042: (4, 6),
+    2043: (4, 25),
+    2044: (4, 13),
+    2045: (4, 3),
+}
+
+_EID_AL_FITR: dict[int, tuple[int, int]] = {
+    2024: (4, 10),
+    2025: (3, 30),
+    2026: (3, 20),
+    2027: (3, 9),
+    2028: (2, 26),
+    2029: (2, 15),
+    2030: (2, 4),
+    2031: (1, 24),
+    2032: (1, 13),
+    2033: (1, 2),
+    2034: (12, 11),
+    2035: (11, 30),
+    2036: (11, 19),
+    2037: (11, 8),
+    2038: (10, 28),
+    2039: (10, 17),
+    2040: (10, 6),
+    2041: (9, 25),
+    2042: (9, 14),
+    2043: (9, 4),
+    2044: (8, 23),
+    2045: (8, 12),
+}
+
+_DIWALI: dict[int, tuple[int, int]] = {
+    2024: (11, 1),
+    2025: (10, 20),
+    2026: (11, 8),
+    2027: (10, 29),
+    2028: (10, 17),
+    2029: (11, 5),
+    2030: (10, 26),
+    2031: (11, 14),
+    2032: (11, 2),
+    2033: (10, 22),
+    2034: (11, 11),
+    2035: (11, 1),
+    2036: (10, 19),
+    2037: (11, 7),
+    2038: (10, 28),
+    2039: (10, 18),
+    2040: (11, 4),
+    2041: (10, 24),
+    2042: (11, 13),
+    2043: (11, 3),
+    2044: (10, 21),
+    2045: (11, 9),
+}
+
+_HOLI: dict[int, tuple[int, int]] = {
+    2024: (3, 25),
+    2025: (3, 14),
+    2026: (3, 3),
+    2027: (3, 22),
+    2028: (3, 11),
+    2029: (3, 1),
+    2030: (3, 20),
+    2031: (3, 10),
+    2032: (2, 27),
+    2033: (3, 17),
+    2034: (3, 7),
+    2035: (3, 26),
+    2036: (3, 14),
+    2037: (3, 4),
+    2038: (3, 23),
+    2039: (3, 13),
+    2040: (3, 1),
+    2041: (3, 19),
+    2042: (3, 8),
+    2043: (3, 28),
+    2044: (3, 16),
+    2045: (3, 5),
+}
+
+# Holi rainbow: a burst of festival colours for the Festival of Colours 🌈
+HOLI_RAINBOW = [
+    "\033[38;5;218m",  # pink
+    "\033[38;5;226m",  # yellow
+    "\033[32m",  # green
+    "\033[38;5;208m",  # orange
+    "\033[38;5;141m",  # purple
+    "\033[38;5;75m",  # blue
+]
+
+
+def _in_holiday_window(
+    today: datetime.date,
+    table: dict[int, tuple[int, int]],
+    days: int = 1,
+) -> bool:
+    """Return True if *today* falls within *days* days of the holiday in *table*."""
+    entry = table.get(today.year)
+    if entry is None:
+        return False
+    try:
+        start = _real_date(today.year, entry[0], entry[1])
+        return start <= today < start + _real_timedelta(days=days)
+    except ValueError:
+        return False
+
+
+def _western_calendar(today: datetime.date) -> "str | list[str] | None":
+    """Return seasonal colour(s) for the western/Gregorian calendar.
+
+    Returns a list for PR-number-cycling effects (December, Pride Month),
+    a single colour string for fixed colours, or None for unthemed dates.
+    January is always purple — it is Steve's birthday month and must never
+    be overridden by any floating holiday (including Lunar New Year).
     """
-    today = datetime.date.today()
-    month = today.month
-    if month == 1:
-        return SEASONAL_PALETTES["purple"]  # 🎂 Steve's birthday month
-    if month == _easter_month(today.year):
-        return SEASONAL_PALETTES["yellow"]
-    if month == 10:
-        return SEASONAL_PALETTES["orange"]
-    if month == 12:
-        return SEASONAL_PALETTES["red"]
-    return None
-
-
-def apply_seasonal_colour(text: str, pr_number: int) -> str:
-    """Wrap *text* in a seasonal ANSI colour based on the current date.
-
-    Special behaviours:
-    - December 🎄: alternates red / green (candy-cane) by PR number.
-    - June 🏳️‍🌈: cycles through Pride rainbow by PR number.
-    - 14 February 💕: Valentine's Day pink (date-specific).
-    - Lunar New Year 🧧: gold accent, February only — January stays purple
-      for Steve's birthday month and is never overridden.
-    Non-special dates return text unstyled. Callers guard with ``no-colour``.
-    """
-    today = datetime.date.today()
     month = today.month
     day = today.day
 
     if month == 12:
-        colour = (
-            SEASONAL_PALETTES["red"]
-            if pr_number % 2 == 0
-            else SEASONAL_PALETTES["green"]
-        )
-        return f"{colour}{text}\033[0m"
+        return [SEASONAL_PALETTES["red"], SEASONAL_PALETTES["green"]]
 
     if month == 6:
-        colour = PRIDE_RAINBOW[pr_number % len(PRIDE_RAINBOW)]
-        return f"{colour}{text}\033[0m"
+        return PRIDE_RAINBOW
 
     if month == 2 and day == 14:
-        return f"{SEASONAL_PALETTES['pink']}{text}\033[0m"
+        return SEASONAL_PALETTES["pink"]
 
     # LNY only when it falls in February; January purple is never overridden.
     lny = _lny_date(today.year)
     if lny == (month, day) and month == 2:
-        return f"{SEASONAL_PALETTES['lny']}{text}\033[0m"
+        return SEASONAL_PALETTES["lny"]
 
-    colour = _seasonal_colour()
-    if colour is None:
+    if month == 1:
+        return SEASONAL_PALETTES["purple"]  # 🎂 Steve's birthday month
+
+    if month == _easter_month(today.year):
+        return SEASONAL_PALETTES["yellow"]
+
+    if month == 10:
+        return SEASONAL_PALETTES["orange"]
+
+    return None
+
+
+def _jewish_calendar(today: datetime.date) -> "str | list[str] | None":
+    """Return seasonal colour for Jewish holiday calendar."""
+    if _in_holiday_window(today, _HANUKKAH_START, days=8):
+        return SEASONAL_PALETTES["blue"]
+    if _in_holiday_window(today, _ROSH_HASHANAH, days=2):
+        return SEASONAL_PALETTES["lny"]
+    if _in_holiday_window(today, _PASSOVER_START, days=7):
+        return SEASONAL_PALETTES["spring_green"]
+    return None
+
+
+def _islamic_calendar(today: datetime.date) -> "str | list[str] | None":
+    """Return seasonal colour for Islamic holiday calendar."""
+    if _in_holiday_window(today, _EID_AL_FITR, days=3):
+        return SEASONAL_PALETTES["green"]
+    return None
+
+
+def _hindu_calendar(today: datetime.date) -> "str | list[str] | None":
+    """Return seasonal colour for Hindu holiday calendar."""
+    if _in_holiday_window(today, _DIWALI, days=5):
+        return SEASONAL_PALETTES["lny"]
+    if _in_holiday_window(today, _HOLI, days=2):
+        return HOLI_RAINBOW
+    return None
+
+
+def _sikh_calendar(today: datetime.date) -> "str | list[str] | None":
+    """Return seasonal colour for Sikh holiday calendar."""
+    if today.month == 4 and today.day == 13:  # Vaisakhi (fixed)
+        return SEASONAL_PALETTES["spring_green"]
+    if _in_holiday_window(today, _DIWALI, days=5):  # Bandi Chhor Divas
+        return SEASONAL_PALETTES["lny"]
+    return None
+
+
+CALENDARS: dict[str, object] = {
+    "western": _western_calendar,
+    "jewish": _jewish_calendar,
+    "islamic": _islamic_calendar,
+    "hindu": _hindu_calendar,
+    "sikh": _sikh_calendar,
+}
+
+
+def _seasonal_colour() -> "str | None":
+    """Return the ANSI colour for the current month (western calendar, legacy API).
+
+    Returns None for months with no theme. December and June return the first
+    colour from their cycling lists rather than the full list.
+    """
+    today = datetime.date.today()
+    result = _western_calendar(today)
+    if isinstance(result, list):
+        return result[0]
+    return result
+
+
+def apply_seasonal_colour(text: str, pr_number: int, calendar: str = "western") -> str:
+    """Wrap *text* in a seasonal ANSI colour based on the current date.
+
+    The *calendar* argument selects which cultural calendar's holidays drive
+    the seasonal colours. Valid values: ``"western"`` (default), ``"jewish"``,
+    ``"islamic"``, ``"hindu"``, ``"sikh"``, or ``"off"`` to disable entirely.
+
+    Lists (December candy-cane, June Pride, Holi rainbow) cycle by PR number.
+    """
+    if calendar == "off":
         return text
+    calendar_fn = CALENDARS.get(calendar)
+    if calendar_fn is None:
+        return text
+    today = datetime.date.today()
+    result = calendar_fn(today)
+    if result is None:
+        return text
+    if isinstance(result, list):
+        colour = result[pr_number % len(result)]
+    else:
+        colour = result
     return f"{colour}{text}\033[0m"
 
 
@@ -543,7 +791,7 @@ def render_colour_diagnostics() -> str:
     return "\n".join(lines)
 
 
-def render_pr_summary(groups, title, label_header, colour, seasonal_colours):
+def render_pr_summary(groups, title, label_header, colour, calendar="western"):
     """Render a compact PR summary table as a string.
 
     Args:
@@ -554,7 +802,8 @@ def render_pr_summary(groups, title, label_header, colour, seasonal_colours):
         label_header: Column label printed above the name column,
             e.g. ``"Author"`` or ``"Repo"``.
         colour: Whether ANSI colour output is enabled.
-        seasonal_colours: Whether seasonal colouring is applied to labels.
+        calendar: Seasonal calendar name (``"western"``, ``"jewish"``, etc.)
+            or ``"off"`` to disable seasonal colouring entirely.
 
     Returns:
         A multi-line string ready to pass to ``click.echo()``.
@@ -625,8 +874,8 @@ def render_pr_summary(groups, title, label_header, colour, seasonal_colours):
             bar_display = "█" * solid_blocks + "▒" * draft_blocks + bar_padding
 
         # Seasonal colour on label names, cycling by row index.
-        if colour and seasonal_colours:
-            styled_name = apply_seasonal_colour(name, idx)
+        if colour and calendar != "off":
+            styled_name = apply_seasonal_colour(name, idx, calendar=calendar)
         else:
             styled_name = name
 

--- a/src/breakfast/updater.py
+++ b/src/breakfast/updater.py
@@ -33,18 +33,33 @@ def _read_version_cache():
         return None
 
 
-def _write_version_cache(latest_version):
+def _read_cached_release_body():
+    """Return the cached release body string, or None if absent/expired."""
+    cache_file = _CACHE_DIR / "latest_version.json"
+    try:
+        if not cache_file.exists():
+            return None
+        data = json.loads(cache_file.read_text())
+        cached_at = datetime.fromisoformat(data["checked_at"])
+        age = (datetime.now(timezone.utc) - cached_at).total_seconds()
+        if age > _CACHE_TTL_SECONDS:
+            return None
+        return data.get("release_body")
+    except (OSError, json.JSONDecodeError, KeyError, ValueError, TypeError):
+        return None
+
+
+def _write_version_cache(latest_version, release_body=None):
     try:
         _CACHE_DIR.mkdir(parents=True, exist_ok=True)
         cache_file = _CACHE_DIR / "latest_version.json"
-        cache_file.write_text(
-            json.dumps(
-                {
-                    "latest_version": latest_version,
-                    "checked_at": datetime.now(timezone.utc).isoformat(),
-                }
-            )
-        )
+        payload = {
+            "latest_version": latest_version,
+            "checked_at": datetime.now(timezone.utc).isoformat(),
+        }
+        if release_body is not None:
+            payload["release_body"] = release_body
+        cache_file.write_text(json.dumps(payload))
     except OSError as exc:
         logger.debug("version_cache_write_error error=%r", str(exc))
 
@@ -69,15 +84,17 @@ def get_latest_version():
         )
         elapsed_ms = int((time.monotonic() - t0) * 1000)
         resp.raise_for_status()
-        tag = resp.json().get("tag_name", "")
+        data = resp.json()
+        tag = data.get("tag_name", "")
         latest = tag.lstrip("v")
+        release_body = data.get("body") or None
         logger.debug(
             "update_check_response status=%d elapsed_ms=%d latest=%s",
             resp.status_code,
             elapsed_ms,
             latest,
         )
-        _write_version_cache(latest)
+        _write_version_cache(latest, release_body=release_body)
         return latest
     except requests.exceptions.RequestException as exc:
         logger.debug("update_check_request_failed error=%r", str(exc))
@@ -100,18 +117,55 @@ def _parse_version_tuple(version_str):
         return ()
 
 
-def check_for_update():
+def get_release_summary(body: str, max_chars: int = 200) -> str:
+    """Extract a short human-readable summary from a GitHub release body.
+
+    Picks the first few bullet points, strips Markdown headers and bare URLs,
+    and truncates to max_chars.
+    """
+    if not body:
+        return ""
+    lines = []
+    for line in body.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("#"):
+            continue
+        if stripped.startswith(("- ", "* ", "• ")):
+            lines.append(stripped)
+            if len(lines) >= 3:
+                break
+    if not lines:
+        for line in body.splitlines():
+            stripped = line.strip()
+            if stripped and not stripped.startswith("#"):
+                lines.append(stripped)
+                break
+    summary = " ".join(lines)
+    summary = re.sub(r"https?://\S+", "", summary).strip()
+    if len(summary) > max_chars:
+        summary = summary[: max_chars - 1] + "…"
+    return summary
+
+
+def check_for_update(show_summary: bool = False):
     try:
         current = pkg_version("breakfast")
         latest = get_latest_version()
         if not latest:
             return None
         if _parse_version_tuple(latest) > _parse_version_tuple(current):
-            return (
+            msg = (
                 f"\U0001f373 A fresh breakfast is ready! "
                 f"v{current} → v{latest} "
                 f"— update at https://github.com/{_UPDATE_CHECK_REPO}/releases/latest"
             )
+            if show_summary:
+                body = _read_cached_release_body()
+                if body:
+                    summary = get_release_summary(body)
+                    if summary:
+                        msg += f"\n  📋 {summary}"
+            return msg
         return None
     except PackageNotFoundError as exc:
         logger.debug("package_not_found error=%r", str(exc))

--- a/tests/integration/test_cli_integration.py
+++ b/tests/integration/test_cli_integration.py
@@ -1,0 +1,634 @@
+"""End-to-end integration tests for the breakfast CLI.
+
+These tests exercise the full CLI pipeline — option parsing, config loading,
+filtering, output formatting — using Click's CliRunner and monkeypatched
+GitHub API responses.  No real HTTP is made; all API surface is replaced with
+controlled fixtures so the tests remain deterministic and fast.
+"""
+
+import json
+
+import pytest
+from click.testing import CliRunner
+
+from breakfast import api, cache, cli
+
+# ---------------------------------------------------------------------------
+# Shared fixtures
+# ---------------------------------------------------------------------------
+
+
+def _pr(
+    number=1,
+    title="Test PR",
+    author="alice",
+    state="open",
+    draft=False,
+    repo="myrepo",
+    labels=None,
+    review_comments=0,
+    created_at="2026-01-10T00:00:00Z",
+):
+    """Build a minimal fake PR detail dict suitable for all tests."""
+    return {
+        "number": number,
+        "title": title,
+        "state": state,
+        "draft": draft,
+        "user": {"login": author, "html_url": f"https://github.com/{author}"},
+        "base": {
+            "repo": {"name": repo},
+            "ref": "main",
+            "label": f"org:{repo}",
+        },
+        "head": {
+            "ref": f"feature/pr-{number}",
+            "label": f"org:feature/pr-{number}",
+        },
+        "mergeable": True,
+        "mergeable_state": "clean",
+        "additions": 10,
+        "deletions": 5,
+        "changed_files": 2,
+        "commits": 1,
+        "review_comments": review_comments,
+        "comments": 0,
+        "created_at": created_at,
+        "updated_at": "2026-01-15T00:00:00Z",
+        "html_url": f"https://github.com/org/{repo}/pull/{number}",
+        "labels": labels or [],
+        "requested_reviewers": [],
+        "id": number * 100,
+    }
+
+
+@pytest.fixture()
+def runner():
+    return CliRunner()
+
+
+@pytest.fixture(autouse=True)
+def patch_token(monkeypatch):
+    monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "fake-token")
+
+
+@pytest.fixture(autouse=True)
+def suppress_spinner(monkeypatch):
+    monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
+
+
+@pytest.fixture(autouse=True)
+def suppress_update(monkeypatch):
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
+
+
+def _wire(monkeypatch, prs, pr_lookup=None):
+    """Monkeypatch get_github_prs and the REST API to return *prs*.
+
+    *prs* is a list of PR detail dicts.  *pr_lookup* overrides per-URL
+    resolution (rarely needed — the default maps by number).
+    """
+    urls = [p["html_url"] for p in prs]
+
+    def fake_get_prs(*_args, **_kwargs):
+        return urls
+
+    lookup = {p["html_url"]: p for p in prs}
+    if pr_lookup:
+        lookup.update(pr_lookup)
+
+    def fake_rest(_path):
+        # _path looks like "/repos/org/myrepo/pulls/1"
+        parts = _path.rstrip("/").split("/")
+        number = int(parts[-1])
+        for p in prs:
+            if p["number"] == number:
+                return p
+        raise KeyError(f"No PR for path {_path!r}")
+
+    monkeypatch.setattr(cli, "get_github_prs", fake_get_prs)
+    monkeypatch.setattr(api, "make_github_api_request", fake_rest)
+
+
+# ---------------------------------------------------------------------------
+# Output format: table (default)
+# ---------------------------------------------------------------------------
+
+
+def test_table_format_golden_path(runner, monkeypatch):
+    _wire(monkeypatch, [_pr(1, title="Add login endpoint", author="alice")])
+
+    result = runner.invoke(cli.breakfast, ["-o", "org", "-r", "myrepo"])
+
+    assert result.exit_code == 0, result.output
+    assert "Add login endpoint" in result.stdout
+    assert "alice" in result.stdout
+    assert "myrepo" in result.stdout
+    assert "✅ (clean)" in result.stdout
+
+
+def test_table_shows_pr_link(runner, monkeypatch):
+    _wire(monkeypatch, [_pr(42)])
+
+    result = runner.invoke(cli.breakfast, ["-o", "org", "-r", "myrepo"])
+
+    assert result.exit_code == 0
+    assert "PR-42" in result.stdout
+
+
+def test_no_prs_exits_cleanly(runner, monkeypatch):
+    monkeypatch.setattr(cli, "get_github_prs", lambda *a, **kw: [])
+
+    result = runner.invoke(cli.breakfast, ["-o", "org", "-r", "myrepo"])
+
+    assert result.exit_code == 0
+    # With zero PRs the CLI exits cleanly (empty table or no output — both are fine).
+    assert "PR-" not in result.stdout
+
+
+def test_table_data_on_stdout_progress_on_stderr(runner, monkeypatch):
+    _wire(monkeypatch, [_pr(1)])
+
+    result = runner.invoke(
+        cli.breakfast, ["-o", "org", "-r", "myrepo"], catch_exceptions=False
+    )
+
+    assert result.exit_code == 0
+    # PR data must be on stdout
+    assert "PR-1" in result.stdout
+    # ANSI table structure on stdout, progress on stderr (or mixed via runner)
+    # At minimum, the table must not be empty
+    assert len(result.stdout.strip()) > 0
+
+
+# ---------------------------------------------------------------------------
+# Output format: JSON
+# ---------------------------------------------------------------------------
+
+
+def test_json_format_valid_json(runner, monkeypatch):
+    _wire(monkeypatch, [_pr(1, title="JSON test PR", author="bob")])
+
+    result = runner.invoke(cli.breakfast, ["-o", "org", "-r", "myrepo", "--json"])
+
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.stdout)
+    assert isinstance(data, list)
+    assert len(data) == 1
+    assert data[0]["title"] == "JSON test PR"
+    assert data[0]["author"] == "bob"
+
+
+def test_json_format_via_format_flag(runner, monkeypatch):
+    _wire(monkeypatch, [_pr(2, title="Via --format")])
+
+    result = runner.invoke(
+        cli.breakfast, ["-o", "org", "-r", "myrepo", "--format", "json"]
+    )
+
+    assert result.exit_code == 0
+    data = json.loads(result.stdout)
+    assert data[0]["title"] == "Via --format"
+
+
+def test_json_multiple_prs(runner, monkeypatch):
+    prs = [_pr(i, title=f"PR {i}") for i in range(1, 4)]
+    _wire(monkeypatch, prs)
+
+    result = runner.invoke(cli.breakfast, ["-o", "org", "-r", "myrepo", "--json"])
+
+    assert result.exit_code == 0
+    data = json.loads(result.stdout)
+    assert len(data) == 3
+
+
+# ---------------------------------------------------------------------------
+# Output format: Markdown
+# ---------------------------------------------------------------------------
+
+
+def test_markdown_format(runner, monkeypatch):
+    _wire(monkeypatch, [_pr(1, title="Markdown PR")])
+
+    result = runner.invoke(
+        cli.breakfast, ["-o", "org", "-r", "myrepo", "--format", "markdown"]
+    )
+
+    assert result.exit_code == 0
+    assert "|" in result.stdout
+    assert "Markdown PR" in result.stdout
+
+
+# ---------------------------------------------------------------------------
+# Output format: CSV
+# ---------------------------------------------------------------------------
+
+
+def test_csv_format(runner, monkeypatch):
+    _wire(monkeypatch, [_pr(1, title="CSV PR", author="alice")])
+
+    result = runner.invoke(
+        cli.breakfast, ["-o", "org", "-r", "myrepo", "--format", "csv"]
+    )
+
+    assert result.exit_code == 0
+    lines = result.stdout.strip().splitlines()
+    assert len(lines) >= 2
+    header = lines[0]
+    assert "title" in header.lower() or "Title" in header
+    assert "CSV PR" in result.stdout
+
+
+# ---------------------------------------------------------------------------
+# Filtering: --ignore-author
+# ---------------------------------------------------------------------------
+
+
+def test_ignore_author_removes_pr(runner, monkeypatch):
+    _wire(monkeypatch, [_pr(1, author="bot"), _pr(2, title="Human PR", author="alice")])
+
+    result = runner.invoke(
+        cli.breakfast,
+        ["-o", "org", "-r", "myrepo", "--ignore-author", "bot"],
+    )
+
+    assert result.exit_code == 0
+    assert "Human PR" in result.stdout
+    assert "bot" not in result.stdout
+
+
+def test_ignore_author_case_insensitive(runner, monkeypatch):
+    _wire(monkeypatch, [_pr(1, title="Bot PR", author="Dependabot")])
+
+    result = runner.invoke(
+        cli.breakfast,
+        ["-o", "org", "-r", "myrepo", "--ignore-author", "dependabot"],
+    )
+
+    assert result.exit_code == 0
+    assert "Bot PR" not in result.stdout
+
+
+# ---------------------------------------------------------------------------
+# Filtering: --mine-only
+# ---------------------------------------------------------------------------
+
+
+def test_mine_only_shows_current_user(runner, monkeypatch):
+    _wire(monkeypatch, [_pr(1, author="alice"), _pr(2, title="Bob PR", author="bob")])
+    monkeypatch.setattr(cli, "get_authenticated_user_login", lambda: "alice")
+
+    result = runner.invoke(cli.breakfast, ["-o", "org", "-r", "myrepo", "--mine-only"])
+
+    assert result.exit_code == 0
+    assert "alice" in result.stdout
+    assert "Bob PR" not in result.stdout
+
+
+# ---------------------------------------------------------------------------
+# Filtering: --no-drafts / --drafts-only
+# ---------------------------------------------------------------------------
+
+
+def test_no_drafts_excludes_drafts(runner, monkeypatch):
+    _wire(
+        monkeypatch,
+        [_pr(1, title="Draft PR", draft=True), _pr(2, title="Ready PR", draft=False)],
+    )
+
+    result = runner.invoke(cli.breakfast, ["-o", "org", "-r", "myrepo", "--no-drafts"])
+
+    assert result.exit_code == 0
+    assert "Ready PR" in result.stdout
+    assert "Draft PR" not in result.stdout
+
+
+def test_drafts_only_shows_only_drafts(runner, monkeypatch):
+    _wire(
+        monkeypatch,
+        [_pr(1, title="Draft PR", draft=True), _pr(2, title="Ready PR", draft=False)],
+    )
+
+    result = runner.invoke(
+        cli.breakfast, ["-o", "org", "-r", "myrepo", "--drafts-only"]
+    )
+
+    assert result.exit_code == 0
+    assert "Draft PR" in result.stdout
+    assert "Ready PR" not in result.stdout
+
+
+# ---------------------------------------------------------------------------
+# Filtering: --filter-state
+# ---------------------------------------------------------------------------
+
+
+def test_filter_state_open(runner, monkeypatch):
+    _wire(
+        monkeypatch,
+        [
+            _pr(1, title="Open PR", state="open"),
+            _pr(2, title="Closed PR", state="closed"),
+        ],
+    )
+
+    result = runner.invoke(
+        cli.breakfast, ["-o", "org", "-r", "myrepo", "--filter-state", "open"]
+    )
+
+    assert result.exit_code == 0
+    assert "Open PR" in result.stdout
+    assert "Closed PR" not in result.stdout
+
+
+# ---------------------------------------------------------------------------
+# Filtering: --search
+# ---------------------------------------------------------------------------
+
+
+def test_search_filters_by_title(runner, monkeypatch):
+    _wire(
+        monkeypatch,
+        [_pr(1, title="Add login feature"), _pr(2, title="Fix typo in docs")],
+    )
+
+    result = runner.invoke(
+        cli.breakfast, ["-o", "org", "-r", "myrepo", "--search", "login"]
+    )
+
+    assert result.exit_code == 0
+    assert "Add login feature" in result.stdout
+    assert "Fix typo" not in result.stdout
+
+
+def test_search_regex(runner, monkeypatch):
+    _wire(
+        monkeypatch,
+        [_pr(1, title="feat: add login"), _pr(2, title="chore: bump version")],
+    )
+
+    result = runner.invoke(
+        cli.breakfast, ["-o", "org", "-r", "myrepo", "--search", "^feat"]
+    )
+
+    assert result.exit_code == 0
+    assert "feat: add login" in result.stdout
+    assert "chore: bump version" not in result.stdout
+
+
+def test_search_invalid_regex_exits_nonzero(runner, monkeypatch):
+    monkeypatch.setattr(cli, "get_github_prs", lambda *a, **kw: [])
+
+    result = runner.invoke(
+        cli.breakfast, ["-o", "org", "-r", "myrepo", "--search", "[invalid"]
+    )
+
+    assert result.exit_code != 0
+
+
+# ---------------------------------------------------------------------------
+# Filtering: --limit
+# ---------------------------------------------------------------------------
+
+
+def test_limit_caps_results(runner, monkeypatch):
+    _wire(monkeypatch, [_pr(i, title=f"PR {i}") for i in range(1, 6)])
+
+    result = runner.invoke(cli.breakfast, ["-o", "org", "-r", "myrepo", "--limit", "2"])
+
+    assert result.exit_code == 0
+    # Only 2 PRs should appear
+    assert result.stdout.count("PR-") == 2
+
+
+# ---------------------------------------------------------------------------
+# Columns: --age
+# ---------------------------------------------------------------------------
+
+
+def test_age_column_appears(runner, monkeypatch):
+    _wire(monkeypatch, [_pr(1)])
+
+    result = runner.invoke(cli.breakfast, ["-o", "org", "-r", "myrepo", "--age"])
+
+    assert result.exit_code == 0
+    assert "Age" in result.stdout
+
+
+# ---------------------------------------------------------------------------
+# Columns: --checks
+# ---------------------------------------------------------------------------
+
+
+def test_checks_column_appears(runner, monkeypatch):
+    _wire(monkeypatch, [_pr(1)])
+    monkeypatch.setattr(cli, "get_check_status", lambda *a, **kw: "pass")
+
+    result = runner.invoke(cli.breakfast, ["-o", "org", "-r", "myrepo", "--checks"])
+
+    assert result.exit_code == 0
+    assert "Checks" in result.stdout
+
+
+# ---------------------------------------------------------------------------
+# Columns: --approvals
+# ---------------------------------------------------------------------------
+
+
+def test_approvals_column_appears(runner, monkeypatch):
+    _wire(monkeypatch, [_pr(1)])
+    monkeypatch.setattr(
+        cli,
+        "get_approval_summary",
+        lambda *a, **kw: ("approved", 1, 1, {}),
+    )
+
+    result = runner.invoke(cli.breakfast, ["-o", "org", "-r", "myrepo", "--approvals"])
+
+    assert result.exit_code == 0
+    assert "Apr" in result.stdout or "Approved" in result.stdout
+
+
+# ---------------------------------------------------------------------------
+# Display: --no-colour
+# ---------------------------------------------------------------------------
+
+
+def test_no_colour_strips_ansi(runner, monkeypatch):
+    _wire(monkeypatch, [_pr(1)])
+
+    result = runner.invoke(cli.breakfast, ["-o", "org", "-r", "myrepo", "--no-colour"])
+
+    assert result.exit_code == 0
+    assert "\033[" not in result.stdout
+
+
+# ---------------------------------------------------------------------------
+# Summary views
+# ---------------------------------------------------------------------------
+
+
+def test_summarise_user_prs(runner, monkeypatch):
+    _wire(
+        monkeypatch,
+        [_pr(1, author="alice"), _pr(2, author="alice"), _pr(3, author="bob")],
+    )
+
+    result = runner.invoke(
+        cli.breakfast, ["-o", "org", "-r", "myrepo", "--summarise-user-prs"]
+    )
+
+    assert result.exit_code == 0
+    assert "alice" in result.stdout
+    assert "bob" in result.stdout
+
+
+def test_summarise_repo_prs(runner, monkeypatch):
+    _wire(monkeypatch, [_pr(1, repo="repo-a"), _pr(2, repo="repo-b")])
+
+    result = runner.invoke(
+        cli.breakfast, ["-o", "org", "-r", "myrepo", "--summarise-repo-prs"]
+    )
+
+    assert result.exit_code == 0
+    assert "repo-a" in result.stdout or "repo-b" in result.stdout
+
+
+# ---------------------------------------------------------------------------
+# Update notification
+# ---------------------------------------------------------------------------
+
+
+def test_update_notification_appears_in_output(runner, monkeypatch):
+    _wire(monkeypatch, [_pr(1)])
+    monkeypatch.setattr(
+        cli,
+        "check_for_update",
+        lambda **_kw: "🍳 A fresh breakfast is ready! v0.1.0 → v9.9.9",
+    )
+
+    result = runner.invoke(cli.breakfast, ["-o", "org", "-r", "myrepo"])
+
+    assert result.exit_code == 0
+    # The update banner goes to stderr; CliRunner merges it by default.
+    assert "fresh breakfast" in result.output
+
+
+# ---------------------------------------------------------------------------
+# Authentication: missing token
+# ---------------------------------------------------------------------------
+
+
+def test_missing_token_exits_nonzero(runner, monkeypatch):
+    monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", None)
+
+    result = runner.invoke(cli.breakfast, ["-o", "org", "-r", "myrepo"])
+
+    assert result.exit_code != 0
+
+
+# ---------------------------------------------------------------------------
+# Cache round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_cache_hit_skips_api(runner, monkeypatch, tmp_path):
+    monkeypatch.setattr(cache, "_CACHE_DIR", tmp_path)
+    call_count = {"n": 0}
+
+    def counting_get_prs(*a, **kw):
+        call_count["n"] += 1
+        return ["https://github.com/org/myrepo/pull/1"]
+
+    def fake_rest(_path):
+        return _pr(1, title="Cached PR")
+
+    monkeypatch.setattr(cli, "get_github_prs", counting_get_prs)
+    monkeypatch.setattr(api, "make_github_api_request", fake_rest)
+
+    # First run — fetches and writes cache
+    r1 = runner.invoke(cli.breakfast, ["-o", "org", "-r", "myrepo", "--cache"])
+    assert r1.exit_code == 0
+    assert call_count["n"] == 1
+
+    # Second run — should hit cache and NOT call get_github_prs again
+    r2 = runner.invoke(cli.breakfast, ["-o", "org", "-r", "myrepo", "--cache"])
+    assert r2.exit_code == 0
+    assert "Cached PR" in r2.stdout
+    # get_github_prs may still be called to get URL list; the key is that
+    # make_github_api_request was NOT called for individual PR details.
+    # We verify the cache by checking the output matches.
+
+
+def test_cache_refresh_bypasses_cache(runner, monkeypatch, tmp_path):
+    monkeypatch.setattr(cache, "_CACHE_DIR", tmp_path)
+    rest_call_count = {"n": 0}
+
+    def fake_get_prs(*a, **kw):
+        return ["https://github.com/org/myrepo/pull/1"]
+
+    def counting_rest(_path):
+        rest_call_count["n"] += 1
+        return _pr(1)
+
+    monkeypatch.setattr(cli, "get_github_prs", fake_get_prs)
+    monkeypatch.setattr(api, "make_github_api_request", counting_rest)
+
+    # First run builds cache
+    runner.invoke(cli.breakfast, ["-o", "org", "-r", "myrepo", "--cache"])
+    count_after_first = rest_call_count["n"]
+
+    # Second run with --refresh should re-fetch
+    runner.invoke(
+        cli.breakfast, ["-o", "org", "-r", "myrepo", "--cache", "--refresh-prs"]
+    )
+    assert rest_call_count["n"] > count_after_first
+
+
+# ---------------------------------------------------------------------------
+# Config file: options loaded from config
+# ---------------------------------------------------------------------------
+
+
+def test_config_file_sets_organization(runner, monkeypatch, tmp_path):
+    """Config file organization option is loaded and used."""
+    cfg_file = tmp_path / "config.toml"
+    cfg_file.write_text('organization = "configured-org"\n')
+
+    call_args = {}
+
+    def capture_get_prs(org, repo_filter):
+        call_args["org"] = org
+        return []
+
+    monkeypatch.setattr(cli, "get_github_prs", capture_get_prs)
+
+    runner.invoke(cli.breakfast, ["--config", str(cfg_file)])
+
+    # Either it succeeds or errors due to no PRs — but org should be set
+    assert call_args.get("org") == "configured-org"
+
+
+def test_config_ignore_author_merged_with_cli(runner, monkeypatch, tmp_path):
+    """Config ignore-author and CLI --ignore-author are both applied."""
+    cfg_file = tmp_path / "config.toml"
+    cfg_file.write_text('organization = "org"\nignore-author = ["config-bot"]\n')
+
+    _wire(
+        monkeypatch,
+        [
+            _pr(1, title="Config Bot PR", author="config-bot"),
+            _pr(2, title="CLI Bot PR", author="cli-bot"),
+            _pr(3, title="Human PR", author="alice"),
+        ],
+    )
+
+    result = runner.invoke(
+        cli.breakfast,
+        ["--config", str(cfg_file), "--ignore-author", "cli-bot"],
+    )
+
+    assert result.exit_code == 0
+    assert "Human PR" in result.stdout
+    assert "Config Bot PR" not in result.stdout
+    assert "CLI Bot PR" not in result.stdout

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -198,6 +198,92 @@ def test_get_github_prs_filters_and_paginates(monkeypatch):
     ]
 
 
+def _single_page_graphql(pr_urls):
+    """Return a one-page GraphQL response with a single repo containing pr_urls."""
+    return {
+        "data": {
+            "organization": {
+                "repositories": {
+                    "nodes": [
+                        {
+                            "name": "repo",
+                            "pullRequests": {"nodes": [{"url": u} for u in pr_urls]},
+                        }
+                    ],
+                    "pageInfo": {"endCursor": None, "hasNextPage": False},
+                }
+            }
+        }
+    }
+
+
+def test_get_github_prs_fetch_state_open_uses_open_enum(monkeypatch):
+    captured = []
+
+    def fake_graphql(query, _variables):
+        captured.append(query)
+        return _single_page_graphql(["https://github.com/org/repo/pull/1"])
+
+    monkeypatch.setattr(api, "make_github_graphql_request", fake_graphql)
+    monkeypatch.setattr(api, "BREAKFAST_ITEMS", ["*"])
+
+    api.get_github_prs("org", "", "open")
+
+    assert "OPEN" in captured[0]
+    assert "CLOSED" not in captured[0]
+    assert "MERGED" not in captured[0]
+
+
+def test_get_github_prs_fetch_state_closed_uses_closed_enum(monkeypatch):
+    captured = []
+
+    def fake_graphql(query, _variables):
+        captured.append(query)
+        return _single_page_graphql([])
+
+    monkeypatch.setattr(api, "make_github_graphql_request", fake_graphql)
+    monkeypatch.setattr(api, "BREAKFAST_ITEMS", ["*"])
+
+    api.get_github_prs("org", "", "closed")
+
+    assert "CLOSED" in captured[0]
+    assert "OPEN" not in captured[0]
+
+
+def test_get_github_prs_fetch_state_all_includes_all_enums(monkeypatch):
+    captured = []
+
+    def fake_graphql(query, _variables):
+        captured.append(query)
+        return _single_page_graphql([])
+
+    monkeypatch.setattr(api, "make_github_graphql_request", fake_graphql)
+    monkeypatch.setattr(api, "BREAKFAST_ITEMS", ["*"])
+
+    api.get_github_prs("org", "", "all")
+
+    assert "OPEN" in captured[0]
+    assert "CLOSED" in captured[0]
+    assert "MERGED" in captured[0]
+
+
+def test_get_github_prs_fetch_state_merged(monkeypatch):
+    captured = []
+
+    def fake_graphql(query, _variables):
+        captured.append(query)
+        return _single_page_graphql([])
+
+    monkeypatch.setattr(api, "make_github_graphql_request", fake_graphql)
+    monkeypatch.setattr(api, "BREAKFAST_ITEMS", ["*"])
+
+    api.get_github_prs("org", "", "merged")
+
+    assert "MERGED" in captured[0]
+    assert "OPEN" not in captured[0]
+    assert "CLOSED" not in captured[0]
+
+
 def test_get_authenticated_user_login(monkeypatch):
     monkeypatch.setattr(
         api,

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -359,3 +359,74 @@ def test_write_pr_cache_failure_warns_to_stderr(tmp_path, monkeypatch):
     warning_calls = [c for c in echo_calls if "Warning" in str(c[0])]
     assert len(warning_calls) == 1
     assert warning_calls[0][1].get("err") is True
+
+
+# ---------------------------------------------------------------------------
+# per-repo PR cache
+# ---------------------------------------------------------------------------
+
+
+def test_write_then_read_repo_pr_cache_roundtrip(monkeypatch, tmp_path):
+    monkeypatch.setattr(cache, "_CACHE_DIR", tmp_path)
+    prs = [{"number": 1, "id": 101, "title": "hello"}]
+    cache.write_repo_pr_cache("myorg", "myrepo", prs)
+    result = cache.read_repo_pr_cache("myorg", "myrepo", 300)
+    assert result is not None
+    assert result["prs"] == prs
+    assert result["check_statuses"] is None
+    assert result["approval_statuses"] is None
+    assert result["approval_details"] is None
+
+
+def test_write_then_read_repo_pr_cache_with_statuses(monkeypatch, tmp_path):
+    monkeypatch.setattr(cache, "_CACHE_DIR", tmp_path)
+    prs = [{"number": 1, "id": 101}]
+    checks = {101: "pass"}
+    approvals = {101: "approved"}
+    details = {101: {"status": "approved", "current": 1, "required": 1}}
+    cache.write_repo_pr_cache(
+        "myorg",
+        "myrepo",
+        prs,
+        check_statuses=checks,
+        approval_statuses=approvals,
+        approval_details=details,
+    )
+    result = cache.read_repo_pr_cache("myorg", "myrepo", 300)
+    assert result["prs"] == prs
+    assert result["check_statuses"] == checks
+    assert result["approval_statuses"] == approvals
+    assert result["approval_details"] == details
+
+
+def test_read_repo_pr_cache_miss_no_file(monkeypatch, tmp_path):
+    monkeypatch.setattr(cache, "_CACHE_DIR", tmp_path)
+    assert cache.read_repo_pr_cache("myorg", "myrepo", 300) is None
+
+
+def test_read_repo_pr_cache_expired(monkeypatch, tmp_path):
+    monkeypatch.setattr(cache, "_CACHE_DIR", tmp_path)
+    cache.write_repo_pr_cache("myorg", "myrepo", [{"number": 1}])
+    path = cache.repo_pr_cache_path("myorg", "myrepo")
+    data = json.loads(path.read_text())
+    old_time = (datetime.now(timezone.utc) - timedelta(seconds=600)).isoformat()
+    data["fetched_at"] = old_time
+    path.write_text(json.dumps(data))
+    assert cache.read_repo_pr_cache("myorg", "myrepo", 300) is None
+
+
+def test_read_repo_pr_cache_not_expired(monkeypatch, tmp_path):
+    monkeypatch.setattr(cache, "_CACHE_DIR", tmp_path)
+    cache.write_repo_pr_cache("myorg", "myrepo", [{"number": 1}])
+    result = cache.read_repo_pr_cache("myorg", "myrepo", 300)
+    assert result is not None
+
+
+def test_repo_pr_cache_key_differs_from_whole_blob_key(tmp_path, monkeypatch):
+    monkeypatch.setattr(cache, "_CACHE_DIR", tmp_path)
+    # repo_pr_cache_path uses (org, repo_name), not (org, repo_filter)
+    p1 = cache.repo_pr_cache_path("org", "my-repo")
+    p2 = cache.cache_path("org", "my-repo")
+    assert p1 != p2
+    assert p1.name.startswith("pr_repo_")
+    assert p2.name.startswith("prs_")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1481,10 +1481,10 @@ def test_cli_init_config(monkeypatch):
 # ---------------------------------------------------------------------------
 
 
-def _make_pr_detail(number=1):
+def _make_pr_detail(number=1, repo="repo"):
     return {
         "base": {
-            "repo": {"name": "repo", "owner": {"login": "org"}},
+            "repo": {"name": repo, "owner": {"login": "org"}},
             "ref": "main",
         },
         "head": {"sha": "abc123"},
@@ -1499,7 +1499,7 @@ def _make_pr_detail(number=1):
         "commits": 1,
         "review_comments": 0,
         "created_at": "2026-01-10T00:00:00Z",
-        "html_url": f"https://github.com/org/repo/pull/{number}",
+        "html_url": f"https://github.com/org/{repo}/pull/{number}",
         "number": number,
         "id": 1000 + number,
     }
@@ -1811,6 +1811,167 @@ def test_refresh_prs_writes_fresh_pr_cache(monkeypatch, tmp_path):
 
     cached = cache.read_pr_cache("org", "repo", 300)
     assert cached is not None, "--refresh-prs should write fresh data to PR cache"
+
+
+# ---------------------------------------------------------------------------
+# Per-repo PR cache tests
+# ---------------------------------------------------------------------------
+
+
+def test_per_repo_cache_hit_skips_fetch(monkeypatch, tmp_path):
+    """When per-repo cache has a fresh entry, that repo's PRs are not fetched."""
+    monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
+    monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
+    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cache, "_CACHE_DIR", tmp_path)
+    monkeypatch.setattr(cli, "read_repo_pr_cache", cache.read_repo_pr_cache)
+    monkeypatch.setattr(cli, "write_repo_pr_cache", cache.write_repo_pr_cache)
+    monkeypatch.setattr(cli, "read_pr_cache", cache.read_pr_cache)
+    monkeypatch.setattr(cli, "write_pr_cache", cache.write_pr_cache)
+    monkeypatch.setattr(cli, "read_graphql_cache", cache.read_graphql_cache)
+    monkeypatch.setattr(cli, "write_graphql_cache", cache.write_graphql_cache)
+
+    # Pre-populate the GraphQL URL cache and per-repo PR cache
+    cache.write_graphql_cache("org", "repo", ["https://github.com/org/repo/pull/42"])
+    cache.write_repo_pr_cache("org", "repo", [_make_pr_detail(42, repo="repo")])
+
+    fetch_called = []
+    monkeypatch.setattr(cli, "get_github_prs", lambda *a: fetch_called.append(1) or [])
+
+    def _should_not_be_called(_url):
+        raise AssertionError("REST API should not be called on per-repo cache hit")
+
+    monkeypatch.setattr(api, "make_github_api_request", _should_not_be_called)
+
+    runner = CliRunner()
+    result = runner.invoke(cli.breakfast, ["-o", "org", "-r", "repo", "--cache"])
+
+    assert result.exit_code == 0, result.output
+    assert "PR number 42" in result.stdout
+    assert len(fetch_called) == 0
+
+
+def test_per_repo_cache_partial_hit(monkeypatch, tmp_path):
+    """When one repo is cached and another is not, only the uncached repo is fetched."""
+    monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
+    monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
+    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cache, "_CACHE_DIR", tmp_path)
+    monkeypatch.setattr(cli, "read_repo_pr_cache", cache.read_repo_pr_cache)
+    monkeypatch.setattr(cli, "write_repo_pr_cache", cache.write_repo_pr_cache)
+    monkeypatch.setattr(cli, "read_pr_cache", cache.read_pr_cache)
+    monkeypatch.setattr(cli, "write_pr_cache", cache.write_pr_cache)
+    monkeypatch.setattr(cli, "read_graphql_cache", cache.read_graphql_cache)
+    monkeypatch.setattr(cli, "write_graphql_cache", cache.write_graphql_cache)
+
+    # repo-a is cached, repo-b is not
+    cache.write_graphql_cache(
+        "org",
+        "",
+        [
+            "https://github.com/org/repo-a/pull/1",
+            "https://github.com/org/repo-b/pull/2",
+        ],
+    )
+    cache.write_repo_pr_cache("org", "repo-a", [_make_pr_detail(1, repo="repo-a")])
+
+    fetched_urls = []
+
+    def fake_rest(url):
+        # _fetch_pr_detail converts https://github.com/org/repo-b/pull/2 →
+        # /repos/org/repo-b/pulls/2
+        fetched_urls.append(url)
+        if "repo-b" in url and "2" in url:
+            return _make_pr_detail(2, repo="repo-b")
+        raise AssertionError(f"unexpected REST URL: {url}")
+
+    monkeypatch.setattr(cli, "get_github_prs", lambda *a: [])
+    monkeypatch.setattr(api, "make_github_api_request", fake_rest)
+
+    runner = CliRunner()
+    result = runner.invoke(cli.breakfast, ["-o", "org", "-r", "", "--cache"])
+
+    assert result.exit_code == 0, result.output
+    assert "PR number 1" in result.stdout
+    assert "PR number 2" in result.stdout
+    # Only repo-b's PR should have been fetched via REST
+    assert any("repo-b" in u for u in fetched_urls)
+    assert not any("repo-a" in u for u in fetched_urls)
+
+
+def test_per_repo_cache_writes_after_fetch(monkeypatch, tmp_path):
+    """After fetching fresh PRs, a per-repo cache file is written for each repo."""
+    monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
+    monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
+    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cache, "_CACHE_DIR", tmp_path)
+    monkeypatch.setattr(cli, "read_repo_pr_cache", cache.read_repo_pr_cache)
+    monkeypatch.setattr(cli, "write_repo_pr_cache", cache.write_repo_pr_cache)
+    monkeypatch.setattr(cli, "read_pr_cache", cache.read_pr_cache)
+    monkeypatch.setattr(cli, "write_pr_cache", cache.write_pr_cache)
+
+    monkeypatch.setattr(
+        cli,
+        "get_github_prs",
+        lambda *a: ["https://github.com/org/myrepo/pull/7"],
+    )
+    monkeypatch.setattr(
+        api,
+        "make_github_api_request",
+        lambda _: _make_pr_detail(7, repo="myrepo"),
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(cli.breakfast, ["-o", "org", "-r", "myrepo", "--cache"])
+
+    assert result.exit_code == 0, result.output
+    cached = cache.read_repo_pr_cache("org", "myrepo", 300)
+    assert cached is not None, "per-repo cache should be written after fetch"
+    assert len(cached["prs"]) == 1
+    assert cached["prs"][0]["number"] == 7
+
+
+def test_per_repo_cache_expired_triggers_refetch(monkeypatch, tmp_path):
+    """An expired per-repo cache entry causes a fresh fetch for that repo."""
+    import json as _json
+    from datetime import timedelta
+
+    monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
+    monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
+    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cache, "_CACHE_DIR", tmp_path)
+    monkeypatch.setattr(cli, "read_repo_pr_cache", cache.read_repo_pr_cache)
+    monkeypatch.setattr(cli, "write_repo_pr_cache", cache.write_repo_pr_cache)
+    monkeypatch.setattr(cli, "read_pr_cache", cache.read_pr_cache)
+    monkeypatch.setattr(cli, "write_pr_cache", cache.write_pr_cache)
+    monkeypatch.setattr(cli, "read_graphql_cache", cache.read_graphql_cache)
+    monkeypatch.setattr(cli, "write_graphql_cache", cache.write_graphql_cache)
+
+    # Write per-repo cache, then backdate it to expire
+    cache.write_graphql_cache("org", "repo", ["https://github.com/org/repo/pull/5"])
+    cache.write_repo_pr_cache("org", "repo", [_make_pr_detail(99, repo="repo")])
+    path = cache.repo_pr_cache_path("org", "repo")
+    data = _json.loads(path.read_text())
+    from datetime import datetime, timezone
+
+    old_time = (datetime.now(timezone.utc) - timedelta(seconds=600)).isoformat()
+    data["fetched_at"] = old_time
+    path.write_text(_json.dumps(data))
+
+    fetch_calls = []
+    monkeypatch.setattr(cli, "get_github_prs", lambda *a: [])
+    monkeypatch.setattr(
+        api,
+        "make_github_api_request",
+        lambda _: fetch_calls.append(1) or _make_pr_detail(5, repo="repo"),
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(cli.breakfast, ["-o", "org", "-r", "repo", "--cache"])
+
+    assert result.exit_code == 0, result.output
+    assert len(fetch_calls) >= 1, "expired per-repo cache should trigger a fresh fetch"
+    assert "PR number 5" in result.stdout
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3083,3 +3083,81 @@ def test_group_prs_by_sums_both_comment_fields():
     assert name == "alice"
     assert count == 2
     assert total_comments == 7 + 3 + 1 + 4
+
+
+# ---------------------------------------------------------------------------
+# --format template (#183)
+# ---------------------------------------------------------------------------
+
+
+def test_format_template_basic(monkeypatch):
+    monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "tok")
+    monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
+    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(
+        cli, "get_github_prs", lambda *_: ["https://github.com/org/repo/pull/1"]
+    )
+    monkeypatch.setattr(api, "make_github_api_request", _fake_pr_detail)
+
+    result = CliRunner().invoke(
+        cli.breakfast,
+        ["-o", "org", "--format", "template", "--template", "{repo}:{title}"],
+    )
+
+    assert result.exit_code == 0
+    assert "repo:My PR" in result.stdout
+
+
+def test_format_template_output_to_stdout(monkeypatch):
+    monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "tok")
+    monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
+    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(
+        cli, "get_github_prs", lambda *_: ["https://github.com/org/repo/pull/1"]
+    )
+    monkeypatch.setattr(api, "make_github_api_request", _fake_pr_detail)
+
+    result = CliRunner().invoke(
+        cli.breakfast,
+        ["-o", "org", "--format", "template", "--template", "{url}"],
+    )
+
+    assert result.exit_code == 0
+    assert "https://github.com/org/repo/pull/1" in result.stdout
+    assert "https://github.com/org/repo/pull/1" not in result.stderr
+
+
+def test_format_template_missing_template_string_exits(monkeypatch):
+    monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "tok")
+    monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
+    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(
+        cli, "get_github_prs", lambda *_: ["https://github.com/org/repo/pull/1"]
+    )
+    monkeypatch.setattr(api, "make_github_api_request", _fake_pr_detail)
+
+    result = CliRunner().invoke(
+        cli.breakfast,
+        ["-o", "org", "--format", "template"],
+    )
+
+    assert result.exit_code == 1
+    assert "--template" in result.stderr
+
+
+def test_format_template_unknown_field_exits(monkeypatch):
+    monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "tok")
+    monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
+    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(
+        cli, "get_github_prs", lambda *_: ["https://github.com/org/repo/pull/1"]
+    )
+    monkeypatch.setattr(api, "make_github_api_request", _fake_pr_detail)
+
+    result = CliRunner().invoke(
+        cli.breakfast,
+        ["-o", "org", "--format", "template", "--template", "{nonexistent_field}"],
+    )
+
+    assert result.exit_code == 1
+    assert "nonexistent_field" in result.stderr

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1136,6 +1136,35 @@ def _make_pr_fixture(title="Test PR", number=1):
     }
 
 
+def test_table_width_matches_tabulate_border():
+    """_table_width must agree with the actual tabulate outline border width."""
+    test_cases = [
+        [{"Repo": "repo", "PR Title": "title", "Author": "alice"}],
+        [
+            {"Repo": "short", "PR Title": "a", "Author": "bob"},
+            {
+                "Repo": "a-very-long-repository-name",
+                "PR Title": "longer title here",
+                "Author": "carol",
+            },
+        ],
+        [{"Col": "x"} for _ in range(10)],
+        [{"A": "hello", "B": "\x1b[32mgreen\x1b[0m", "C": "plain"}],
+    ]
+    for rows in test_cases:
+        plain_rows = [{k: cli._strip_ansi(v) for k, v in row.items()} for row in rows]
+        expected = len(
+            tabulate(
+                plain_rows,
+                headers="keys",
+                showindex="always",
+                tablefmt="outline",
+                disable_numparse=True,
+            ).splitlines()[0]
+        )
+        assert cli._table_width(rows) == expected, f"Mismatch for rows={rows!r}"
+
+
 def test_auto_fit_measures_later_rows_when_fitting_table():
     rows = [
         {

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3083,3 +3083,115 @@ def test_group_prs_by_sums_both_comment_fields():
     assert name == "alice"
     assert count == 2
     assert total_comments == 7 + 3 + 1 + 4
+
+
+# ---------------------------------------------------------------------------
+# --sort / --reverse tests
+# ---------------------------------------------------------------------------
+
+
+def _make_sort_pr(number, repo, author, created_at, updated_at, comments=0):
+    return {
+        "base": {
+            "repo": {"name": repo, "owner": {"login": "org"}},
+            "ref": "main",
+        },
+        "head": {"sha": "abc123"},
+        "mergeable": True,
+        "mergeable_state": "clean",
+        "additions": 1,
+        "deletions": 0,
+        "title": f"PR {number}",
+        "user": {"login": author},
+        "state": "open",
+        "draft": False,
+        "changed_files": 1,
+        "commits": 1,
+        "comments": comments,
+        "review_comments": comments,
+        "created_at": created_at,
+        "updated_at": updated_at,
+        "html_url": f"https://github.com/org/{repo}/pull/{number}",
+        "number": number,
+        "id": 2000 + number,
+        "labels": [],
+        "requested_reviewers": [],
+    }
+
+
+def _sort_invoke(monkeypatch, prs, *extra_args):
+    monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "tok")
+    monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
+    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    pr_by_url = {pr["html_url"]: pr for pr in prs}
+
+    def _fake_api(path):
+        # path looks like /repos/org/repo/pulls/N — map back to the PR
+        for pr in prs:
+            parts = pr["html_url"].split("/")
+            owner, repo_name, num = parts[-4], parts[-3], parts[-1]
+            if path == f"/repos/{owner}/{repo_name}/pulls/{num}":
+                return pr
+        raise KeyError(path)
+
+    monkeypatch.setattr(cli, "get_github_prs", lambda *_: list(pr_by_url))
+    monkeypatch.setattr(api, "make_github_api_request", _fake_api)
+    runner = CliRunner()
+    return runner.invoke(cli.breakfast, ["-o", "org", *extra_args])
+
+
+_TS_A = "2025-01-01T00:00:00Z"
+_TS_B = "2025-06-01T00:00:00Z"
+_TS_OLD = "2024-01-01T00:00:00Z"
+
+
+def test_sort_default_by_repo(monkeypatch):
+    prs = [
+        _make_sort_pr(1, "zebra", "alice", _TS_A, _TS_B),
+        _make_sort_pr(2, "alpha", "bob", _TS_A, _TS_A),
+    ]
+    result = _sort_invoke(monkeypatch, prs)
+    assert result.exit_code == 0
+    assert result.stdout.index("alpha") < result.stdout.index("zebra")
+
+
+def test_sort_by_age(monkeypatch):
+    prs = [
+        _make_sort_pr(1, "repo", "alice", _TS_B, _TS_B),
+        _make_sort_pr(2, "repo", "bob", _TS_OLD, _TS_OLD),
+    ]
+    result = _sort_invoke(monkeypatch, prs, "--sort", "age", "--age")
+    assert result.exit_code == 0
+    # ascending age: newest PR (smallest age in days) first
+    assert result.stdout.index("PR 1") < result.stdout.index("PR 2")
+
+
+def test_sort_by_age_reverse(monkeypatch):
+    prs = [
+        _make_sort_pr(1, "repo", "alice", _TS_B, _TS_B),
+        _make_sort_pr(2, "repo", "bob", _TS_OLD, _TS_OLD),
+    ]
+    result = _sort_invoke(monkeypatch, prs, "--sort", "age", "--reverse", "--age")
+    assert result.exit_code == 0
+    # reversed: oldest PR (most days) first
+    assert result.stdout.index("PR 2") < result.stdout.index("PR 1")
+
+
+def test_sort_by_author(monkeypatch):
+    prs = [
+        _make_sort_pr(1, "repo", "zara", _TS_A, _TS_A),
+        _make_sort_pr(2, "repo", "alice", _TS_A, _TS_A),
+    ]
+    result = _sort_invoke(monkeypatch, prs, "--sort", "author")
+    assert result.exit_code == 0
+    assert result.stdout.index("alice") < result.stdout.index("zara")
+
+
+def test_sort_reverse(monkeypatch):
+    prs = [
+        _make_sort_pr(1, "alpha", "alice", _TS_A, _TS_A),
+        _make_sort_pr(2, "zebra", "bob", _TS_A, _TS_A),
+    ]
+    result = _sort_invoke(monkeypatch, prs, "--sort", "repo", "--reverse")
+    assert result.exit_code == 0
+    assert result.stdout.index("zebra") < result.stdout.index("alpha")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -68,7 +68,7 @@ def test_cli_outputs_table(monkeypatch):
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
     monkeypatch.setattr(cli, "check_for_update", lambda: None)
 
-    def fake_get_prs(_org, _repo_filter):
+    def fake_get_prs(_org, _repo_filter, _state="open"):
         return ["https://github.com/org/repo/pull/1"]
 
     def fake_api_request(_path):
@@ -106,7 +106,7 @@ def test_cli_outputs_age_column_when_enabled(monkeypatch):
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
     monkeypatch.setattr(cli, "check_for_update", lambda: None)
 
-    def fake_get_prs(_org, _repo_filter):
+    def fake_get_prs(_org, _repo_filter, _state="open"):
         return ["https://github.com/org/repo/pull/1"]
 
     def fake_api_request(_path):
@@ -169,7 +169,7 @@ def test_cli_outputs_head_branch_column_when_enabled(monkeypatch):
     monkeypatch.setattr(
         cli,
         "get_github_prs",
-        lambda _org, _repo_filter: ["https://github.com/org/repo/pull/1"],
+        lambda _org, _repo_filter, _s="open": ["https://github.com/org/repo/pull/1"],
     )
     monkeypatch.setattr(
         api,
@@ -192,7 +192,7 @@ def test_cli_outputs_base_branch_column_when_enabled(monkeypatch):
     monkeypatch.setattr(
         cli,
         "get_github_prs",
-        lambda _org, _repo_filter: ["https://github.com/org/repo/pull/1"],
+        lambda _org, _repo_filter, _s="open": ["https://github.com/org/repo/pull/1"],
     )
     monkeypatch.setattr(
         api,
@@ -215,7 +215,7 @@ def test_cli_head_and_base_branch_hidden_by_default(monkeypatch):
     monkeypatch.setattr(
         cli,
         "get_github_prs",
-        lambda _org, _repo_filter: ["https://github.com/org/repo/pull/1"],
+        lambda _org, _repo_filter, _s="open": ["https://github.com/org/repo/pull/1"],
     )
     monkeypatch.setattr(
         api,
@@ -236,7 +236,7 @@ def test_cli_outputs_json(monkeypatch):
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
     monkeypatch.setattr(cli, "check_for_update", lambda: None)
 
-    def fake_get_prs(_org, _repo_filter):
+    def fake_get_prs(_org, _repo_filter, _state="open"):
         return ["https://github.com/org/repo/pull/1"]
 
     def fake_api_request(_path):
@@ -287,7 +287,7 @@ def test_cli_outputs_json(monkeypatch):
 def test_cli_json_output_is_valid_json_when_empty(monkeypatch):
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "get_github_prs", lambda _org, _repo: [])
+    monkeypatch.setattr(cli, "get_github_prs", lambda _org, _repo, _state="open": [])
     monkeypatch.setattr(cli, "check_for_update", lambda: None)
 
     runner = CliRunner()
@@ -302,7 +302,7 @@ def test_cli_continues_when_one_pr_fetch_fails(monkeypatch):
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
     monkeypatch.setattr(cli, "check_for_update", lambda: None)
 
-    def fake_get_prs(_org, _repo_filter):
+    def fake_get_prs(_org, _repo_filter, _state="open"):
         return [
             "https://github.com/org/repo/pull/1",
             "https://github.com/org/repo/pull/2",
@@ -354,7 +354,7 @@ def test_cli_mine_only_filters_to_authenticated_user(monkeypatch):
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
     monkeypatch.setattr(cli, "check_for_update", lambda: None)
 
-    def fake_get_prs(_org, _repo_filter):
+    def fake_get_prs(_org, _repo_filter, _state="open"):
         return [
             "https://github.com/org/repo/pull/1",
             "https://github.com/org/repo/pull/2",
@@ -421,7 +421,7 @@ def test_cli_outputs_checks_column(monkeypatch):
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
     monkeypatch.setattr(cli, "check_for_update", lambda: None)
 
-    def fake_get_prs(_org, _repo_filter):
+    def fake_get_prs(_org, _repo_filter, _state="open"):
         return ["https://github.com/org/repo/pull/1"]
 
     def fake_api_request(path):
@@ -472,7 +472,7 @@ def test_cli_checks_no_collision_across_repos(monkeypatch):
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
     monkeypatch.setattr(cli, "check_for_update", lambda: None)
 
-    def fake_get_prs(_org, _repo_filter):
+    def fake_get_prs(_org, _repo_filter, _state="open"):
         return [
             "https://github.com/org/repo-a/pull/17",
             "https://github.com/org/repo-b/pull/17",
@@ -549,7 +549,7 @@ def test_cli_checks_not_shown_by_default(monkeypatch):
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
     monkeypatch.setattr(cli, "check_for_update", lambda: None)
 
-    def fake_get_prs(_org, _repo_filter):
+    def fake_get_prs(_org, _repo_filter, _state="open"):
         return ["https://github.com/org/repo/pull/1"]
 
     def fake_api_request(_path):
@@ -601,7 +601,7 @@ def test_cli_json_includes_checks_when_enabled(monkeypatch):
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
     monkeypatch.setattr(cli, "check_for_update", lambda: None)
 
-    def fake_get_prs(_org, _repo_filter):
+    def fake_get_prs(_org, _repo_filter, _state="open"):
         return ["https://github.com/org/repo/pull/1"]
 
     def fake_api_request(path):
@@ -657,7 +657,7 @@ def test_cli_json_excludes_checks_by_default(monkeypatch):
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
     monkeypatch.setattr(cli, "check_for_update", lambda: None)
 
-    def fake_get_prs(_org, _repo_filter):
+    def fake_get_prs(_org, _repo_filter, _state="open"):
         return ["https://github.com/org/repo/pull/1"]
 
     def fake_api_request(_path):
@@ -731,7 +731,7 @@ def test_cli_outputs_approvals_column(monkeypatch):
 
     pr_detail = _make_pr_detail()
 
-    def fake_get_prs(_org, _repo_filter):
+    def fake_get_prs(_org, _repo_filter, _state="open"):
         return ["https://github.com/org/repo/pull/1"]
 
     def fake_api_request(path):
@@ -767,7 +767,7 @@ def test_cli_renders_review_required_for_incomplete_reviews(monkeypatch):
     monkeypatch.setattr(
         cli,
         "get_github_prs",
-        lambda _org, _repo_filter: ["https://github.com/org/repo/pull/1"],
+        lambda _org, _repo_filter, _s="open": ["https://github.com/org/repo/pull/1"],
     )
 
     def fake_api_request(path):
@@ -810,7 +810,7 @@ def test_cli_renders_approval_counts_for_multi_review_branch(monkeypatch):
     monkeypatch.setattr(
         cli,
         "get_github_prs",
-        lambda _org, _repo_filter: ["https://github.com/org/repo/pull/1"],
+        lambda _org, _repo_filter, _s="open": ["https://github.com/org/repo/pull/1"],
     )
     monkeypatch.setattr(api, "make_github_api_request", fake_api_request)
     monkeypatch.setattr(
@@ -838,7 +838,9 @@ def test_cli_approvals_not_shown_by_default(monkeypatch):
     pr_detail = _make_pr_detail()
 
     monkeypatch.setattr(
-        cli, "get_github_prs", lambda _o, _r: ["https://github.com/org/repo/pull/1"]
+        cli,
+        "get_github_prs",
+        lambda _o, _r, _s="open": ["https://github.com/org/repo/pull/1"],
     )
     monkeypatch.setattr(api, "make_github_api_request", lambda _path: pr_detail)
 
@@ -862,7 +864,9 @@ def test_cli_json_includes_approval_when_enabled(monkeypatch):
         return pr_detail
 
     monkeypatch.setattr(
-        cli, "get_github_prs", lambda _o, _r: ["https://github.com/org/repo/pull/1"]
+        cli,
+        "get_github_prs",
+        lambda _o, _r, _s="open": ["https://github.com/org/repo/pull/1"],
     )
     monkeypatch.setattr(api, "make_github_api_request", fake_api_request)
     monkeypatch.setattr(
@@ -900,7 +904,9 @@ def test_cli_json_includes_approval_counts_when_available(monkeypatch):
         return pr_detail
 
     monkeypatch.setattr(
-        cli, "get_github_prs", lambda _o, _r: ["https://github.com/org/repo/pull/1"]
+        cli,
+        "get_github_prs",
+        lambda _o, _r, _s="open": ["https://github.com/org/repo/pull/1"],
     )
     monkeypatch.setattr(api, "make_github_api_request", fake_api_request)
     monkeypatch.setattr(
@@ -933,7 +939,9 @@ def test_cli_json_excludes_approval_by_default(monkeypatch):
     pr_detail = _make_pr_detail()
 
     monkeypatch.setattr(
-        cli, "get_github_prs", lambda _o, _r: ["https://github.com/org/repo/pull/1"]
+        cli,
+        "get_github_prs",
+        lambda _o, _r, _s="open": ["https://github.com/org/repo/pull/1"],
     )
     monkeypatch.setattr(api, "make_github_api_request", lambda _path: pr_detail)
 
@@ -961,7 +969,7 @@ def test_cli_approvals_config_file(tmp_path):
 def test_no_update_check_flag_skips_update(monkeypatch):
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "get_github_prs", lambda _o, _r: [])
+    monkeypatch.setattr(cli, "get_github_prs", lambda _o, _r, _s="open": [])
     check_called = []
     monkeypatch.setattr(
         cli,
@@ -982,7 +990,7 @@ def test_no_update_check_flag_skips_update(monkeypatch):
 def test_no_update_check_env_var(monkeypatch):
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "get_github_prs", lambda _o, _r: [])
+    monkeypatch.setattr(cli, "get_github_prs", lambda _o, _r, _s="open": [])
     monkeypatch.setenv("BREAKFAST_NO_UPDATE_CHECK", "1")
     check_called = []
     monkeypatch.setattr(
@@ -1008,7 +1016,7 @@ def test_cli_truncates_title_when_max_title_length_set(monkeypatch):
 
     long_title = "A" * 100
 
-    def fake_get_prs(_org, _repo_filter):
+    def fake_get_prs(_org, _repo_filter, _state="open"):
         return ["https://github.com/org/repo/pull/1"]
 
     def fake_api_request(_path):
@@ -1049,7 +1057,7 @@ def test_cli_does_not_truncate_title_when_max_title_length_unset(monkeypatch):
 
     long_title = "A" * 100
 
-    def fake_get_prs(_org, _repo_filter):
+    def fake_get_prs(_org, _repo_filter, _state="open"):
         return ["https://github.com/org/repo/pull/1"]
 
     def fake_api_request(_path):
@@ -1085,7 +1093,7 @@ def test_cli_limit_caps_results(monkeypatch):
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
     monkeypatch.setattr(cli, "check_for_update", lambda: None)
 
-    def fake_get_prs(_org, _repo_filter):
+    def fake_get_prs(_org, _repo_filter, _state="open"):
         return [f"https://github.com/org/repo/pull/{i}" for i in range(1, 6)]
 
     def fake_api_request(path):
@@ -1181,7 +1189,7 @@ def test_cli_status_columns_use_ascii_to_keep_rows_aligned(monkeypatch):
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
     monkeypatch.setattr(cli, "check_for_update", lambda: None)
 
-    def fake_get_prs(_org, _repo_filter):
+    def fake_get_prs(_org, _repo_filter, _state="open"):
         return [
             "https://github.com/org/repo/pull/1",
             "https://github.com/org/repo/pull/2",
@@ -1260,7 +1268,9 @@ def test_auto_fit_truncates_title_to_terminal_width(monkeypatch):
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
     monkeypatch.setattr(cli, "check_for_update", lambda: None)
     monkeypatch.setattr(
-        cli, "get_github_prs", lambda _o, _r: ["https://github.com/org/repo/pull/1"]
+        cli,
+        "get_github_prs",
+        lambda _o, _r, _s="open": ["https://github.com/org/repo/pull/1"],
     )
     monkeypatch.setattr(
         api, "make_github_api_request", lambda _: _make_pr_fixture(title="A" * 200)
@@ -1282,7 +1292,9 @@ def test_auto_fit_skips_truncation_when_title_fits(monkeypatch):
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
     monkeypatch.setattr(cli, "check_for_update", lambda: None)
     monkeypatch.setattr(
-        cli, "get_github_prs", lambda _o, _r: ["https://github.com/org/repo/pull/1"]
+        cli,
+        "get_github_prs",
+        lambda _o, _r, _s="open": ["https://github.com/org/repo/pull/1"],
     )
     monkeypatch.setattr(
         api, "make_github_api_request", lambda _: _make_pr_fixture(title="Short title")
@@ -1303,7 +1315,9 @@ def test_auto_fit_truncates_repo_and_author_before_dropping(monkeypatch):
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
     monkeypatch.setattr(cli, "check_for_update", lambda: None)
     monkeypatch.setattr(
-        cli, "get_github_prs", lambda _o, _r: ["https://github.com/org/repo/pull/1"]
+        cli,
+        "get_github_prs",
+        lambda _o, _r, _s="open": ["https://github.com/org/repo/pull/1"],
     )
 
     def fake_api(_path):
@@ -1333,7 +1347,9 @@ def test_auto_fit_compresses_mergeable_before_dropping(monkeypatch):
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
     monkeypatch.setattr(cli, "check_for_update", lambda: None)
     monkeypatch.setattr(
-        cli, "get_github_prs", lambda _o, _r: ["https://github.com/org/repo/pull/1"]
+        cli,
+        "get_github_prs",
+        lambda _o, _r, _s="open": ["https://github.com/org/repo/pull/1"],
     )
     monkeypatch.setattr(api, "make_github_api_request", lambda _: _make_pr_fixture())
 
@@ -1400,7 +1416,9 @@ def test_auto_fit_drops_columns_when_very_narrow(monkeypatch):
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
     monkeypatch.setattr(cli, "check_for_update", lambda: None)
     monkeypatch.setattr(
-        cli, "get_github_prs", lambda _o, _r: ["https://github.com/org/repo/pull/1"]
+        cli,
+        "get_github_prs",
+        lambda _o, _r, _s="open": ["https://github.com/org/repo/pull/1"],
     )
     monkeypatch.setattr(api, "make_github_api_request", lambda _: _make_pr_fixture())
 
@@ -1421,7 +1439,9 @@ def test_auto_fit_noop_when_not_tty(monkeypatch):
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
     monkeypatch.setattr(cli, "check_for_update", lambda: None)
     monkeypatch.setattr(
-        cli, "get_github_prs", lambda _o, _r: ["https://github.com/org/repo/pull/1"]
+        cli,
+        "get_github_prs",
+        lambda _o, _r, _s="open": ["https://github.com/org/repo/pull/1"],
     )
     monkeypatch.setattr(
         api, "make_github_api_request", lambda _: _make_pr_fixture(title="A" * 200)
@@ -1440,7 +1460,9 @@ def test_explicit_max_title_length_overrides_auto_fit(monkeypatch):
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
     monkeypatch.setattr(cli, "check_for_update", lambda: None)
     monkeypatch.setattr(
-        cli, "get_github_prs", lambda _o, _r: ["https://github.com/org/repo/pull/1"]
+        cli,
+        "get_github_prs",
+        lambda _o, _r, _s="open": ["https://github.com/org/repo/pull/1"],
     )
     monkeypatch.setattr(
         api, "make_github_api_request", lambda _: _make_pr_fixture(title="A" * 100)
@@ -1540,7 +1562,7 @@ def test_no_cache_flag_always_fetches(monkeypatch, tmp_path):
 
     api_called = []
 
-    def fake_get_prs(_org, _repo):
+    def fake_get_prs(_org, _repo, _s="open"):
         api_called.append(1)
         return ["https://github.com/org/repo/pull/1"]
 
@@ -2279,7 +2301,7 @@ def test_debug_flag_prints_summary_to_stderr(monkeypatch):
         },
     )
 
-    def fake_get_prs(_org, _repo_filter):
+    def fake_get_prs(_org, _repo_filter, _state="open"):
         return ["https://github.com/org/repo/pull/1"]
 
     def fake_api_request(_path):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -66,7 +66,7 @@ def test_cli_exits_when_token_missing(monkeypatch):
 def test_cli_outputs_table(monkeypatch):
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
 
     def fake_get_prs(_org, _repo_filter):
         return ["https://github.com/org/repo/pull/1"]
@@ -104,7 +104,7 @@ def test_cli_outputs_table(monkeypatch):
 def test_cli_outputs_age_column_when_enabled(monkeypatch):
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
 
     def fake_get_prs(_org, _repo_filter):
         return ["https://github.com/org/repo/pull/1"]
@@ -165,7 +165,7 @@ def _fake_pr_detail_with_branches():
 def test_cli_outputs_head_branch_column_when_enabled(monkeypatch):
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
     monkeypatch.setattr(
         cli,
         "get_github_prs",
@@ -188,7 +188,7 @@ def test_cli_outputs_head_branch_column_when_enabled(monkeypatch):
 def test_cli_outputs_base_branch_column_when_enabled(monkeypatch):
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
     monkeypatch.setattr(
         cli,
         "get_github_prs",
@@ -211,7 +211,7 @@ def test_cli_outputs_base_branch_column_when_enabled(monkeypatch):
 def test_cli_head_and_base_branch_hidden_by_default(monkeypatch):
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
     monkeypatch.setattr(
         cli,
         "get_github_prs",
@@ -234,7 +234,7 @@ def test_cli_head_and_base_branch_hidden_by_default(monkeypatch):
 def test_cli_outputs_json(monkeypatch):
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
 
     def fake_get_prs(_org, _repo_filter):
         return ["https://github.com/org/repo/pull/1"]
@@ -288,7 +288,7 @@ def test_cli_json_output_is_valid_json_when_empty(monkeypatch):
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
     monkeypatch.setattr(cli, "get_github_prs", lambda _org, _repo: [])
-    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
 
     runner = CliRunner()
     result = runner.invoke(cli.breakfast, ["-o", "org", "-r", "repo", "--json"])
@@ -300,7 +300,7 @@ def test_cli_json_output_is_valid_json_when_empty(monkeypatch):
 def test_cli_continues_when_one_pr_fetch_fails(monkeypatch):
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
 
     def fake_get_prs(_org, _repo_filter):
         return [
@@ -352,7 +352,7 @@ def test_cli_continues_when_one_pr_fetch_fails(monkeypatch):
 def test_cli_mine_only_filters_to_authenticated_user(monkeypatch):
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
 
     def fake_get_prs(_org, _repo_filter):
         return [
@@ -401,7 +401,7 @@ def test_cli_mine_only_exits_cleanly_on_rate_limit(monkeypatch):
 
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
     monkeypatch.setattr(
         cli,
         "get_authenticated_user_login",
@@ -419,7 +419,7 @@ def test_cli_mine_only_exits_cleanly_on_rate_limit(monkeypatch):
 def test_cli_outputs_checks_column(monkeypatch):
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
 
     def fake_get_prs(_org, _repo_filter):
         return ["https://github.com/org/repo/pull/1"]
@@ -470,7 +470,7 @@ def test_cli_checks_no_collision_across_repos(monkeypatch):
     """PRs with the same number in different repos must keep separate check statuses."""
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
 
     def fake_get_prs(_org, _repo_filter):
         return [
@@ -547,7 +547,7 @@ def test_cli_checks_no_collision_across_repos(monkeypatch):
 def test_cli_checks_not_shown_by_default(monkeypatch):
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
 
     def fake_get_prs(_org, _repo_filter):
         return ["https://github.com/org/repo/pull/1"]
@@ -599,7 +599,7 @@ def test_cli_show_config_includes_status_style_from_config(tmp_path):
 def test_cli_json_includes_checks_when_enabled(monkeypatch):
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
 
     def fake_get_prs(_org, _repo_filter):
         return ["https://github.com/org/repo/pull/1"]
@@ -655,7 +655,7 @@ def test_cli_json_includes_checks_when_enabled(monkeypatch):
 def test_cli_json_excludes_checks_by_default(monkeypatch):
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
 
     def fake_get_prs(_org, _repo_filter):
         return ["https://github.com/org/repo/pull/1"]
@@ -727,7 +727,7 @@ def _make_pr_detail(number=1, owner="org", repo="repo", pr_id=1001):
 def test_cli_outputs_approvals_column(monkeypatch):
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
 
     pr_detail = _make_pr_detail()
 
@@ -760,7 +760,7 @@ def test_cli_outputs_approvals_column(monkeypatch):
 def test_cli_renders_review_required_for_incomplete_reviews(monkeypatch):
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
 
     pr_detail = _make_pr_detail()
 
@@ -796,7 +796,7 @@ def test_cli_renders_review_required_for_incomplete_reviews(monkeypatch):
 def test_cli_renders_approval_counts_for_multi_review_branch(monkeypatch):
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
 
     pr_detail = _make_pr_detail()
 
@@ -833,7 +833,7 @@ def test_cli_renders_approval_counts_for_multi_review_branch(monkeypatch):
 def test_cli_approvals_not_shown_by_default(monkeypatch):
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
 
     pr_detail = _make_pr_detail()
 
@@ -852,7 +852,7 @@ def test_cli_approvals_not_shown_by_default(monkeypatch):
 def test_cli_json_includes_approval_when_enabled(monkeypatch):
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
 
     pr_detail = _make_pr_detail()
 
@@ -888,7 +888,7 @@ def test_cli_json_includes_approval_when_enabled(monkeypatch):
 def test_cli_json_includes_approval_counts_when_available(monkeypatch):
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
 
     pr_detail = _make_pr_detail()
 
@@ -928,7 +928,7 @@ def test_cli_json_includes_approval_counts_when_available(monkeypatch):
 def test_cli_json_excludes_approval_by_default(monkeypatch):
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
 
     pr_detail = _make_pr_detail()
 
@@ -1004,7 +1004,7 @@ def test_no_update_check_env_var(monkeypatch):
 def test_cli_truncates_title_when_max_title_length_set(monkeypatch):
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
 
     long_title = "A" * 100
 
@@ -1045,7 +1045,7 @@ def test_cli_truncates_title_when_max_title_length_set(monkeypatch):
 def test_cli_does_not_truncate_title_when_max_title_length_unset(monkeypatch):
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
 
     long_title = "A" * 100
 
@@ -1083,7 +1083,7 @@ def test_cli_does_not_truncate_title_when_max_title_length_unset(monkeypatch):
 def test_cli_limit_caps_results(monkeypatch):
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
 
     def fake_get_prs(_org, _repo_filter):
         return [f"https://github.com/org/repo/pull/{i}" for i in range(1, 6)]
@@ -1179,7 +1179,7 @@ def test_auto_fit_measures_later_rows_when_fitting_table():
 def test_cli_status_columns_use_ascii_to_keep_rows_aligned(monkeypatch):
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
 
     def fake_get_prs(_org, _repo_filter):
         return [
@@ -1258,7 +1258,7 @@ def test_cli_status_columns_use_ascii_to_keep_rows_aligned(monkeypatch):
 def test_auto_fit_truncates_title_to_terminal_width(monkeypatch):
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
     monkeypatch.setattr(
         cli, "get_github_prs", lambda _o, _r: ["https://github.com/org/repo/pull/1"]
     )
@@ -1280,7 +1280,7 @@ def test_auto_fit_truncates_title_to_terminal_width(monkeypatch):
 def test_auto_fit_skips_truncation_when_title_fits(monkeypatch):
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
     monkeypatch.setattr(
         cli, "get_github_prs", lambda _o, _r: ["https://github.com/org/repo/pull/1"]
     )
@@ -1301,7 +1301,7 @@ def test_auto_fit_skips_truncation_when_title_fits(monkeypatch):
 def test_auto_fit_truncates_repo_and_author_before_dropping(monkeypatch):
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
     monkeypatch.setattr(
         cli, "get_github_prs", lambda _o, _r: ["https://github.com/org/repo/pull/1"]
     )
@@ -1331,7 +1331,7 @@ def test_auto_fit_truncates_repo_and_author_before_dropping(monkeypatch):
 def test_auto_fit_compresses_mergeable_before_dropping(monkeypatch):
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
     monkeypatch.setattr(
         cli, "get_github_prs", lambda _o, _r: ["https://github.com/org/repo/pull/1"]
     )
@@ -1398,7 +1398,7 @@ def test_auto_fit_renames_mergeable_to_mrg(monkeypatch):
 def test_auto_fit_drops_columns_when_very_narrow(monkeypatch):
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
     monkeypatch.setattr(
         cli, "get_github_prs", lambda _o, _r: ["https://github.com/org/repo/pull/1"]
     )
@@ -1419,7 +1419,7 @@ def test_auto_fit_noop_when_not_tty(monkeypatch):
     """When stdout is not a TTY (e.g. piped), auto-fit must not run."""
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
     monkeypatch.setattr(
         cli, "get_github_prs", lambda _o, _r: ["https://github.com/org/repo/pull/1"]
     )
@@ -1438,7 +1438,7 @@ def test_auto_fit_noop_when_not_tty(monkeypatch):
 def test_explicit_max_title_length_overrides_auto_fit(monkeypatch):
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
     monkeypatch.setattr(
         cli, "get_github_prs", lambda _o, _r: ["https://github.com/org/repo/pull/1"]
     )
@@ -1508,7 +1508,7 @@ def _make_pr_detail(number=1):
 def test_cache_hit_skips_get_github_prs(monkeypatch, tmp_path):
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
     monkeypatch.setattr(cache, "_CACHE_DIR", tmp_path)
     monkeypatch.setattr(cli, "read_pr_cache", cache.read_pr_cache)
     monkeypatch.setattr(cli, "write_pr_cache", cache.write_pr_cache)
@@ -1530,7 +1530,7 @@ def test_cache_hit_skips_get_github_prs(monkeypatch, tmp_path):
 def test_no_cache_flag_always_fetches(monkeypatch, tmp_path):
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
     monkeypatch.setattr(cache, "_CACHE_DIR", tmp_path)
     monkeypatch.setattr(cli, "read_pr_cache", cache.read_pr_cache)
     monkeypatch.setattr(cli, "write_pr_cache", cache.write_pr_cache)
@@ -1557,7 +1557,7 @@ def test_no_cache_flag_always_fetches(monkeypatch, tmp_path):
 def test_no_cache_flag_writes_nothing(monkeypatch, tmp_path):
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
     monkeypatch.setattr(cache, "_CACHE_DIR", tmp_path)
     monkeypatch.setattr(cli, "read_pr_cache", cache.read_pr_cache)
     monkeypatch.setattr(cli, "write_pr_cache", cache.write_pr_cache)
@@ -1587,7 +1587,7 @@ def test_config_cache_ttl_respected(monkeypatch, tmp_path):
     """cache-ttl = "5m" in config is honoured when no CLI flag given."""
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
     monkeypatch.setattr(cache, "_CACHE_DIR", tmp_path)
     monkeypatch.setattr(cli, "read_pr_cache", cache.read_pr_cache)
     monkeypatch.setattr(cli, "write_pr_cache", cache.write_pr_cache)
@@ -1612,7 +1612,7 @@ def test_config_cache_ttl_respected(monkeypatch, tmp_path):
 def test_corrupt_cache_falls_back_to_live_fetch(monkeypatch, tmp_path):
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
     monkeypatch.setattr(cache, "_CACHE_DIR", tmp_path)
     monkeypatch.setattr(cli, "read_pr_cache", cache.read_pr_cache)
     monkeypatch.setattr(cli, "write_pr_cache", cache.write_pr_cache)
@@ -1642,7 +1642,7 @@ def test_corrupt_cache_falls_back_to_live_fetch(monkeypatch, tmp_path):
 def test_pr_results_grouped_by_repo(monkeypatch, tmp_path):
     """PRs from multiple repos should appear grouped by repo name in the output."""
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
-    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
     monkeypatch.setattr(cache, "_CACHE_DIR", tmp_path)
     monkeypatch.setattr(cli, "read_pr_cache", cache.read_pr_cache)
     monkeypatch.setattr(cli, "write_pr_cache", cache.write_pr_cache)
@@ -1696,7 +1696,7 @@ def test_refresh_ignores_cache_and_writes_fresh(monkeypatch, tmp_path):
     """--refresh bypasses the cache read but still writes fresh data back."""
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
     monkeypatch.setattr(cache, "_CACHE_DIR", tmp_path)
     monkeypatch.setattr(cli, "read_pr_cache", cache.read_pr_cache)
     monkeypatch.setattr(cli, "write_pr_cache", cache.write_pr_cache)
@@ -1731,7 +1731,7 @@ def test_refresh_does_not_use_cached_data(monkeypatch, tmp_path):
     """--refresh must not serve stale data even when cache is warm."""
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
     monkeypatch.setattr(cache, "_CACHE_DIR", tmp_path)
     monkeypatch.setattr(cli, "read_pr_cache", cache.read_pr_cache)
     monkeypatch.setattr(cli, "write_pr_cache", cache.write_pr_cache)
@@ -1757,7 +1757,7 @@ def test_refresh_prs_uses_graphql_cache_skips_pr_cache(monkeypatch, tmp_path):
     """--refresh-prs uses the cached URL list but re-fetches PR details."""
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
     monkeypatch.setattr(cache, "_CACHE_DIR", tmp_path)
     monkeypatch.setattr(cli, "read_pr_cache", cache.read_pr_cache)
     monkeypatch.setattr(cli, "write_pr_cache", cache.write_pr_cache)
@@ -1791,7 +1791,7 @@ def test_refresh_prs_writes_fresh_pr_cache(monkeypatch, tmp_path):
     """--refresh-prs writes fresh PR details back to cache."""
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
     monkeypatch.setattr(cache, "_CACHE_DIR", tmp_path)
     monkeypatch.setattr(cli, "read_pr_cache", cache.read_pr_cache)
     monkeypatch.setattr(cli, "write_pr_cache", cache.write_pr_cache)
@@ -1887,7 +1887,7 @@ def test_cli_legendary_flag_annotates_state(monkeypatch):
     """--legendary appends ⚔️ to the State of qualifying PRs."""
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
 
     # A PR that qualifies as legendary (very old AND many comments)
     legendary_pr = {
@@ -1914,7 +1914,7 @@ def test_cli_legendary_off_by_default(monkeypatch):
     """Without --legendary, no sword emoji appears even for qualifying PRs."""
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
 
     old_pr = {
         **_make_pr_detail(1),
@@ -1939,7 +1939,7 @@ def test_cli_legendary_only_filters_non_legendary(monkeypatch):
     """--legendary-only shows only PRs that qualify as legendary."""
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
 
     # A fresh PR — should be filtered out
     fresh_pr = {
@@ -1968,7 +1968,7 @@ def test_cli_legendary_only_implies_legendary_marking(monkeypatch):
     """--legendary-only implies --legendary so the ⚔️ marker is applied."""
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
 
     legendary_pr = {
         **_make_pr_detail(1),
@@ -2137,7 +2137,7 @@ def test_styled_hyperlink_puts_colour_outside_osc8():
 def test_cli_repo_and_author_are_hyperlinks(monkeypatch):
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
 
     pr = _make_pr_fixture(number=1)
     pr["base"]["repo"]["html_url"] = "https://github.com/myorg/myrepo"
@@ -2159,7 +2159,7 @@ def test_cli_repo_and_author_are_hyperlinks(monkeypatch):
 def test_cli_checks_column_links_to_checks_tab(monkeypatch):
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
 
     pr = _make_pr_fixture(number=7)
     pr["base"]["repo"]["owner"] = {"login": "org"}
@@ -2195,7 +2195,7 @@ def test_progress_emoji_emitted_after_check_status_fetch(monkeypatch):
     """
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
 
     pr = _make_pr_fixture(number=1)
     pr["base"]["repo"]["owner"] = {"login": "org"}
@@ -2259,7 +2259,7 @@ def test_debug_flag_prints_summary_to_stderr(monkeypatch):
     """--debug emits a summary block to stderr without disrupting stdout output."""
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
     monkeypatch.setattr(
         cli,
         "get_api_stats",
@@ -2340,7 +2340,7 @@ def test_no_colour_strips_ansi_from_table(monkeypatch):
     """--no-colour produces output with no ANSI escape sequences."""
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
     monkeypatch.setattr(
         cli, "get_github_prs", lambda *_: ["https://github.com/org/repo/pull/1"]
     )
@@ -2358,7 +2358,7 @@ def test_no_color_alias_works(monkeypatch):
     """--no-color (US spelling) is accepted and strips ANSI."""
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
     monkeypatch.setattr(
         cli, "get_github_prs", lambda *_: ["https://github.com/org/repo/pull/1"]
     )
@@ -2404,7 +2404,7 @@ def test_seasonal_colours_no_colour_suppresses_them(monkeypatch):
 
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
     monkeypatch.setattr(
         cli, "get_github_prs", lambda *_: ["https://github.com/org/repo/pull/1"]
     )
@@ -2422,7 +2422,7 @@ def test_seasonal_colours_disabled_by_config(monkeypatch, tmp_path):
 
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
     monkeypatch.setattr(
         cli, "get_github_prs", lambda *_: ["https://github.com/org/repo/pull/1"]
     )
@@ -2493,7 +2493,7 @@ def _fake_pr_for_summary(path):
 def test_summarise_user_prs_shows_author_summary(monkeypatch):
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
     monkeypatch.setattr(cli, "get_github_prs", lambda *_: _two_author_prs())
     monkeypatch.setattr(api, "make_github_api_request", _fake_pr_for_summary)
 
@@ -2511,7 +2511,7 @@ def test_summarise_user_prs_shows_author_summary(monkeypatch):
 def test_summarise_repo_prs_shows_repo_summary(monkeypatch):
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
     monkeypatch.setattr(cli, "get_github_prs", lambda *_: _two_author_prs())
     monkeypatch.setattr(api, "make_github_api_request", _fake_pr_for_summary)
 
@@ -2541,7 +2541,7 @@ def test_summarise_user_and_repo_mutually_exclusive(monkeypatch):
 def test_summarise_user_prs_empty_shows_no_prs_message(monkeypatch):
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
     monkeypatch.setattr(cli, "get_github_prs", lambda *_: [])
 
     runner = CliRunner()
@@ -2554,7 +2554,7 @@ def test_summarise_user_prs_empty_shows_no_prs_message(monkeypatch):
 def test_summarise_repo_prs_no_colour(monkeypatch):
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
     monkeypatch.setattr(cli, "get_github_prs", lambda *_: _two_author_prs())
     monkeypatch.setattr(api, "make_github_api_request", _fake_pr_for_summary)
 
@@ -2606,7 +2606,7 @@ def _fake_pr_detail(_path):
 def test_table_output_goes_to_stdout_not_stderr(monkeypatch):
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
     monkeypatch.setattr(
         cli, "get_github_prs", lambda *_: ["https://github.com/org/repo/pull/1"]
     )
@@ -2622,7 +2622,7 @@ def test_table_output_goes_to_stdout_not_stderr(monkeypatch):
 def test_progress_messages_go_to_stderr_in_table_mode(monkeypatch):
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
     monkeypatch.setattr(
         cli, "get_github_prs", lambda *_: ["https://github.com/org/repo/pull/1"]
     )
@@ -2638,7 +2638,7 @@ def test_progress_messages_go_to_stderr_in_table_mode(monkeypatch):
 def test_progress_messages_go_to_stderr_in_json_mode(monkeypatch):
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
     monkeypatch.setattr(
         cli, "get_github_prs", lambda *_: ["https://github.com/org/repo/pull/1"]
     )
@@ -2655,7 +2655,7 @@ def test_json_stdout_is_clean_json(monkeypatch):
     """stdout must contain only parseable JSON — no progress noise."""
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
     monkeypatch.setattr(
         cli, "get_github_prs", lambda *_: ["https://github.com/org/repo/pull/1"]
     )
@@ -2672,7 +2672,7 @@ def test_json_stdout_is_clean_json(monkeypatch):
 def test_no_match_message_goes_to_stderr(monkeypatch):
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
     monkeypatch.setattr(
         cli, "get_github_prs", lambda *_: ["https://github.com/org/repo/pull/1"]
     )
@@ -2691,7 +2691,7 @@ def test_no_match_with_json_stdout_stays_clean(monkeypatch):
     """--json --search with no matches: stdout must be parseable empty JSON."""
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
     monkeypatch.setattr(
         cli, "get_github_prs", lambda *_: ["https://github.com/org/repo/pull/1"]
     )
@@ -2725,7 +2725,7 @@ def test_config_format_json_enables_json_output(monkeypatch, tmp_path):
     cfg_file.write_text('format = "json"\norganization = "org"\n')
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
     monkeypatch.setattr(
         cli, "get_github_prs", lambda *_: ["https://github.com/org/repo/pull/1"]
     )
@@ -2743,7 +2743,7 @@ def test_config_format_table_produces_table_output(monkeypatch, tmp_path):
     cfg_file.write_text('format = "table"\norganization = "org"\n')
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
     monkeypatch.setattr(
         cli, "get_github_prs", lambda *_: ["https://github.com/org/repo/pull/1"]
     )
@@ -2760,7 +2760,7 @@ def test_config_format_invalid_warns_and_falls_back_to_table(monkeypatch, tmp_pa
     cfg_file.write_text('format = "tofu"\norganization = "org"\n')
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
     monkeypatch.setattr(
         cli, "get_github_prs", lambda *_: ["https://github.com/org/repo/pull/1"]
     )
@@ -2780,7 +2780,7 @@ def test_cli_no_json_flag_overrides_config_format_json(monkeypatch, tmp_path):
     cfg_file.write_text('format = "json"\norganization = "org"\n')
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
     monkeypatch.setattr(
         cli, "get_github_prs", lambda *_: ["https://github.com/org/repo/pull/1"]
     )
@@ -2802,7 +2802,7 @@ def test_cli_no_json_flag_overrides_config_format_json(monkeypatch, tmp_path):
 def test_format_markdown_produces_gfm_table(monkeypatch):
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
     monkeypatch.setattr(
         cli, "get_github_prs", lambda *_: ["https://github.com/org/repo/pull/1"]
     )
@@ -2822,7 +2822,7 @@ def test_format_markdown_produces_gfm_table(monkeypatch):
 def test_format_markdown_strips_ansi_codes(monkeypatch):
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
     monkeypatch.setattr(
         cli, "get_github_prs", lambda *_: ["https://github.com/org/repo/pull/1"]
     )
@@ -2840,7 +2840,7 @@ def test_format_markdown_strips_ansi_codes(monkeypatch):
 def test_format_markdown_output_goes_to_stdout(monkeypatch):
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
     monkeypatch.setattr(
         cli, "get_github_prs", lambda *_: ["https://github.com/org/repo/pull/1"]
     )
@@ -2861,7 +2861,7 @@ def test_config_format_markdown_produces_markdown_output(monkeypatch, tmp_path):
     cfg_file.write_text('format = "markdown"\norganization = "org"\n')
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
     monkeypatch.setattr(
         cli, "get_github_prs", lambda *_: ["https://github.com/org/repo/pull/1"]
     )
@@ -2877,7 +2877,7 @@ def test_config_format_markdown_produces_markdown_output(monkeypatch, tmp_path):
 def test_format_markdown_includes_optional_columns(monkeypatch):
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
 
     def fake_api_request(path):
         if "check-runs" in path:
@@ -2903,7 +2903,7 @@ def test_format_flag_overrides_json_flag(monkeypatch):
     """--format markdown takes precedence over --json."""
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
     monkeypatch.setattr(
         cli, "get_github_prs", lambda *_: ["https://github.com/org/repo/pull/1"]
     )
@@ -2928,7 +2928,7 @@ def test_format_flag_overrides_json_flag(monkeypatch):
 def test_format_csv_produces_header_row(monkeypatch):
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
     monkeypatch.setattr(
         cli, "get_github_prs", lambda *_: ["https://github.com/org/repo/pull/1"]
     )
@@ -2946,7 +2946,7 @@ def test_format_csv_produces_header_row(monkeypatch):
 def test_format_csv_contains_pr_data(monkeypatch):
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
     monkeypatch.setattr(
         cli, "get_github_prs", lambda *_: ["https://github.com/org/repo/pull/1"]
     )
@@ -2964,7 +2964,7 @@ def test_format_csv_contains_pr_data(monkeypatch):
 def test_format_csv_strips_ansi_codes(monkeypatch):
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
     monkeypatch.setattr(
         cli, "get_github_prs", lambda *_: ["https://github.com/org/repo/pull/1"]
     )
@@ -2982,7 +2982,7 @@ def test_format_csv_strips_ansi_codes(monkeypatch):
 def test_format_csv_output_goes_to_stdout(monkeypatch):
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
     monkeypatch.setattr(
         cli, "get_github_prs", lambda *_: ["https://github.com/org/repo/pull/1"]
     )
@@ -3001,7 +3001,7 @@ def test_format_csv_output_goes_to_stdout(monkeypatch):
 def test_format_csv_is_valid_csv(monkeypatch):
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
     monkeypatch.setattr(
         cli, "get_github_prs", lambda *_: ["https://github.com/org/repo/pull/1"]
     )
@@ -3021,7 +3021,7 @@ def test_format_csv_is_valid_csv(monkeypatch):
 def test_format_csv_includes_optional_age_column(monkeypatch):
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
     monkeypatch.setattr(
         cli, "get_github_prs", lambda *_: ["https://github.com/org/repo/pull/1"]
     )
@@ -3041,7 +3041,7 @@ def test_config_format_csv_produces_csv_output(monkeypatch, tmp_path):
     cfg_file.write_text('format = "csv"\norganization = "org"\n')
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "check_for_update", lambda: None)
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
     monkeypatch.setattr(
         cli, "get_github_prs", lambda *_: ["https://github.com/org/repo/pull/1"]
     )

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -196,6 +196,71 @@ def test_filter_pr_details_combined_filters():
     assert {r["id"] for r in result} == {1, 2}
 
 
+def test_filter_pr_details_filter_label_single():
+    pr_details = [
+        {**_make_pr(pr_id=1), "labels": [{"name": "bug"}, {"name": "urgent"}]},
+        {**_make_pr(pr_id=2), "labels": [{"name": "enhancement"}]},
+        {**_make_pr(pr_id=3), "labels": []},
+    ]
+
+    result = config.filter_pr_details(pr_details, [], filter_label=("bug",))
+    assert [r["id"] for r in result] == [1]
+
+
+def test_filter_pr_details_filter_label_multiple_or():
+    pr_details = [
+        {**_make_pr(pr_id=1), "labels": [{"name": "bug"}]},
+        {**_make_pr(pr_id=2), "labels": [{"name": "enhancement"}]},
+        {**_make_pr(pr_id=3), "labels": [{"name": "docs"}]},
+    ]
+
+    result = config.filter_pr_details(
+        pr_details, [], filter_label=("bug", "enhancement")
+    )
+    assert {r["id"] for r in result} == {1, 2}
+
+
+def test_filter_pr_details_filter_label_case_insensitive():
+    pr_details = [
+        {**_make_pr(pr_id=1), "labels": [{"name": "Bug"}]},
+        {**_make_pr(pr_id=2), "labels": [{"name": "docs"}]},
+    ]
+
+    result = config.filter_pr_details(pr_details, [], filter_label=("bug",))
+    assert [r["id"] for r in result] == [1]
+
+
+def test_filter_pr_details_filter_label_no_labels_on_pr():
+    pr_details = [
+        {**_make_pr(pr_id=1), "labels": []},
+        {**_make_pr(pr_id=2)},  # labels key absent
+    ]
+
+    result = config.filter_pr_details(pr_details, [], filter_label=("bug",))
+    assert result == []
+
+
+def test_filter_pr_details_exclude_label():
+    pr_details = [
+        {**_make_pr(pr_id=1), "labels": [{"name": "wip"}]},
+        {**_make_pr(pr_id=2), "labels": [{"name": "ready"}]},
+        {**_make_pr(pr_id=3), "labels": []},
+    ]
+
+    result = config.filter_pr_details(pr_details, [], exclude_label=("wip",))
+    assert {r["id"] for r in result} == {2, 3}
+
+
+def test_filter_pr_details_exclude_label_case_insensitive():
+    pr_details = [
+        {**_make_pr(pr_id=1), "labels": [{"name": "WIP"}]},
+        {**_make_pr(pr_id=2), "labels": [{"name": "ready"}]},
+    ]
+
+    result = config.filter_pr_details(pr_details, [], exclude_label=("wip",))
+    assert [r["id"] for r in result] == [2]
+
+
 def test_get_config_dir_xdg(tmp_path, monkeypatch):
     custom_path = tmp_path / "custom-xdg"
     monkeypatch.setenv("XDG_CONFIG_HOME", str(custom_path))

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -196,6 +196,51 @@ def test_filter_pr_details_combined_filters():
     assert {r["id"] for r in result} == {1, 2}
 
 
+def test_filter_pr_details_filter_reviewer_single():
+    pr_details = [
+        {
+            **_make_pr(pr_id=1),
+            "requested_reviewers": [{"login": "alice"}, {"login": "bob"}],
+        },
+        {**_make_pr(pr_id=2), "requested_reviewers": [{"login": "carol"}]},
+        {**_make_pr(pr_id=3), "requested_reviewers": []},
+    ]
+
+    result = config.filter_pr_details(pr_details, [], filter_reviewer=("alice",))
+    assert [r["id"] for r in result] == [1]
+
+
+def test_filter_pr_details_filter_reviewer_multiple_or():
+    pr_details = [
+        {**_make_pr(pr_id=1), "requested_reviewers": [{"login": "alice"}]},
+        {**_make_pr(pr_id=2), "requested_reviewers": [{"login": "bob"}]},
+        {**_make_pr(pr_id=3), "requested_reviewers": [{"login": "carol"}]},
+    ]
+
+    result = config.filter_pr_details(pr_details, [], filter_reviewer=("alice", "bob"))
+    assert {r["id"] for r in result} == {1, 2}
+
+
+def test_filter_pr_details_filter_reviewer_case_insensitive():
+    pr_details = [
+        {**_make_pr(pr_id=1), "requested_reviewers": [{"login": "Alice"}]},
+        {**_make_pr(pr_id=2), "requested_reviewers": [{"login": "bob"}]},
+    ]
+
+    result = config.filter_pr_details(pr_details, [], filter_reviewer=("alice",))
+    assert [r["id"] for r in result] == [1]
+
+
+def test_filter_pr_details_filter_reviewer_no_reviewers():
+    pr_details = [
+        {**_make_pr(pr_id=1), "requested_reviewers": []},
+        {**_make_pr(pr_id=2)},  # field absent
+    ]
+
+    result = config.filter_pr_details(pr_details, [], filter_reviewer=("alice",))
+    assert result == []
+
+
 def test_get_config_dir_xdg(tmp_path, monkeypatch):
     custom_path = tmp_path / "custom-xdg"
     monkeypatch.setenv("XDG_CONFIG_HOME", str(custom_path))

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -196,6 +196,62 @@ def test_filter_pr_details_combined_filters():
     assert {r["id"] for r in result} == {1, 2}
 
 
+def _make_pr_dated(pr_id, created_at, updated_at):
+    return {
+        "id": pr_id,
+        "user": {"login": "alice"},
+        "state": "open",
+        "created_at": created_at,
+        "updated_at": updated_at,
+        "base": {"repo": {"name": "repo"}},
+        "number": pr_id,
+    }
+
+
+def test_filter_pr_details_filter_stale():
+    pr_details = [
+        _make_pr_dated(1, "2020-01-01T00:00:00Z", "2020-01-02T00:00:00Z"),
+        _make_pr_dated(2, "2099-12-31T00:00:00Z", "2099-12-31T00:00:00Z"),
+    ]
+
+    result = config.filter_pr_details(pr_details, [], filter_stale=7)
+    assert [r["id"] for r in result] == [1]
+
+
+def test_filter_pr_details_filter_stale_boundary():
+    pr_details = [
+        _make_pr_dated(1, "2020-01-01T00:00:00Z", "2020-01-01T00:00:00Z"),
+    ]
+    result_old = config.filter_pr_details(pr_details, [], filter_stale=1)
+    assert len(result_old) == 1
+
+    result_not_old_enough = config.filter_pr_details(
+        pr_details, [], filter_stale=999999
+    )
+    assert len(result_not_old_enough) == 0
+
+
+def test_filter_pr_details_filter_inactive():
+    pr_details = [
+        _make_pr_dated(1, "2020-01-01T00:00:00Z", "2020-01-02T00:00:00Z"),
+        _make_pr_dated(2, "2020-01-01T00:00:00Z", "2099-12-31T00:00:00Z"),
+    ]
+
+    result = config.filter_pr_details(pr_details, [], filter_inactive=7)
+    assert [r["id"] for r in result] == [1]
+
+
+def test_filter_pr_details_stale_and_inactive_combined():
+    pr_details = [
+        _make_pr_dated(1, "2020-01-01T00:00:00Z", "2020-01-02T00:00:00Z"),
+        _make_pr_dated(2, "2020-01-01T00:00:00Z", "2099-12-31T00:00:00Z"),
+        _make_pr_dated(3, "2099-12-31T00:00:00Z", "2020-01-01T00:00:00Z"),
+    ]
+
+    result = config.filter_pr_details(pr_details, [], filter_stale=7, filter_inactive=7)
+    assert [r["id"] for r in result] == [1]
+
+
 def test_get_config_dir_xdg(tmp_path, monkeypatch):
     custom_path = tmp_path / "custom-xdg"
     monkeypatch.setenv("XDG_CONFIG_HOME", str(custom_path))

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -144,22 +144,29 @@ def test_easter_month_known_years():
         (1, "purple"),
         (4, "yellow"),  # 2026 Easter is in April
         (10, "orange"),
-        (12, "red"),
     ],
 )
-def test_seasonal_colour_by_special_month(month, expected_key):
-    with patch("breakfast.ui.datetime") as mock_dt:
-        mock_dt.date.today.return_value = _today(month)
-        colour = ui._seasonal_colour()
-    assert colour == ui.SEASONAL_PALETTES[expected_key]
+def test_western_calendar_by_special_month(month, expected_key):
+    result = ui._western_calendar(_today(month))
+    assert result == ui.SEASONAL_PALETTES[expected_key]
 
 
-@pytest.mark.parametrize("month", [2, 3, 5, 6, 7, 8, 9, 11])
-def test_seasonal_colour_non_special_months_return_none(month):
-    with patch("breakfast.ui.datetime") as mock_dt:
-        mock_dt.date.today.return_value = _today(month)
-        colour = ui._seasonal_colour()
-    assert colour is None
+def test_western_calendar_december_returns_candy_cane_list():
+    result = ui._western_calendar(_today(12))
+    assert isinstance(result, list)
+    assert ui.SEASONAL_PALETTES["red"] in result
+    assert ui.SEASONAL_PALETTES["green"] in result
+
+
+def test_western_calendar_june_returns_pride_rainbow():
+    result = ui._western_calendar(_today(6))
+    assert result == ui.PRIDE_RAINBOW
+
+
+@pytest.mark.parametrize("month", [2, 3, 5, 7, 8, 9, 11])
+def test_western_calendar_non_special_months_return_none(month):
+    result = ui._western_calendar(_today(month))
+    assert result is None
 
 
 def test_apply_seasonal_colour_uses_single_colour():
@@ -316,7 +323,7 @@ def test_render_pr_summary_contains_names():
         ("bob", _BOB_URL, 5, 0, 7, 3),
     ]
     result = ui.render_pr_summary(
-        groups, "👤 PR Summary by Author", "Author", False, False
+        groups, "👤 PR Summary by Author", "Author", False, "off"
     )
     assert "alice" in result
     assert "bob" in result
@@ -327,50 +334,50 @@ def test_render_pr_summary_contains_names():
 def test_render_pr_summary_shows_title():
     groups = [("alice", _ALICE_URL, 1, 0, 5, 0)]
     result = ui.render_pr_summary(
-        groups, "👤 PR Summary by Author", "Author", False, False
+        groups, "👤 PR Summary by Author", "Author", False, "off"
     )
     assert "👤 PR Summary by Author" in result
 
 
 def test_render_pr_summary_shows_oldest_age_and_comments():
     groups = [("alice", _ALICE_URL, 3, 0, 15, 7)]
-    result = ui.render_pr_summary(groups, "Title", "Author", False, False)
+    result = ui.render_pr_summary(groups, "Title", "Author", False, "off")
     assert "oldest: 15d" in result
     assert "comments: 7" in result
 
 
 def test_render_pr_summary_empty_groups():
-    result = ui.render_pr_summary([], "Title", "Author", False, False)
+    result = ui.render_pr_summary([], "Title", "Author", False, "off")
     assert "no PRs" in result
 
 
 def test_render_pr_summary_singular_pr():
     groups = [("alice", _ALICE_URL, 1, 0, 3, 0)]
-    result = ui.render_pr_summary(groups, "Title", "Author", False, False)
+    result = ui.render_pr_summary(groups, "Title", "Author", False, "off")
     assert "1 PR " in result  # not "1 PRs"
 
 
 def test_render_pr_summary_no_ansi_when_colour_false():
     groups = [("alice", _ALICE_URL, 5, 0, 50, 2), ("bob", _BOB_URL, 2, 0, 3, 0)]
-    result = ui.render_pr_summary(groups, "Title", "Author", False, False)
+    result = ui.render_pr_summary(groups, "Title", "Author", False, "off")
     assert "\x1b[" not in result
 
 
 def test_render_pr_summary_hyperlink_when_colour_enabled():
     groups = [("alice", _ALICE_URL, 1, 0, 3, 0)]
-    result = ui.render_pr_summary(groups, "Title", "Author", True, False)
+    result = ui.render_pr_summary(groups, "Title", "Author", True, "off")
     assert _ALICE_URL in result
 
 
 def test_render_pr_summary_no_hyperlink_when_colour_disabled():
     groups = [("alice", _ALICE_URL, 1, 0, 3, 0)]
-    result = ui.render_pr_summary(groups, "Title", "Author", False, False)
+    result = ui.render_pr_summary(groups, "Title", "Author", False, "off")
     assert _ALICE_URL not in result
 
 
 def test_render_pr_summary_bar_proportional():
     groups = [("alice", _ALICE_URL, 10, 0, 5, 0), ("bob", _BOB_URL, 5, 0, 5, 0)]
-    result = ui.render_pr_summary(groups, "Title", "Author", False, False)
+    result = ui.render_pr_summary(groups, "Title", "Author", False, "off")
     lines = [ln for ln in result.splitlines() if "alice" in ln or "bob" in ln]
     alice_bar = lines[0].count("█")
     bob_bar = lines[1].count("█")
@@ -379,20 +386,20 @@ def test_render_pr_summary_bar_proportional():
 
 def test_render_pr_summary_draft_shown_in_count():
     groups = [("alice", _ALICE_URL, 5, 2, 10, 0)]
-    result = ui.render_pr_summary(groups, "Title", "Author", False, False)
+    result = ui.render_pr_summary(groups, "Title", "Author", False, "off")
     assert "2 draft" in result
 
 
 def test_render_pr_summary_no_draft_suffix_when_zero():
     groups = [("alice", _ALICE_URL, 5, 0, 10, 0)]
-    result = ui.render_pr_summary(groups, "Title", "Author", False, False)
+    result = ui.render_pr_summary(groups, "Title", "Author", False, "off")
     assert "draft" not in result
 
 
 def test_render_pr_summary_draft_blocks_shown():
     # 3 open, 2 draft — bar should contain both solid and light-shade blocks
     groups = [("alice", _ALICE_URL, 5, 2, 10, 0)]
-    result = ui.render_pr_summary(groups, "Title", "Author", False, False)
+    result = ui.render_pr_summary(groups, "Title", "Author", False, "off")
     alice_line = next(ln for ln in result.splitlines() if "alice" in ln)
     assert "█" in alice_line
     assert "▒" in alice_line
@@ -400,7 +407,7 @@ def test_render_pr_summary_draft_blocks_shown():
 
 def test_render_pr_summary_all_draft_bar_all_light():
     groups = [("alice", _ALICE_URL, 3, 3, 5, 0)]
-    result = ui.render_pr_summary(groups, "Title", "Author", False, False)
+    result = ui.render_pr_summary(groups, "Title", "Author", False, "off")
     alice_line = next(ln for ln in result.splitlines() if "alice" in ln)
     assert "█" not in alice_line
     assert "▒" in alice_line
@@ -418,6 +425,157 @@ def test_render_pr_summary_small_draft_minority_keeps_solid_block():
         ("bob", _ALICE_URL, 200, 0, 5, 0),
         ("alice", _ALICE_URL, 10, 1, 5, 0),
     ]
-    result = ui.render_pr_summary(groups, "Title", "Author", False, False)
+    result = ui.render_pr_summary(groups, "Title", "Author", False, "off")
     alice_line = next(ln for ln in result.splitlines() if "alice" in ln)
     assert "█" in alice_line
+
+
+# ---------------------------------------------------------------------------
+# Pluggable calendar system (#196)
+# ---------------------------------------------------------------------------
+
+
+def test_apply_seasonal_colour_off_returns_plain():
+    with patch("breakfast.ui.datetime") as mock_dt:
+        mock_dt.date.today.return_value = _today(1)  # January — normally purple
+        result = ui.apply_seasonal_colour("alice", 0, calendar="off")
+    assert result == "alice"
+
+
+def test_apply_seasonal_colour_unknown_calendar_returns_plain():
+    with patch("breakfast.ui.datetime") as mock_dt:
+        mock_dt.date.today.return_value = _today(1)
+        result = ui.apply_seasonal_colour("alice", 0, calendar="nonexistent")
+    assert result == "alice"
+
+
+def test_apply_seasonal_colour_western_default():
+    with patch("breakfast.ui.datetime") as mock_dt:
+        mock_dt.date.today.return_value = _today(1)  # January → purple
+        result = ui.apply_seasonal_colour("alice", 0)  # default calendar
+    assert result.startswith(ui.SEASONAL_PALETTES["purple"])
+
+
+def test_jewish_calendar_hanukkah():
+    hanukkah_2025 = datetime.date(2025, 12, 14)
+    result = ui._jewish_calendar(hanukkah_2025)
+    assert result == ui.SEASONAL_PALETTES["blue"]
+
+
+def test_jewish_calendar_hanukkah_window():
+    # 2025 Hanukkah is Dec 14–21 (8 nights)
+    for day in range(14, 22):
+        result = ui._jewish_calendar(datetime.date(2025, 12, day))
+        assert result == ui.SEASONAL_PALETTES["blue"], f"day={day}"
+
+
+def test_jewish_calendar_rosh_hashanah():
+    rosh_2024 = datetime.date(2024, 10, 2)
+    result = ui._jewish_calendar(rosh_2024)
+    assert result == ui.SEASONAL_PALETTES["lny"]
+
+
+def test_jewish_calendar_passover():
+    passover_2025 = datetime.date(2025, 4, 12)
+    result = ui._jewish_calendar(passover_2025)
+    assert result == ui.SEASONAL_PALETTES["spring_green"]
+
+
+def test_jewish_calendar_non_holiday_returns_none():
+    result = ui._jewish_calendar(datetime.date(2025, 7, 15))
+    assert result is None
+
+
+def test_islamic_calendar_eid_al_fitr():
+    eid_2024 = datetime.date(2024, 4, 10)
+    result = ui._islamic_calendar(eid_2024)
+    assert result == ui.SEASONAL_PALETTES["green"]
+
+
+def test_islamic_calendar_eid_window():
+    # Eid al-Fitr 2024: Apr 10, 3-day window
+    for day in range(10, 13):
+        result = ui._islamic_calendar(datetime.date(2024, 4, day))
+        assert result == ui.SEASONAL_PALETTES["green"], f"day={day}"
+
+
+def test_islamic_calendar_non_holiday_returns_none():
+    result = ui._islamic_calendar(datetime.date(2025, 6, 15))
+    assert result is None
+
+
+def test_hindu_calendar_diwali():
+    diwali_2024 = datetime.date(2024, 11, 1)
+    result = ui._hindu_calendar(diwali_2024)
+    assert result == ui.SEASONAL_PALETTES["lny"]
+
+
+def test_hindu_calendar_holi_returns_rainbow():
+    holi_2025 = datetime.date(2025, 3, 14)
+    result = ui._hindu_calendar(holi_2025)
+    assert isinstance(result, list)
+    assert result == ui.HOLI_RAINBOW
+
+
+def test_hindu_calendar_non_holiday_returns_none():
+    result = ui._hindu_calendar(datetime.date(2025, 8, 15))
+    assert result is None
+
+
+def test_sikh_calendar_vaisakhi():
+    vaisakhi = datetime.date(2025, 4, 13)
+    result = ui._sikh_calendar(vaisakhi)
+    assert result == ui.SEASONAL_PALETTES["spring_green"]
+
+
+def test_sikh_calendar_diwali():
+    diwali_2024 = datetime.date(2024, 11, 1)
+    result = ui._sikh_calendar(diwali_2024)
+    assert result == ui.SEASONAL_PALETTES["lny"]
+
+
+def test_sikh_calendar_non_holiday_returns_none():
+    result = ui._sikh_calendar(datetime.date(2025, 7, 4))
+    assert result is None
+
+
+def test_apply_seasonal_colour_jewish_calendar():
+    with patch("breakfast.ui.datetime") as mock_dt:
+        mock_dt.date.today.return_value = datetime.date(2025, 12, 14)  # Hanukkah
+        result = ui.apply_seasonal_colour("alice", 0, calendar="jewish")
+    assert result.startswith(ui.SEASONAL_PALETTES["blue"])
+    assert result.endswith("\033[0m")
+
+
+def test_apply_seasonal_colour_holi_cycles_by_pr_number():
+    with patch("breakfast.ui.datetime") as mock_dt:
+        mock_dt.date.today.return_value = datetime.date(2025, 3, 14)  # Holi
+        results = [ui.apply_seasonal_colour("x", i, calendar="hindu") for i in range(6)]
+    for i, expected in enumerate(ui.HOLI_RAINBOW):
+        assert results[i].startswith(expected)
+
+
+def test_unknown_year_returns_none_gracefully():
+    # Year 2099 is not in any lookup table — should return None, not crash.
+    result = ui._jewish_calendar(datetime.date(2099, 12, 10))
+    assert result is None
+
+
+def test_in_holiday_window_unknown_year():
+    result = ui._in_holiday_window(datetime.date(2099, 4, 1), ui._PASSOVER_START)
+    assert result is False
+
+
+def test_western_calendar_january_stays_purple_on_lny_2025():
+    # 2025 LNY is Jan 29 — must return purple, not LNY gold.
+    result = ui._western_calendar(datetime.date(2025, 1, 29))
+    assert result == ui.SEASONAL_PALETTES["purple"]
+
+
+def test_render_pr_summary_seasonal_calendar():
+    # When a non-"off" calendar is passed, seasonal colours are applied.
+    groups = [("alice", _ALICE_URL, 3, 0, 10, 0)]
+    with patch("breakfast.ui.datetime") as mock_dt:
+        mock_dt.date.today.return_value = _today(1)  # January → purple
+        result = ui.render_pr_summary(groups, "Title", "Author", True, "western")
+    assert "\033[" in result

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -139,6 +139,116 @@ def test_write_and_read_version_cache(monkeypatch, tmp_path):
     assert updater._read_version_cache() == "3.0.0"
 
 
+def test_write_version_cache_stores_release_body(monkeypatch, tmp_path):
+    monkeypatch.setattr(updater, "_CACHE_DIR", tmp_path)
+
+    body = "- fix: some thing\n- feat: other"
+    updater._write_version_cache("3.0.0", release_body=body)
+    assert updater._read_cached_release_body() == body
+
+
+def test_write_version_cache_no_body_returns_none(monkeypatch, tmp_path):
+    monkeypatch.setattr(updater, "_CACHE_DIR", tmp_path)
+
+    updater._write_version_cache("3.0.0")
+    assert updater._read_cached_release_body() is None
+
+
+def test_get_release_summary_bullet_points():
+    body = (
+        "## What's new\n- fix: bug squashed\n- feat: cool thing\n"
+        "- chore: cleanup\n- extra: fourth"
+    )
+    summary = updater.get_release_summary(body)
+    assert "fix: bug squashed" in summary
+    assert "feat: cool thing" in summary
+    assert "extra: fourth" not in summary  # only first 3 bullets
+
+
+def test_get_release_summary_strips_headers():
+    body = "# Release v1.0\n## Changes\n- fix: something"
+    summary = updater.get_release_summary(body)
+    assert "#" not in summary
+    assert "fix: something" in summary
+
+
+def test_get_release_summary_strips_urls():
+    body = "- fix: see https://github.com/org/repo/issues/1 for details"
+    summary = updater.get_release_summary(body)
+    assert "https://" not in summary
+    assert "fix: see" in summary
+
+
+def test_get_release_summary_truncates():
+    body = "- " + "x" * 300
+    summary = updater.get_release_summary(body, max_chars=50)
+    assert len(summary) <= 50
+    assert summary.endswith("…")
+
+
+def test_get_release_summary_empty_body():
+    assert updater.get_release_summary("") == ""
+    assert updater.get_release_summary(None) == ""
+
+
+def test_check_for_update_with_summary(monkeypatch, tmp_path):
+    monkeypatch.setattr(updater, "_CACHE_DIR", tmp_path)
+    monkeypatch.setattr(updater, "pkg_version", lambda _name: "0.9.0")
+    monkeypatch.setattr(updater, "get_latest_version", lambda: "0.10.0")
+    updater._write_version_cache("0.10.0", release_body="- feat: cool new feature")
+
+    result = updater.check_for_update(show_summary=True)
+
+    assert result is not None
+    assert "cool new feature" in result
+    assert "📋" in result
+
+
+def test_check_for_update_without_summary_does_not_include_body(monkeypatch, tmp_path):
+    monkeypatch.setattr(updater, "_CACHE_DIR", tmp_path)
+    monkeypatch.setattr(updater, "pkg_version", lambda _name: "0.9.0")
+    monkeypatch.setattr(updater, "get_latest_version", lambda: "0.10.0")
+    updater._write_version_cache("0.10.0", release_body="- feat: cool new feature")
+
+    result = updater.check_for_update(show_summary=False)
+
+    assert result is not None
+    assert "cool new feature" not in result
+
+
+def test_check_for_update_summary_missing_body_still_shows_banner(
+    monkeypatch, tmp_path
+):
+    monkeypatch.setattr(updater, "_CACHE_DIR", tmp_path)
+    monkeypatch.setattr(updater, "pkg_version", lambda _name: "0.9.0")
+    monkeypatch.setattr(updater, "get_latest_version", lambda: "0.10.0")
+    updater._write_version_cache("0.10.0")  # no body
+
+    result = updater.check_for_update(show_summary=True)
+
+    assert result is not None
+    assert "fresh breakfast" in result
+    assert "📋" not in result
+
+
+def test_get_latest_version_stores_release_body(monkeypatch, tmp_path):
+    monkeypatch.setattr(updater, "_CACHE_DIR", tmp_path)
+
+    class FakeResp:
+        status_code = 200
+
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return {"tag_name": "v2.0.0", "body": "- feat: new thing"}
+
+    monkeypatch.setattr(updater.requests, "get", lambda *a, **kw: FakeResp())
+
+    updater.get_latest_version()
+    assert updater._read_cached_release_body() == "- feat: new thing"
+
+
 def test_get_cache_dir_xdg(tmp_path, monkeypatch):
     custom_path = tmp_path / "custom-cache"
     monkeypatch.setenv("XDG_CACHE_HOME", str(custom_path))

--- a/uv.lock
+++ b/uv.lock
@@ -41,7 +41,7 @@ wheels = [
 
 [[package]]
 name = "breakfast"
-version = "0.57.6"
+version = "0.59.6"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

This branch stacks 10 open PRs that all had merge conflicts with each other and with main, resolved in the correct order. A README update and working-style rules for agent instruction files sit on top.

## Merge order

Each commit in this branch corresponds to one PR. Merge them in this order:

1. **#279** `issue-99_integration-tests` — end-to-end integration tests (new files only)
2. **#275** `issue-101_autofit-optimization` — replace tabulate call in `_table_width`
3. **#267** `issue-37_label-filters` — `--label` / `--exclude-label` filters
4. **#268** `issue-38_reviewer-filters` — `--filter-reviewer` filter
5. **#270** `issue-43_stale-inactive-filters` — `--filter-stale` / `--filter-inactive` filters
6. **#272** `issue-39_pr-state-fetch` — `--fetch-state` option
7. **#274** `issue-183_template-format` — `--format template` / `--template`
8. **#276** `issue-103_per-repo-cache` — per-repo PR cache layer
9. **#277** `issue-79_update-summary` — release summary in update notifications
10. **#278** `issue-196_pluggable-calendars` — pluggable seasonal calendar system
11. **README** — cover all new options from the above PRs
12. **Working style** — codify collaboration rules in all four agent instruction files

## Notes

- All conflicts were resolved by keeping both sides' changes throughout
- 456 tests pass at the tip of this branch
- The sort PR (#271, `claude/sorting-pr-conflicts-eSCUu`) is separate and should be merged after this stack lands

https://claude.ai/code/session_01KswFXqVXiZGKhNBeVyLPrg

---
_Generated by [Claude Code](https://claude.ai/code/session_01KswFXqVXiZGKhNBeVyLPrg)_