### PR TITLE
#304: Update README and add Working Style to agent instruction files

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -82,3 +82,9 @@ When updating project rules, update **all four files** to keep them consistent.
 - If CLI options, features, or user-visible behaviors change, you MUST update the relevant manual pages in `docs/manual/` (`options.md`, `usage.md`, etc.).
 - If the project structure or developer workflow changes, you MUST update `CONTRIBUTING.md`.
 - These updates should be in the same PR.
+
+## Working Style
+- **Narrate intent before acting.** If a task would take the work beyond the literal ask, say so first and wait for confirmation. Never expand scope silently.
+- **Surface, don't solve.** If related work is spotted (missing docs, adjacent bugs, cleanup opportunities), flag it as an observation and ask before doing anything. "I notice X — want me to address that too?"
+- **Ask when scope is ambiguous.** When an instruction could mean a narrow or a broad thing, ask which is wanted before writing a single line of code or docs.
+- **Pause at natural checkpoints on large changes.** For multi-step or multi-file work, describe the plan and confirm before committing and pushing. That way the user can redirect early rather than unpicking completed work.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -100,3 +100,9 @@ When updating project rules, update **all four files** to keep them consistent.
 - **When adding, changing, or removing CLI options, features, or user-visible behaviour, you MUST update the relevant manual pages in `docs/manual/` in the same commit or PR.** This includes `options.md`, `usage.md`, `output-formats.md`, and `troubleshooting.md` as appropriate.
 - **If the project structure or developer workflow changes, you MUST update `CONTRIBUTING.md`.**
 - When adding a new feature design, create a document in `docs/design/` and add it to the table in `docs/design/README.md`.
+
+## Working Style
+- **Narrate intent before acting.** If a task would take the work beyond the literal ask, say so first and wait for confirmation. Never expand scope silently.
+- **Surface, don't solve.** If related work is spotted (missing docs, adjacent bugs, cleanup opportunities), flag it as an observation and ask before doing anything. "I notice X — want me to address that too?"
+- **Ask when scope is ambiguous.** When an instruction could mean a narrow or a broad thing, ask which is wanted before writing a single line of code or docs.
+- **Pause at natural checkpoints on large changes.** For multi-step or multi-file work, describe the plan and confirm before committing and pushing. That way the user can redirect early rather than unpicking completed work.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,3 +100,9 @@ When updating project rules, update **all four files** to keep them consistent.
 - **When adding, changing, or removing CLI options, features, or user-visible behaviour, you MUST update the relevant manual pages in `docs/manual/` in the same commit or PR.** This includes `options.md`, `usage.md`, `output-formats.md`, and `troubleshooting.md` as appropriate.
 - **If the project structure or developer workflow changes, you MUST update `CONTRIBUTING.md`.**
 - When adding a new feature design, create a document in `docs/design/` and add it to the table in `docs/design/README.md`.
+
+## Working Style
+- **Narrate intent before acting.** If a task would take the work beyond the literal ask, say so first and wait for confirmation. Never expand scope silently.
+- **Surface, don't solve.** If related work is spotted (missing docs, adjacent bugs, cleanup opportunities), flag it as an observation and ask before doing anything. "I notice X — want me to address that too?"
+- **Ask when scope is ambiguous.** When an instruction could mean a narrow or a broad thing, ask which is wanted before writing a single line of code or docs.
+- **Pause at natural checkpoints on large changes.** For multi-step or multi-file work, describe the plan and confirm before committing and pushing. That way the user can redirect early rather than unpicking completed work.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -47,3 +47,9 @@ When updating project rules, update **all four files** to keep them consistent.
 - **Testing with Cache:** Since caching is implemented, all manual testing must be performed both *with* the cache enabled and *without* the cache (e.g., clearing the cache or disabling it).
 - **Real App Testing:** Always perform a real, end-to-end test of the CLI application in the terminal, not just unit tests.
 - **Documentation:** If CLI options, features, or user-visible behaviors change, you MUST update the relevant manual pages in `docs/manual/` (`options.md`, `usage.md`, etc.). If the project structure or developer workflow changes, you MUST update `CONTRIBUTING.md`. These updates should be in the same PR.
+
+## Working Style
+- **Narrate intent before acting.** If a task would take the work beyond the literal ask, say so first and wait for confirmation. Never expand scope silently.
+- **Surface, don't solve.** If related work is spotted (missing docs, adjacent bugs, cleanup opportunities), flag it as an observation and ask before doing anything. "I notice X — want me to address that too?"
+- **Ask when scope is ambiguous.** When an instruction could mean a narrow or a broad thing, ask which is wanted before writing a single line of code or docs.
+- **Pause at natural checkpoints on large changes.** For multi-step or multi-file work, describe the plan and confirm before committing and pushing. That way the user can redirect early rather than unpicking completed work.

--- a/README.md
+++ b/README.md
@@ -27,17 +27,29 @@ breakfast -o my-org -r my-app
 breakfast -o my-org -r my-app
 breakfast -o my-org -o another-org -r platform
 breakfast -o my-org:api -o another-org:platform
-breakfast -o my-org:api -o my-org:platform
 breakfast -o my-org -r my-app --ignore-author dependabot[bot] --ignore-author renovate[bot]
 breakfast -o my-org -r my-app --mine-only
 breakfast -o my-org -r my-app --age
 breakfast -o my-org -r my-app --checks
 breakfast -o my-org -r my-app --approvals
 breakfast -o my-org -r my-app --checks --status-style ascii
+breakfast -o my-org -r my-app --fetch-state all
 breakfast -o my-org -r my-app --filter-state open
 breakfast -o my-org -r my-app --filter-check fail --filter-check pending
 breakfast -o my-org -r my-app --filter-approval approved
-breakfast -o my-org -r my-app --json
+breakfast -o my-org -r my-app --label bug --label enhancement
+breakfast -o my-org -r my-app --exclude-label wip
+breakfast -o my-org -r my-app --filter-reviewer alice
+breakfast -o my-org -r my-app --filter-stale 30
+breakfast -o my-org -r my-app --filter-inactive 7
+breakfast -o my-org -r my-app --search "hotfix"
+breakfast -o my-org -r my-app --sort age
+breakfast -o my-org -r my-app --sort comments --reverse
+breakfast -o my-org -r my-app --format json
+breakfast -o my-org -r my-app --format markdown
+breakfast -o my-org -r my-app --format template --template "{repo}: {title} ({url})"
+breakfast -o my-org -r my-app --summarise-user-prs
+breakfast -o my-org -r my-app --summarise-repo-prs
 breakfast -o my-org -r my-app --cache
 breakfast -o my-org -r my-app --cache --refresh
 breakfast -o my-org -r my-app --cache --refresh-prs
@@ -50,23 +62,48 @@ breakfast -o my-org -r my-app --legendary-only
 ### Display
 
 - `--organization`, `-o`: One or multiple organizations to query for PRs (repeatable). Supports scoped filters like `org:repo`.
-- `--repo-filter`, `-r`: Filter repos by name substring.
+- `--repo-filter`, `-r`: Filter repos by name substring or glob pattern. Repeatable.
 - `--age`: Add an age column (days since creation).
 - `--checks`: Add a checks column showing CI status (✅ pass / ❌ fail / ⚠️ pending).
 - `--approvals`: Add an approvals column showing review status (✅ approved / ✅ 1/2 approvals / ❌ changes / ⏳ pending).
+- `--head-branch`: Add a head branch column.
+- `--base-branch`: Add a base branch column.
 - `--status-style`: Render status cells with `emoji` (default) or `ascii` labels.
-- `--json`: Output as JSON instead of a table.
 - `--limit`: Cap the number of PRs shown.
 - `--max-title-length`: Truncate PR titles to this many characters.
+
+### Output format
+
+- `--format`: Output format: `table` (default), `json`, `markdown`, `csv`, `template`.
+- `--template`: Format string for `--format template`. Available fields: `{repo}`, `{title}`, `{author}`, `{url}`, `{state}`, `{number}`, `{created_at}`, `{updated_at}`, `{additions}`, `{deletions}`, `{changed_files}`, `{commits}`, `{review_comments}`, `{labels}`, `{requested_reviewers}`.
 
 ### Filtering
 
 - `--ignore-author`: Exclude PRs by author (case-insensitive, repeatable).
 - `--no-ignore-author`: Clear `ignore-author` config defaults for this run.
 - `--mine-only`: Show only your own PRs.
-- `--filter-state`: Only show PRs with this state (`open`, `closed`). Repeatable.
+- `--no-drafts`: Hide draft PRs.
+- `--drafts-only`: Show only draft PRs.
+- `--fetch-state`: Which PR states to fetch from GitHub: `open` (default), `closed`, `merged`, `all`.
+- `--filter-state`: Only show PRs with this state (`open`, `closed`, `draft`). Repeatable.
 - `--filter-check`: Only show PRs with this CI result (`pass`, `fail`, `pending`, `none`). Repeatable. Implies `--checks`.
 - `--filter-approval`: Only show PRs with this review status (`approved`, `pending`, `changes`). Repeatable.
+- `--label`: Only show PRs that have this label (case-insensitive, repeatable — OR logic).
+- `--exclude-label`: Hide PRs that have this label (case-insensitive, repeatable).
+- `--filter-reviewer`: Only show PRs with this user as a requested reviewer (case-insensitive, repeatable — OR logic).
+- `--filter-stale`: Only show PRs older than N days.
+- `--filter-inactive`: Only show PRs not updated in the last N days.
+- `--search`, `-s`: Filter PRs by title (plain string or regex, case-insensitive).
+
+### Sorting
+
+- `--sort`: Sort by field: `repo` (default), `age`, `updated`, `author`, `comments`, `reviews`.
+- `--reverse`: Reverse the sort order.
+
+### Summary views
+
+- `--summarise-user-prs`: Print a per-author PR count summary instead of the full table.
+- `--summarise-repo-prs`: Print a per-repo PR count summary instead of the full table.
 
 ### Caching
 


### PR DESCRIPTION
## Summary

- README was significantly out of date — still referenced the deprecated \`--json\` alias and missing all features added since v0.59
- Adds usage examples and options entries for: \`--label\`, \`--exclude-label\`, \`--filter-reviewer\`, \`--filter-stale\`, \`--filter-inactive\`, \`--fetch-state\`, \`--search\`, \`--format template/json/markdown\`, \`--sort\`, \`--reverse\`, \`--summarise-user-prs\`, \`--summarise-repo-prs\`, \`--no-drafts\`, \`--head-branch\`, \`--base-branch\`
- Adds a Working Style section to all four agent instruction files (CLAUDE.md, AGENTS.md, GEMINI.md, copilot-instructions.md), rescued from the superseded stack PR #299

## Test plan

- [x] \`make lint\` passes (markdownlint clean)
- [x] \`make test\` passes (444 tests)
- [x] README examples match actual CLI flags

Closes #304

🤖 Generated with [Claude Code](https://claude.com/claude-code)