### PR TITLE
#301: Prevent table auto-fit row wrapping with emoji status columns

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
   "click",
   "requests",
   "tabulate",
+  "wcwidth",
 ]
 
 [project.scripts]

--- a/src/breakfast/cli.py
+++ b/src/breakfast/cli.py
@@ -11,6 +11,7 @@ from urllib.parse import urlparse
 
 import click
 import requests
+import wcwidth
 from tabulate import tabulate
 
 from .api import (
@@ -92,8 +93,6 @@ def _strip_ansi(s):
 
 def _visible_width(s):
     """Return the terminal display width of a string, ignoring ANSI escape codes."""
-    import wcwidth
-
     plain = _strip_ansi(s)
     w = wcwidth.wcswidth(plain)
     return w if w >= 0 else len(plain)

--- a/src/breakfast/cli.py
+++ b/src/breakfast/cli.py
@@ -90,6 +90,15 @@ def _strip_ansi(s):
     return _ANSI_RE.sub("", str(s))
 
 
+def _visible_width(s):
+    """Return the terminal display width of a string, ignoring ANSI escape codes."""
+    import wcwidth
+
+    plain = _strip_ansi(s)
+    w = wcwidth.wcswidth(plain)
+    return w if w >= 0 else len(plain)
+
+
 def _osc8_to_markdown(s):
     """Convert OSC 8 hyperlinks and ANSI codes in *s* to Markdown link syntax."""
     result = _OSC8_ANY_RE.sub(
@@ -109,7 +118,7 @@ def _truncate_formatted_text(value, limit):
         The truncated value with any existing formatting preserved.
     """
     plain = _strip_ansi(value)
-    if len(plain) <= limit:
+    if _visible_width(plain) <= limit:
         return value
 
     truncated = plain[: limit - 1] + "…"
@@ -155,10 +164,10 @@ def _table_width(rows):
     total = 1 + max(4, idx_width + 2) + 1
     for h in headers:
         cell_max = max(
-            (len(_strip_ansi(str(row.get(h, "")))) for row in rows),
+            (_visible_width(str(row.get(h, ""))) for row in rows),
             default=0,
         )
-        total += max(len(h) + 4, cell_max + 2) + 1
+        total += max(_visible_width(h) + 4, cell_max + 2) + 1
     return total
 
 
@@ -181,7 +190,7 @@ def _truncate_col(pr_data, key, terminal_width, min_len=8):
         excess = _table_width(pr_data) - terminal_width
         if excess <= 0:
             return pr_data
-        current_max = max(len(_strip_ansi(row[key])) for row in pr_data)
+        current_max = max(_visible_width(row[key]) for row in pr_data)
         limit = max(current_max - excess, min_len)
 
     if limit < min_len:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3883,3 +3883,38 @@ def test_cli_duplicate_org_fetches_prevented(monkeypatch):
     assert len(calls) == 2
     assert calls[0] == ("org-a", ["filter-one", "filter-two"])
     assert calls[1] == ("org-b", ["global-f", "filter-three"])
+
+
+def test_table_width_auto_fit_emoji_regression():
+    """Verify that _table_width accounts for double-width emojis correctly
+
+    so that auto-fit does not underestimate table display width.
+    """
+    rows = [
+        {
+            "Repo": "short",
+            "PR Title": "short title",
+            "Author": "alice",
+            "Checks": "✅ pass",
+            "Approved": "⏳ pending",
+            "Mergeable?": "❌ (dirty)",
+        }
+    ]
+    # Estimate width using _table_width
+    estimated_width = cli._table_width(rows)
+
+    # Actual width from tabulate (with wcwidth installed)
+    from tabulate import tabulate
+
+    actual_width = len(
+        tabulate(
+            rows,
+            headers="keys",
+            showindex="always",
+            tablefmt="outline",
+            disable_numparse=True,
+        ).splitlines()[0]
+    )
+
+    # They should match exactly, preventing line wrap double spacing
+    assert estimated_width == actual_width

--- a/uv.lock
+++ b/uv.lock
@@ -41,12 +41,13 @@ wheels = [
 
 [[package]]
 name = "breakfast"
-version = "0.65.0"
+version = "0.66.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },
     { name = "requests" },
     { name = "tabulate" },
+    { name = "wcwidth" },
 ]
 
 [package.optional-dependencies]
@@ -88,6 +89,7 @@ requires-dist = [
     { name = "shiv", marker = "extra == 'build'" },
     { name = "shiv", marker = "extra == 'dev'" },
     { name = "tabulate" },
+    { name = "wcwidth" },
 ]
 provides-extras = ["test", "lint", "build", "dev"]
 
@@ -429,4 +431,13 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+]
+
+[[package]]
+name = "wcwidth"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2c/ee/afaf0f85a9a18fe47a67f1e4422ed6cf1fe642f0ae0a2f81166231303c52/wcwidth-0.7.0.tar.gz", hash = "sha256:90e3a7ea092341c44b99562e75d09e4d5160fe7a3974c6fb842a101a95e7eed0", size = 182132, upload-time = "2026-05-02T16:04:12.653Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/52/e465037f5375f43533d1a80b6923955201596a99142ed524d77b571a1418/wcwidth-0.7.0-py3-none-any.whl", hash = "sha256:5d69154c429a82910e241c738cd0e2976fac8a2dd47a1a805f4afed1c0f136f2", size = 110825, upload-time = "2026-05-02T16:04:11.033Z" },
 ]


### PR DESCRIPTION
Closes #301. This PR introduces `wcwidth` to correctly compute the visual display width of emoji status columns (such as checkmarks, warning icons, etc.) in the terminal. This prevents the `_table_width` function from underestimating table width, which was causing terminal rows to double-wrap and look double-spaced.