### PR TITLE
#313: Color PR number column with calendar color

### DIFF
--- a/.claude/commands/finish-issue.md
+++ b/.claude/commands/finish-issue.md
@@ -1,0 +1,1 @@
+Read and follow the instructions in .agents/skills/finish-issue/SKILL.md.

--- a/.claude/commands/monitor-pr.md
+++ b/.claude/commands/monitor-pr.md
@@ -1,0 +1,1 @@
+Read and follow the instructions in .agents/skills/monitor-pr/SKILL.md.

--- a/.claude/commands/raise-issue.md
+++ b/.claude/commands/raise-issue.md
@@ -1,0 +1,1 @@
+Read and follow the instructions in .agents/skills/raise-issue/SKILL.md.

--- a/.claude/commands/raise-pr.md
+++ b/.claude/commands/raise-pr.md
@@ -1,0 +1,1 @@
+Read and follow the instructions in .agents/skills/raise-pr/SKILL.md.

--- a/.claude/commands/start-issue.md
+++ b/.claude/commands/start-issue.md
@@ -1,0 +1,3 @@
+Read and follow the instructions in .agents/skills/start-issue/SKILL.md.
+
+Issue number: $ARGUMENTS

--- a/src/breakfast/cli.py
+++ b/src/breakfast/cli.py
@@ -1963,7 +1963,8 @@ def breakfast(
             )
         return
 
-    for pr_detail in pr_details:
+    colored_indices = []
+    for idx, pr_detail in enumerate(pr_details):
         adds = click.style(
             "+" + str(pr_detail.get("additions", 0)), fg="green", bold=True
         )
@@ -2047,6 +2048,7 @@ def breakfast(
         row["Link"] = _seasonal_colour_link(
             pr_detail["html_url"], f"PR-{pr_detail['number']}"
         )
+        colored_indices.append(_seasonal_colour(str(idx)))
         pr_data.append(row)
 
     # Apply explicit title truncation, then auto-fit to terminal if interactive
@@ -2066,7 +2068,7 @@ def breakfast(
         tabulate(
             pr_data,
             headers="keys",
-            showindex="always",
+            showindex=colored_indices,
             tablefmt="outline",
             disable_numparse=True,
         ),

--- a/src/breakfast/cli.py
+++ b/src/breakfast/cli.py
@@ -1133,7 +1133,7 @@ def breakfast(
     seasonal_calendar = cfg.get("seasonal-calendar", "western")
     if not seasonal_colours:
         seasonal_calendar = "off"
-    colour_index = cfg.get("colour-index", True)
+    colour_index = cfg.get("colour-index", False)
     summarise_user_prs = summarise_user_prs or cfg.get("summarise-user-prs", False)
     summarise_repo_prs = summarise_repo_prs or cfg.get("summarise-repo-prs", False)
     show_update_summary = cfg.get("update-summary", False)

--- a/src/breakfast/cli.py
+++ b/src/breakfast/cli.py
@@ -1133,6 +1133,7 @@ def breakfast(
     seasonal_calendar = cfg.get("seasonal-calendar", "western")
     if not seasonal_colours:
         seasonal_calendar = "off"
+    colour_index = cfg.get("colour-index", True)
     summarise_user_prs = summarise_user_prs or cfg.get("summarise-user-prs", False)
     summarise_repo_prs = summarise_repo_prs or cfg.get("summarise-repo-prs", False)
     show_update_summary = cfg.get("update-summary", False)
@@ -2048,7 +2049,7 @@ def breakfast(
         row["Link"] = _seasonal_colour_link(
             pr_detail["html_url"], f"PR-{pr_detail['number']}"
         )
-        colored_indices.append(_seasonal_colour(str(idx)))
+        colored_indices.append(_seasonal_colour(str(idx)) if colour_index else str(idx))
         pr_data.append(row)
 
     # Apply explicit title truncation, then auto-fit to terminal if interactive

--- a/src/breakfast/config.py
+++ b/src/breakfast/config.py
@@ -154,6 +154,9 @@ _DEFAULT_CONFIG_CONTENT = """\
 # Note: seasonal-colours = false is equivalent to seasonal-calendar = "off"
 # seasonal-calendar = "western"
 
+# Colour the row-index column with the seasonal palette.
+# colour-index = true
+
 
 # -----------------------------------------------------------------------------
 # Legendary PRs ⚔️

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3991,7 +3991,27 @@ def test_table_width_auto_fit_emoji_regression():
     assert estimated_width == actual_width
 
 
-def test_index_column_is_seasonally_colored(monkeypatch):
+_COLOUR_INDEX_PR = {
+    "base": {"repo": {"name": "repo", "owner": {"login": "org"}}},
+    "mergeable": True,
+    "mergeable_state": "clean",
+    "additions": 5,
+    "deletions": 2,
+    "title": "Test PR",
+    "user": {"login": "alice"},
+    "number": 1,
+    "html_url": "https://github.com/org/repo/pull/1",
+    "state": "open",
+    "id": 123,
+    "review_comments": 0,
+    "commits": 1,
+    "changed_files": 1,
+    "created_at": "2026-06-01T12:00:00Z",
+    "updated_at": "2026-06-01T12:00:00Z",
+}
+
+
+def _setup_colour_index_mocks(monkeypatch):
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
     monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
@@ -4000,82 +4020,24 @@ def test_index_column_is_seasonally_colored(monkeypatch):
         "get_github_prs",
         lambda _org, _repo_filter, _s="open": ["https://github.com/org/repo/pull/1"],
     )
-    monkeypatch.setattr(
-        api,
-        "make_github_api_request",
-        lambda _path: {
-            "base": {"repo": {"name": "repo", "owner": {"login": "org"}}},
-            "mergeable": True,
-            "mergeable_state": "clean",
-            "additions": 5,
-            "deletions": 2,
-            "title": "Test PR",
-            "user": {"login": "alice"},
-            "number": 1,
-            "html_url": "https://github.com/org/repo/pull/1",
-            "state": "open",
-            "id": 123,
-            "review_comments": 0,
-            "commits": 1,
-            "changed_files": 1,
-            "created_at": "2026-06-01T12:00:00Z",
-            "updated_at": "2026-06-01T12:00:00Z",
-        },
-    )
-    # Force stdout to be treated as tty and colour to be enabled
+    monkeypatch.setattr(api, "make_github_api_request", lambda _path: _COLOUR_INDEX_PR)
     monkeypatch.setattr(cli, "_stdout_is_tty", lambda: True)
 
-    runner = CliRunner()
-    # Run with default western calendar (which should be active and color the output)
-    result = runner.invoke(cli.breakfast, ["-o", "org", "-r", "repo"])
 
+def test_index_column_plain_by_default(monkeypatch):
+    _setup_colour_index_mocks(monkeypatch)
+    result = CliRunner().invoke(cli.breakfast, ["-o", "org", "-r", "repo"])
     assert result.exit_code == 0
-    # The output should contain the ANSI escape codes around the row index "0"
-    # and the colored "0" index should be present in the output
-    assert "\x1b[" in result.stdout
+    assert re.search(r"\| 0 +\|", result.stdout)
 
 
-def test_index_column_colour_disabled_by_config(monkeypatch, tmp_path):
-    monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
-    monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
-    monkeypatch.setattr(
-        cli,
-        "get_github_prs",
-        lambda _org, _repo_filter, _s="open": ["https://github.com/org/repo/pull/1"],
-    )
-    monkeypatch.setattr(
-        api,
-        "make_github_api_request",
-        lambda _path: {
-            "base": {"repo": {"name": "repo", "owner": {"login": "org"}}},
-            "mergeable": True,
-            "mergeable_state": "clean",
-            "additions": 5,
-            "deletions": 2,
-            "title": "Test PR",
-            "user": {"login": "alice"},
-            "number": 1,
-            "html_url": "https://github.com/org/repo/pull/1",
-            "state": "open",
-            "id": 123,
-            "review_comments": 0,
-            "commits": 1,
-            "changed_files": 1,
-            "created_at": "2026-06-01T12:00:00Z",
-            "updated_at": "2026-06-01T12:00:00Z",
-        },
-    )
-    monkeypatch.setattr(cli, "_stdout_is_tty", lambda: True)
-
+def test_index_column_coloured_when_enabled_by_config(monkeypatch, tmp_path):
+    _setup_colour_index_mocks(monkeypatch)
     cfg_file = tmp_path / "test.toml"
-    cfg_file.write_text("colour-index = false\n")
-
-    runner = CliRunner()
-    result = runner.invoke(
+    cfg_file.write_text("colour-index = true\n")
+    result = CliRunner().invoke(
         cli.breakfast, ["-o", "org", "-r", "repo", "--config", str(cfg_file)]
     )
-
     assert result.exit_code == 0
-    # Index "0" should be plain text — no ANSI escape codes wrapping it
-    assert re.search(r"\| 0 +\|", result.stdout)
+    # ANSI escape codes should wrap the index digit
+    assert not re.search(r"\| 0 +\|", result.stdout)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3988,3 +3988,47 @@ def test_table_width_auto_fit_emoji_regression():
 
     # They should match exactly, preventing line wrap double spacing
     assert estimated_width == actual_width
+
+
+def test_index_column_is_seasonally_colored(monkeypatch):
+    monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
+    monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
+    monkeypatch.setattr(
+        cli,
+        "get_github_prs",
+        lambda _org, _repo_filter, _s="open": ["https://github.com/org/repo/pull/1"],
+    )
+    monkeypatch.setattr(
+        api,
+        "make_github_api_request",
+        lambda _path: {
+            "base": {"repo": {"name": "repo", "owner": {"login": "org"}}},
+            "mergeable": True,
+            "mergeable_state": "clean",
+            "additions": 5,
+            "deletions": 2,
+            "title": "Test PR",
+            "user": {"login": "alice"},
+            "number": 1,
+            "html_url": "https://github.com/org/repo/pull/1",
+            "state": "open",
+            "id": 123,
+            "review_comments": 0,
+            "commits": 1,
+            "changed_files": 1,
+            "created_at": "2026-06-01T12:00:00Z",
+            "updated_at": "2026-06-01T12:00:00Z",
+        },
+    )
+    # Force stdout to be treated as tty and colour to be enabled
+    monkeypatch.setattr(cli, "_stdout_is_tty", lambda: True)
+
+    runner = CliRunner()
+    # Run with default western calendar (which should be active and color the output)
+    result = runner.invoke(cli.breakfast, ["-o", "org", "-r", "repo"])
+
+    assert result.exit_code == 0
+    # The output should contain the ANSI escape codes around the row index "0"
+    # and the colored "0" index should be present in the output
+    assert "\x1b[" in result.stdout

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,7 @@
 import csv
 import io
 import json
+import re
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timezone
 from unittest.mock import patch
@@ -4032,3 +4033,49 @@ def test_index_column_is_seasonally_colored(monkeypatch):
     # The output should contain the ANSI escape codes around the row index "0"
     # and the colored "0" index should be present in the output
     assert "\x1b[" in result.stdout
+
+
+def test_index_column_colour_disabled_by_config(monkeypatch, tmp_path):
+    monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
+    monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
+    monkeypatch.setattr(
+        cli,
+        "get_github_prs",
+        lambda _org, _repo_filter, _s="open": ["https://github.com/org/repo/pull/1"],
+    )
+    monkeypatch.setattr(
+        api,
+        "make_github_api_request",
+        lambda _path: {
+            "base": {"repo": {"name": "repo", "owner": {"login": "org"}}},
+            "mergeable": True,
+            "mergeable_state": "clean",
+            "additions": 5,
+            "deletions": 2,
+            "title": "Test PR",
+            "user": {"login": "alice"},
+            "number": 1,
+            "html_url": "https://github.com/org/repo/pull/1",
+            "state": "open",
+            "id": 123,
+            "review_comments": 0,
+            "commits": 1,
+            "changed_files": 1,
+            "created_at": "2026-06-01T12:00:00Z",
+            "updated_at": "2026-06-01T12:00:00Z",
+        },
+    )
+    monkeypatch.setattr(cli, "_stdout_is_tty", lambda: True)
+
+    cfg_file = tmp_path / "test.toml"
+    cfg_file.write_text("colour-index = false\n")
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli.breakfast, ["-o", "org", "-r", "repo", "--config", str(cfg_file)]
+    )
+
+    assert result.exit_code == 0
+    # Index "0" should be plain text — no ANSI escape codes wrapping it
+    assert re.search(r"\| 0 +\|", result.stdout)

--- a/uv.lock
+++ b/uv.lock
@@ -41,7 +41,7 @@ wheels = [
 
 [[package]]
 name = "breakfast"
-version = "0.70.0"
+version = "0.71.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

- **Seasonal index colouring (opt-in easter egg)**: The row-index column can now be coloured with the active seasonal calendar palette by setting `colour-index = true` in config. It is **off by default** to preserve the standard tabulate alignment with column headers.
- **Key Changes**:
  - `src/breakfast/cli.py`: reads `colour-index` config key (default `false`); when enabled, passes a list of seasonally-coloured index strings to `tabulate`'s `showindex` parameter instead of `"always"`.
  - `src/breakfast/config.py`: adds `colour-index = true` as a commented-out option in the default config template, tucked alongside the other seasonal easter egg keys.
  - `tests/test_cli.py`: adds `test_index_column_plain_by_default` and `test_index_column_coloured_when_enabled_by_config`; refactors shared PR fixture into `_COLOUR_INDEX_PR` and `_setup_colour_index_mocks` helper.
  - `.claude/commands/`: adds five project-level Claude Code slash commands (`/start-issue`, `/finish-issue`, `/raise-pr`, `/monitor-pr`, `/raise-issue`) that delegate to the corresponding `.agents/skills/*/SKILL.md` files.

## Test plan

- [x] `make format && make lint && make test` passes (446 tests)
- [x] `test_index_column_plain_by_default` — verifies index is uncoloured without config
- [x] `test_index_column_coloured_when_enabled_by_config` — verifies ANSI codes are absent from plain index when `colour-index = true` opts in

Closes #313

🤖 Generated with [Claude Code](https://claude.com/claude-code)