### PR TITLE
#319: Add raise-issue skill to create detailed GitHub issues

### DIFF
--- a/.agents/skills/monitor-pr/SKILL.md
+++ b/.agents/skills/monitor-pr/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: monitor-pr
+description: Monitor the CI checks status of a Pull Request on GitHub, parse logs on failure, and address any non-passing tests.
+---
+
+# Monitor PR Skill
+
+Standardized procedure to track pull request CI checks on GitHub and address any test or linting failures.
+
+## When to use this skill
+- Use this skill after raising a pull request (e.g., using `raise-pr`), or when the user requests to check, monitor, or track the CI/test status of an active PR.
+
+## How to use it
+
+### Steps
+
+1. **Check CI checks status:**
+   Use the GitHub CLI (`gh`) to retrieve the status of all active checks on the current branch:
+   ```bash
+   gh pr checks
+   ```
+
+2. **Wait for completion (if pending):**
+   If any checks are marked as `pending`:
+   - Set a one-shot wakeup timer using the `schedule` tool (e.g., set for 120 seconds with the prompt `"Check CI status for PR"`).
+   - Stop calling tools to yield back control while the timer is running.
+   - Do NOT run a shell `sleep` loop or poll continuously in a terminal process.
+
+3. **Handle successful runs:**
+   If all checks are marked as `pass` or `success`:
+   - Confirm to the user that CI has successfully completed and all tests are passing.
+   - Inform the user that the PR is ready for review and merge.
+
+4. **Diagnose and fix failures (if any check fails):**
+   If any check fails (status is `fail` or `failure`):
+   - **Identify the failing check:** Look at the name of the failing check (e.g., `test`, `lint`, `docs-lint`).
+   - **View failing logs:** Retrieve the CI run details or logs:
+     ```bash
+     gh run list --branch <current-branch> --limit 1
+     gh run view <run-id> --log-failed
+     ```
+   - **Reproduce locally:** Execute the matching local quality check target to reproduce the failure in your workspace:
+     - For test failures: `make test` (or run a specific test: `uv run pytest -k <failing_test_name>`)
+     - For lint/format failures: `make lint` or `make format`
+   - **Fix the issue:** Debug the codebase, resolve the failing tests/lint issues, and run the complete verification suite locally (`make format && make lint && make test`) to confirm the fix.
+   - **Push the fix:** Stage the modified files, commit them using conventional commits (`fix: address failing CI check`), and push them to origin (`git push`).
+   - **Resume monitoring:** Go back to Step 1 to monitor the fresh CI run.

--- a/.agents/skills/raise-issue/SKILL.md
+++ b/.agents/skills/raise-issue/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: raise-issue
+description: Raise a detailed, structured issue on GitHub. Gathers context, builds reproduction steps, expected outcomes, and acceptance criteria.
+---
+
+# Raise Issue Skill
+
+Standardized procedure to generate and raise a high-quality, deeply detailed issue on GitHub for this project.
+
+## When to use this skill
+- Use this skill when you identify a bug, a required enhancement, or a new feature that does not have an active GitHub issue yet.
+- Remember: **A GitHub issue MUST exist before any coding work begins.** Always use this skill to create the issue first.
+
+## How to use it
+
+### Steps
+
+1. **Analyze the problem or requirement:**
+   Collect all relevant details:
+   - For bugs: exact error tracebacks, terminal output, reproduction commands, and conditions.
+   - For features: the proposed feature goals, user benefit, command-line flags, configuration structures, and CLI outputs.
+
+2. **Generate a detailed, structured description:**
+   Determine whether the issue is a **Bug** or a **Feature/Enhancement**, and choose the corresponding structure.
+
+   #### Structure for Bug Issues:
+   ```markdown
+   ## Problem
+   [Detailed description of what is failing and why it is wrong/suboptimal. Include any traceback error logs here.]
+
+   ## Steps to reproduce / Reproduction
+   \`\`\`bash
+   [Exact shell command or python sequence to trigger the bug]
+   \`\`\`
+
+   ## Expected behaviour
+   [Explain what the CLI/application should ideally output or do.]
+
+   ## Actual behaviour
+   [Explain what the CLI/application is currently outputting or doing.]
+
+   ## Suspected Cause (optional)
+   [If a specific file, class, function, or recent commit is suspected, reference it here.]
+   ```
+
+   #### Structure for Feature/Enhancement Issues:
+   ```markdown
+   ## Description / Problem
+   [High-level explanation of the new feature, why it is beneficial, and what user problem it solves.]
+
+   ## Proposed Solution
+   [Explain how it should be implemented, listing CLI flags, configuration parameters, and code structure.]
+
+   ## Examples
+   \`\`\`bash
+   # Show command examples if applicable
+   breakfast -o spec --new-flag
+   \`\`\`
+
+   ## Acceptance Criteria
+   - [ ] [Feature behaves as expected under condition A]
+   - [ ] [Configuration overrides CLI values correctly]
+   - [ ] [Updated manual pages in docs/manual/ reflect changes]
+   - [ ] [make format && make lint && make test all pass]
+   ```
+
+3. **Verify the Title format:**
+   Ensure the issue title is clean and descriptive.
+   - **Important**: Do not use conventional commit prefixes (like `feat:` or `fix:`) in GitHub issue titles, as these are reserved for commits and PRs. Keep the title imperative and natural.
+   - *Example*: "Support per-org scoped repo filter with org:filter syntax"
+
+4. **Create the issue using the GitHub CLI (`gh`):**
+   Execute the `gh issue create` command using the derived title and generated body:
+   ```bash
+   gh issue create --title "<title>" --body "<body>"
+   ```
+   *(If the GitHub CLI is not authenticated or available, output the formatted title and body so the user can easily copy and paste them into the GitHub web interface).*
+
+5. **Confirm to the user:** Report the generated issue URL, issue number, and a summary of the details.

--- a/.agents/skills/raise-pr/SKILL.md
+++ b/.agents/skills/raise-pr/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: raise-pr
+description: Generate a detailed, high-depth pull request body and create a PR on GitHub. Analyzes changes and creates a highly informative PR description.
+---
+
+# Raise PR Skill
+
+Standardized procedure to generate and submit a highly detailed, high-depth pull request on GitHub for this project.
+
+## When to use this skill
+- Use this skill when you have completed work on an issue branch, run all verification checks, and are ready to create a GitHub Pull Request for the active branch.
+
+## How to use it
+
+### Steps
+
+1. **Analyze workspace changes:**
+   Review your local git changes, commit history, and test outcomes to collect all context:
+   - Identify which files were created, modified, or deleted.
+   - Collect the exact names of any new unit tests added (e.g., in `tests/test_*.py`).
+   - Identify the linked GitHub issue number from your branch name (`issue-<N>_...`).
+
+2. **Generate a detailed, high-depth PR body:**
+   Construct a pull request body matching the standard project PR template structure. Your description must be rich and thorough (avoiding generic or one-sentence summaries).
+
+   #### Template Format:
+   ```markdown
+   ## Summary
+
+   - **[Brief feature description]**: [Explain the high-level intent].
+   - **Key Changes**:
+     - Detail the specific classes, functions, or logic flows modified (e.g., in `src/breakfast/`).
+     - List any new configuration keys or command-line arguments introduced.
+     - List new files, directories, or assets added to the codebase.
+   - **Abstractions & Design Decisions**: Explain any architectural or design patterns utilized (e.g., modular directory structures, custom index iterables).
+
+   ## Test plan
+
+   - [x] `make format && make lint && make test` passes (verify all checks are clean).
+   - [x] **[Specific unit tests run or added]**:
+     - `test_func_a` — verifies [intent].
+     - `test_func_b` — verifies [intent].
+   - [x] **Manual Verification / Smoke Test**:
+     - Verify CLI execution (e.g., `uv run breakfast --version` runs cleanly).
+     - Run any targeted CLI configurations to confirm visual correctness.
+
+   Closes #<issue-number>
+
+   🤖 Prepared by [Antigravity](https://github.com/google-deepmind)
+   ```
+
+3. **Verify the PR Title format:**
+   Ensure the Pull Request title matches the mandatory convention:
+   `#<issue-number>: <description>`
+   - *Example*: `#313: Color PR number column with calendar color`
+
+4. **Create the PR using the GitHub CLI (`gh`):**
+   Execute the `gh pr create` command using the derived title and generated body:
+   ```bash
+   gh pr create --title "#<issue-number>: <short-description>" --body "<generated-body-content>"
+   ```
+   *(If the GitHub CLI is not authenticated or available, output the formatted title and body so the user can easily copy and paste them into the GitHub web interface).*
+
+5. **Confirm to the user:** Report the generated PR URL and a summary of the details submitted.

--- a/.agents/skills/raise-pr/SKILL.md
+++ b/.agents/skills/raise-pr/SKILL.md
@@ -46,7 +46,7 @@ Standardized procedure to generate and submit a highly detailed, high-depth pull
 
    Closes #<issue-number>
 
-   🤖 Prepared by [Antigravity](https://github.com/google-deepmind)
+   [Agent signature: e.g., 🤖 Prepared by [Antigravity](https://github.com/google-deepmind), 🤖 Generated with [Claude Code](https://claude.com/claude-code), 🥐 Prepared by [Gemini](https://deepmind.google/technologies/gemini/), etc., matching your own identity]
    ```
 
 3. **Verify the PR Title format:**

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -35,6 +35,7 @@ This repository provides standardized automated workflows for managing issues. A
 - **Start work on an issue:** Follow the steps defined in [.agents/skills/start-issue/SKILL.md](.agents/skills/start-issue/SKILL.md).
 - **Finish work on an issue:** Follow the steps defined in [.agents/skills/finish-issue/SKILL.md](.agents/skills/finish-issue/SKILL.md).
 - **Raise a Pull Request:** Follow the steps defined in [.agents/skills/raise-pr/SKILL.md](.agents/skills/raise-pr/SKILL.md).
+- **Monitor Pull Request CI:** Follow the steps defined in [.agents/skills/monitor-pr/SKILL.md](.agents/skills/monitor-pr/SKILL.md).
 
 ## Tooling & Environment
 - **Python:** >= 3.11

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -34,6 +34,7 @@ When updating project rules, update **all four files** to keep them consistent.
 This repository provides standardized automated workflows for managing issues. All agents must refer to and execute these exact steps:
 - **Start work on an issue:** Follow the steps defined in [.agents/skills/start-issue/SKILL.md](.agents/skills/start-issue/SKILL.md).
 - **Finish work on an issue:** Follow the steps defined in [.agents/skills/finish-issue/SKILL.md](.agents/skills/finish-issue/SKILL.md).
+- **Raise a Pull Request:** Follow the steps defined in [.agents/skills/raise-pr/SKILL.md](.agents/skills/raise-pr/SKILL.md).
 
 ## Tooling & Environment
 - **Python:** >= 3.11

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -36,6 +36,7 @@ This repository provides standardized automated workflows for managing issues. A
 - **Finish work on an issue:** Follow the steps defined in [.agents/skills/finish-issue/SKILL.md](.agents/skills/finish-issue/SKILL.md).
 - **Raise a Pull Request:** Follow the steps defined in [.agents/skills/raise-pr/SKILL.md](.agents/skills/raise-pr/SKILL.md).
 - **Monitor Pull Request CI:** Follow the steps defined in [.agents/skills/monitor-pr/SKILL.md](.agents/skills/monitor-pr/SKILL.md).
+- **Raise a new issue:** Follow the steps defined in [.agents/skills/raise-issue/SKILL.md](.agents/skills/raise-issue/SKILL.md).
 
 ## Tooling & Environment
 - **Python:** >= 3.11

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,6 +62,7 @@ This repository provides standardized automated workflows for managing issues. A
 - **Start work on an issue:** Follow the steps defined in [.agents/skills/start-issue/SKILL.md](.agents/skills/start-issue/SKILL.md).
 - **Finish work on an issue:** Follow the steps defined in [.agents/skills/finish-issue/SKILL.md](.agents/skills/finish-issue/SKILL.md).
 - **Raise a Pull Request:** Follow the steps defined in [.agents/skills/raise-pr/SKILL.md](.agents/skills/raise-pr/SKILL.md).
+- **Monitor Pull Request CI:** Follow the steps defined in [.agents/skills/monitor-pr/SKILL.md](.agents/skills/monitor-pr/SKILL.md).
 
 ## Commit Messages
 - Use Conventional Commits (e.g., `feat: ...`, `fix: ...`, `chore: ...`, `docs: ...`, `refactor: ...`, `test: ...`, `ci: ...`).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,6 +63,7 @@ This repository provides standardized automated workflows for managing issues. A
 - **Finish work on an issue:** Follow the steps defined in [.agents/skills/finish-issue/SKILL.md](.agents/skills/finish-issue/SKILL.md).
 - **Raise a Pull Request:** Follow the steps defined in [.agents/skills/raise-pr/SKILL.md](.agents/skills/raise-pr/SKILL.md).
 - **Monitor Pull Request CI:** Follow the steps defined in [.agents/skills/monitor-pr/SKILL.md](.agents/skills/monitor-pr/SKILL.md).
+- **Raise a new issue:** Follow the steps defined in [.agents/skills/raise-issue/SKILL.md](.agents/skills/raise-issue/SKILL.md).
 
 ## Commit Messages
 - Use Conventional Commits (e.g., `feat: ...`, `fix: ...`, `chore: ...`, `docs: ...`, `refactor: ...`, `test: ...`, `ci: ...`).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,6 +61,7 @@ When updating project rules, update **all four files** to keep them consistent.
 This repository provides standardized automated workflows for managing issues. All agents must refer to and execute these exact steps:
 - **Start work on an issue:** Follow the steps defined in [.agents/skills/start-issue/SKILL.md](.agents/skills/start-issue/SKILL.md).
 - **Finish work on an issue:** Follow the steps defined in [.agents/skills/finish-issue/SKILL.md](.agents/skills/finish-issue/SKILL.md).
+- **Raise a Pull Request:** Follow the steps defined in [.agents/skills/raise-pr/SKILL.md](.agents/skills/raise-pr/SKILL.md).
 
 ## Commit Messages
 - Use Conventional Commits (e.g., `feat: ...`, `fix: ...`, `chore: ...`, `docs: ...`, `refactor: ...`, `test: ...`, `ci: ...`).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,6 +62,7 @@ This repository provides standardized automated workflows for managing issues. A
 - **Start work on an issue:** Follow the steps defined in [.agents/skills/start-issue/SKILL.md](.agents/skills/start-issue/SKILL.md).
 - **Finish work on an issue:** Follow the steps defined in [.agents/skills/finish-issue/SKILL.md](.agents/skills/finish-issue/SKILL.md).
 - **Raise a Pull Request:** Follow the steps defined in [.agents/skills/raise-pr/SKILL.md](.agents/skills/raise-pr/SKILL.md).
+- **Monitor Pull Request CI:** Follow the steps defined in [.agents/skills/monitor-pr/SKILL.md](.agents/skills/monitor-pr/SKILL.md).
 
 ## Commit Messages
 - Use Conventional Commits (e.g., `feat: ...`, `fix: ...`, `chore: ...`, `docs: ...`, `refactor: ...`, `test: ...`, `ci: ...`).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,6 +63,7 @@ This repository provides standardized automated workflows for managing issues. A
 - **Finish work on an issue:** Follow the steps defined in [.agents/skills/finish-issue/SKILL.md](.agents/skills/finish-issue/SKILL.md).
 - **Raise a Pull Request:** Follow the steps defined in [.agents/skills/raise-pr/SKILL.md](.agents/skills/raise-pr/SKILL.md).
 - **Monitor Pull Request CI:** Follow the steps defined in [.agents/skills/monitor-pr/SKILL.md](.agents/skills/monitor-pr/SKILL.md).
+- **Raise a new issue:** Follow the steps defined in [.agents/skills/raise-issue/SKILL.md](.agents/skills/raise-issue/SKILL.md).
 
 ## Commit Messages
 - Use Conventional Commits (e.g., `feat: ...`, `fix: ...`, `chore: ...`, `docs: ...`, `refactor: ...`, `test: ...`, `ci: ...`).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,6 +61,7 @@ When updating project rules, update **all four files** to keep them consistent.
 This repository provides standardized automated workflows for managing issues. All agents must refer to and execute these exact steps:
 - **Start work on an issue:** Follow the steps defined in [.agents/skills/start-issue/SKILL.md](.agents/skills/start-issue/SKILL.md).
 - **Finish work on an issue:** Follow the steps defined in [.agents/skills/finish-issue/SKILL.md](.agents/skills/finish-issue/SKILL.md).
+- **Raise a Pull Request:** Follow the steps defined in [.agents/skills/raise-pr/SKILL.md](.agents/skills/raise-pr/SKILL.md).
 
 ## Commit Messages
 - Use Conventional Commits (e.g., `feat: ...`, `fix: ...`, `chore: ...`, `docs: ...`, `refactor: ...`, `test: ...`, `ci: ...`).

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -29,6 +29,7 @@ When updating project rules, update **all four files** to keep them consistent.
 This repository provides standardized automated workflows for managing issues. All agents must refer to and execute these exact steps:
 - **Start work on an issue:** Follow the steps defined in [.agents/skills/start-issue/SKILL.md](.agents/skills/start-issue/SKILL.md).
 - **Finish work on an issue:** Follow the steps defined in [.agents/skills/finish-issue/SKILL.md](.agents/skills/finish-issue/SKILL.md).
+- **Raise a Pull Request:** Follow the steps defined in [.agents/skills/raise-pr/SKILL.md](.agents/skills/raise-pr/SKILL.md).
 
 ## Tooling & Environment
 - **Python:** >= 3.11

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -30,6 +30,7 @@ This repository provides standardized automated workflows for managing issues. A
 - **Start work on an issue:** Follow the steps defined in [.agents/skills/start-issue/SKILL.md](.agents/skills/start-issue/SKILL.md).
 - **Finish work on an issue:** Follow the steps defined in [.agents/skills/finish-issue/SKILL.md](.agents/skills/finish-issue/SKILL.md).
 - **Raise a Pull Request:** Follow the steps defined in [.agents/skills/raise-pr/SKILL.md](.agents/skills/raise-pr/SKILL.md).
+- **Monitor Pull Request CI:** Follow the steps defined in [.agents/skills/monitor-pr/SKILL.md](.agents/skills/monitor-pr/SKILL.md).
 
 ## Tooling & Environment
 - **Python:** >= 3.11

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -31,6 +31,7 @@ This repository provides standardized automated workflows for managing issues. A
 - **Finish work on an issue:** Follow the steps defined in [.agents/skills/finish-issue/SKILL.md](.agents/skills/finish-issue/SKILL.md).
 - **Raise a Pull Request:** Follow the steps defined in [.agents/skills/raise-pr/SKILL.md](.agents/skills/raise-pr/SKILL.md).
 - **Monitor Pull Request CI:** Follow the steps defined in [.agents/skills/monitor-pr/SKILL.md](.agents/skills/monitor-pr/SKILL.md).
+- **Raise a new issue:** Follow the steps defined in [.agents/skills/raise-issue/SKILL.md](.agents/skills/raise-issue/SKILL.md).
 
 ## Tooling & Environment
 - **Python:** >= 3.11

--- a/uv.lock
+++ b/uv.lock
@@ -41,7 +41,7 @@ wheels = [
 
 [[package]]
 name = "breakfast"
-version = "0.70.0"
+version = "0.71.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

- **GitHub Issue Creation Automation**: Implemented a new, formal project-level skill called `raise-issue` to guide agents in creating highly structured, rich GitHub issues.
- **Key Changes**:
  - Created new skill [.agents/skills/raise-issue/SKILL.md](.agents/skills/raise-issue/SKILL.md) which sets up step-by-step procedures for Bug vs. Feature issue structuring, expected/actual behaviors, reproduction commands, clean non-conventional-prefixed title format checking, and `gh issue create` integration.
  - Synchronized workspace agent instruction files (`GEMINI.md`, `CLAUDE.md`, `AGENTS.md`, and `.github/copilot-instructions.md`) to point to this new skill.
- **Abstractions & Design Decisions**:
  - Derived formatting structures directly from highly detailed open/closed issues within this repository for maximum alignment with current codebase standards.

## Test plan

- [x] `make format && make lint && make test` passes (all checks verified clean).
- [x] All 444 existing unit tests continue to pass seamlessly in 1.69s.

Closes #319

🥐 Prepared by [Gemini](https://deepmind.google/technologies/gemini/)