### PR TITLE
#321: Extend raise-pr skill to support updating PR bodies and posting comments

### DIFF
--- a/.agents/skills/monitor-pr/SKILL.md
+++ b/.agents/skills/monitor-pr/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: monitor-pr
+description: Monitor the CI checks status of a Pull Request on GitHub, parse logs on failure, and address any non-passing tests.
+---
+
+# Monitor PR Skill
+
+Standardized procedure to track pull request CI checks on GitHub and address any test or linting failures.
+
+## When to use this skill
+- Use this skill after raising a pull request (e.g., using `raise-pr`), or when the user requests to check, monitor, or track the CI/test status of an active PR.
+
+## How to use it
+
+### Steps
+
+1. **Check CI checks status:**
+   Use the GitHub CLI (`gh`) to retrieve the status of all active checks on the current branch:
+   ```bash
+   gh pr checks
+   ```
+
+2. **Wait for completion (if pending):**
+   If any checks are marked as `pending`:
+   - Set a one-shot wakeup timer using the `schedule` tool (e.g., set for 120 seconds with the prompt `"Check CI status for PR"`).
+   - Stop calling tools to yield back control while the timer is running.
+   - Do NOT run a shell `sleep` loop or poll continuously in a terminal process.
+
+3. **Handle successful runs:**
+   If all checks are marked as `pass` or `success`:
+   - Confirm to the user that CI has successfully completed and all tests are passing.
+   - Inform the user that the PR is ready for review and merge.
+
+4. **Diagnose and fix failures (if any check fails):**
+   If any check fails (status is `fail` or `failure`):
+   - **Identify the failing check:** Look at the name of the failing check (e.g., `test`, `lint`, `docs-lint`).
+   - **View failing logs:** Retrieve the CI run details or logs:
+     ```bash
+     gh run list --branch <current-branch> --limit 1
+     gh run view <run-id> --log-failed
+     ```
+   - **Reproduce locally:** Execute the matching local quality check target to reproduce the failure in your workspace:
+     - For test failures: `make test` (or run a specific test: `uv run pytest -k <failing_test_name>`)
+     - For lint/format failures: `make lint` or `make format`
+   - **Fix the issue:** Debug the codebase, resolve the failing tests/lint issues, and run the complete verification suite locally (`make format && make lint && make test`) to confirm the fix.
+   - **Push the fix:** Stage the modified files, commit them using conventional commits (`fix: address failing CI check`), and push them to origin (`git push`).
+   - **Resume monitoring:** Go back to Step 1 to monitor the fresh CI run.

--- a/.agents/skills/raise-issue/SKILL.md
+++ b/.agents/skills/raise-issue/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: raise-issue
+description: Raise a detailed, structured issue on GitHub. Gathers context, builds reproduction steps, expected outcomes, and acceptance criteria.
+---
+
+# Raise Issue Skill
+
+Standardized procedure to generate and raise a high-quality, deeply detailed issue on GitHub for this project.
+
+## When to use this skill
+- Use this skill when you identify a bug, a required enhancement, or a new feature that does not have an active GitHub issue yet.
+- Remember: **A GitHub issue MUST exist before any coding work begins.** Always use this skill to create the issue first.
+
+## How to use it
+
+### Steps
+
+1. **Analyze the problem or requirement:**
+   Collect all relevant details:
+   - For bugs: exact error tracebacks, terminal output, reproduction commands, and conditions.
+   - For features: the proposed feature goals, user benefit, command-line flags, configuration structures, and CLI outputs.
+
+2. **Generate a detailed, structured description:**
+   Determine whether the issue is a **Bug** or a **Feature/Enhancement**, and choose the corresponding structure.
+
+   #### Structure for Bug Issues:
+   ```markdown
+   ## Problem
+   [Detailed description of what is failing and why it is wrong/suboptimal. Include any traceback error logs here.]
+
+   ## Steps to reproduce / Reproduction
+   \`\`\`bash
+   [Exact shell command or python sequence to trigger the bug]
+   \`\`\`
+
+   ## Expected behaviour
+   [Explain what the CLI/application should ideally output or do.]
+
+   ## Actual behaviour
+   [Explain what the CLI/application is currently outputting or doing.]
+
+   ## Suspected Cause (optional)
+   [If a specific file, class, function, or recent commit is suspected, reference it here.]
+   ```
+
+   #### Structure for Feature/Enhancement Issues:
+   ```markdown
+   ## Description / Problem
+   [High-level explanation of the new feature, why it is beneficial, and what user problem it solves.]
+
+   ## Proposed Solution
+   [Explain how it should be implemented, listing CLI flags, configuration parameters, and code structure.]
+
+   ## Examples
+   \`\`\`bash
+   # Show command examples if applicable
+   breakfast -o spec --new-flag
+   \`\`\`
+
+   ## Acceptance Criteria
+   - [ ] [Feature behaves as expected under condition A]
+   - [ ] [Configuration overrides CLI values correctly]
+   - [ ] [Updated manual pages in docs/manual/ reflect changes]
+   - [ ] [make format && make lint && make test all pass]
+   ```
+
+3. **Verify the Title format:**
+   Ensure the issue title is clean and descriptive.
+   - **Important**: Do not use conventional commit prefixes (like `feat:` or `fix:`) in GitHub issue titles, as these are reserved for commits and PRs. Keep the title imperative and natural.
+   - *Example*: "Support per-org scoped repo filter with org:filter syntax"
+
+4. **Create the issue using the GitHub CLI (`gh`):**
+   Execute the `gh issue create` command using the derived title and generated body:
+   ```bash
+   gh issue create --title "<title>" --body "<body>"
+   ```
+   *(If the GitHub CLI is not authenticated or available, output the formatted title and body so the user can easily copy and paste them into the GitHub web interface).*
+
+5. **Confirm to the user:** Report the generated issue URL, issue number, and a summary of the details.

--- a/.agents/skills/raise-pr/SKILL.md
+++ b/.agents/skills/raise-pr/SKILL.md
@@ -1,18 +1,18 @@
 ---
 name: raise-pr
-description: Generate a detailed, high-depth pull request body and create a PR on GitHub. Analyzes changes and creates a highly informative PR description.
+description: Generate a detailed, high-depth pull request body and create/update a PR on GitHub. Gathers workspace changes, updates the PR body dynamically, and posts update comments to capture a historical paper trail.
 ---
 
 # Raise PR Skill
 
-Standardized procedure to generate and submit a highly detailed, high-depth pull request on GitHub for this project.
+Standardized procedure to generate, submit, and dynamically update a highly detailed, high-depth pull request on GitHub for this project.
 
 ## When to use this skill
-- Use this skill when you have completed work on an issue branch, run all verification checks, and are ready to create a GitHub Pull Request for the active branch.
+- Use this skill when you have completed work or made additional updates on an issue branch, run all verification checks, and are ready to create or update a GitHub Pull Request for the active branch.
 
 ## How to use it
 
-### Steps
+### Steps for Creating a Pull Request
 
 1. **Analyze workspace changes:**
    Review your local git changes, commit history, and test outcomes to collect all context:
@@ -62,3 +62,30 @@ Standardized procedure to generate and submit a highly detailed, high-depth pull
    *(If the GitHub CLI is not authenticated or available, output the formatted title and body so the user can easily copy and paste them into the GitHub web interface).*
 
 5. **Confirm to the user:** Report the generated PR URL and a summary of the details submitted.
+
+---
+
+### Steps for Updating a Pull Request
+
+If a Pull Request has already been opened for the current branch, follow this procedure when pushing new updates:
+
+1. **Regenerate the PR body:**
+   - Gather all changes made across the entire branch (from the base `main` branch to your latest commit).
+   - Re-run Step 2 of "Steps for Creating a Pull Request" to generate a complete, up-to-date PR body description representing the full set of changes, test plans, and acceptance criteria.
+   - Update the existing Pull Request body on GitHub using the GitHub CLI:
+     ```bash
+     gh pr edit --body "<regenerated-body-content>"
+     ```
+
+2. **Add an update comment (for the historical paper trail):**
+   - Identify the specific changes introduced in this *latest* update/commit.
+   - Write a concise summary of the new additions, bug fixes, or test enhancements.
+   - Post this update summary as a comment on the Pull Request using the GitHub CLI:
+     ```bash
+     gh pr comment --body "### Update Comment: [Brief Description]
+
+     - **What's New**: [Detail the latest additions/fixes].
+     - **Verification**: [Mention unit tests run or added in this update]."
+     ```
+     This ensures a clear historical paper trail of how the PR evolved over time.
+

--- a/.agents/skills/raise-pr/SKILL.md
+++ b/.agents/skills/raise-pr/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: raise-pr
+description: Generate a detailed, high-depth pull request body and create a PR on GitHub. Analyzes changes and creates a highly informative PR description.
+---
+
+# Raise PR Skill
+
+Standardized procedure to generate and submit a highly detailed, high-depth pull request on GitHub for this project.
+
+## When to use this skill
+- Use this skill when you have completed work on an issue branch, run all verification checks, and are ready to create a GitHub Pull Request for the active branch.
+
+## How to use it
+
+### Steps
+
+1. **Analyze workspace changes:**
+   Review your local git changes, commit history, and test outcomes to collect all context:
+   - Identify which files were created, modified, or deleted.
+   - Collect the exact names of any new unit tests added (e.g., in `tests/test_*.py`).
+   - Identify the linked GitHub issue number from your branch name (`issue-<N>_...`).
+
+2. **Generate a detailed, high-depth PR body:**
+   Construct a pull request body matching the standard project PR template structure. Your description must be rich and thorough (avoiding generic or one-sentence summaries).
+
+   #### Template Format:
+   ```markdown
+   ## Summary
+
+   - **[Brief feature description]**: [Explain the high-level intent].
+   - **Key Changes**:
+     - Detail the specific classes, functions, or logic flows modified (e.g., in `src/breakfast/`).
+     - List any new configuration keys or command-line arguments introduced.
+     - List new files, directories, or assets added to the codebase.
+   - **Abstractions & Design Decisions**: Explain any architectural or design patterns utilized (e.g., modular directory structures, custom index iterables).
+
+   ## Test plan
+
+   - [x] `make format && make lint && make test` passes (verify all checks are clean).
+   - [x] **[Specific unit tests run or added]**:
+     - `test_func_a` — verifies [intent].
+     - `test_func_b` — verifies [intent].
+   - [x] **Manual Verification / Smoke Test**:
+     - Verify CLI execution (e.g., `uv run breakfast --version` runs cleanly).
+     - Run any targeted CLI configurations to confirm visual correctness.
+
+   Closes #<issue-number>
+
+   🤖 Prepared by [Antigravity](https://github.com/google-deepmind)
+   ```
+
+3. **Verify the PR Title format:**
+   Ensure the Pull Request title matches the mandatory convention:
+   `#<issue-number>: <description>`
+   - *Example*: `#313: Color PR number column with calendar color`
+
+4. **Create the PR using the GitHub CLI (`gh`):**
+   Execute the `gh pr create` command using the derived title and generated body:
+   ```bash
+   gh pr create --title "#<issue-number>: <short-description>" --body "<generated-body-content>"
+   ```
+   *(If the GitHub CLI is not authenticated or available, output the formatted title and body so the user can easily copy and paste them into the GitHub web interface).*
+
+5. **Confirm to the user:** Report the generated PR URL and a summary of the details submitted.

--- a/.agents/skills/raise-pr/SKILL.md
+++ b/.agents/skills/raise-pr/SKILL.md
@@ -46,7 +46,7 @@ Standardized procedure to generate and submit a highly detailed, high-depth pull
 
    Closes #<issue-number>
 
-   🤖 Prepared by [Antigravity](https://github.com/google-deepmind)
+   [Agent signature: e.g., 🤖 Prepared by [Antigravity](https://github.com/google-deepmind), 🤖 Generated with [Claude Code](https://claude.com/claude-code), 🥐 Prepared by [Gemini](https://deepmind.google/technologies/gemini/), etc., matching your own identity]
    ```
 
 3. **Verify the PR Title format:**

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -35,6 +35,7 @@ This repository provides standardized automated workflows for managing issues. A
 - **Start work on an issue:** Follow the steps defined in [.agents/skills/start-issue/SKILL.md](.agents/skills/start-issue/SKILL.md).
 - **Finish work on an issue:** Follow the steps defined in [.agents/skills/finish-issue/SKILL.md](.agents/skills/finish-issue/SKILL.md).
 - **Raise a Pull Request:** Follow the steps defined in [.agents/skills/raise-pr/SKILL.md](.agents/skills/raise-pr/SKILL.md).
+- **Monitor Pull Request CI:** Follow the steps defined in [.agents/skills/monitor-pr/SKILL.md](.agents/skills/monitor-pr/SKILL.md).
 
 ## Tooling & Environment
 - **Python:** >= 3.11

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -21,8 +21,8 @@ This project maintains per-agent instruction files that all convey the same rule
 When updating project rules, update **all four files** to keep them consistent.
 
 ## Mandatory Workflow
-1. **GitHub Issues First:** An issue MUST exist before work begins. If none exists, create one via `gh issue create`. (Do not use conventional commit prefixes for issue titles).
-2. **One Issue = One PR:** Never combine fixes for multiple issues into a single PR. Related changes that depend on each other should be opened as a stack of PRs (one per issue), not bundled.
+1. **GitHub Issues First:** An issue MUST exist before work begins. If none exists, create one via `gh issue create`. (Do not use conventional commit prefixes for issue titles). *Exception*: Refinements, feedback iterations, or trivial tweaks on in-flight/undelivered feature branches do not require raising new issues; make changes directly on the active branch.
+2. **One Issue = One PR:** Never combine fixes for multiple unrelated issues into a single PR. Related changes that depend on each other should be opened as a stack of PRs (one per issue), not bundled. *Exception*: Trivial tweaks or closely related follow-up iterations can be added directly to the active branch rather than stack-PRing every detail.
 3. **Branch Naming:** Format: `issue-N_short_description` (e.g., `issue-42_add_avocado_toast`).
 4. **PR Titles:** Include the issue number: `#N: Description` (e.g., `#42: Add Avocado Toast output`).
 5. **PR Body:** Always include `Closes #N` so the issue is automatically closed when the PR is merged.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -34,6 +34,7 @@ When updating project rules, update **all four files** to keep them consistent.
 This repository provides standardized automated workflows for managing issues. All agents must refer to and execute these exact steps:
 - **Start work on an issue:** Follow the steps defined in [.agents/skills/start-issue/SKILL.md](.agents/skills/start-issue/SKILL.md).
 - **Finish work on an issue:** Follow the steps defined in [.agents/skills/finish-issue/SKILL.md](.agents/skills/finish-issue/SKILL.md).
+- **Raise a Pull Request:** Follow the steps defined in [.agents/skills/raise-pr/SKILL.md](.agents/skills/raise-pr/SKILL.md).
 
 ## Tooling & Environment
 - **Python:** >= 3.11

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -36,6 +36,7 @@ This repository provides standardized automated workflows for managing issues. A
 - **Finish work on an issue:** Follow the steps defined in [.agents/skills/finish-issue/SKILL.md](.agents/skills/finish-issue/SKILL.md).
 - **Raise a Pull Request:** Follow the steps defined in [.agents/skills/raise-pr/SKILL.md](.agents/skills/raise-pr/SKILL.md).
 - **Monitor Pull Request CI:** Follow the steps defined in [.agents/skills/monitor-pr/SKILL.md](.agents/skills/monitor-pr/SKILL.md).
+- **Raise a new issue:** Follow the steps defined in [.agents/skills/raise-issue/SKILL.md](.agents/skills/raise-issue/SKILL.md).
 
 ## Tooling & Environment
 - **Python:** >= 3.11

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -21,7 +21,7 @@ This project maintains per-agent instruction files that all convey the same rule
 When updating project rules, update **all four files** to keep them consistent.
 
 ## Mandatory Workflow
-1. **GitHub Issues First:** An issue MUST exist before work begins. If none exists, create one via `gh issue create`. (Do not use conventional commit prefixes for issue titles). *Exception*: Refinements, feedback iterations, or trivial tweaks on in-flight/undelivered feature branches do not require raising new issues; make changes directly on the active branch.
+1. **GitHub Issues First:** An issue MUST exist before work begins. If none exists, create one via `gh issue create`. (Do not use conventional commit prefixes for issue titles). *Exception*: Refinements, feedback iterations, or trivial tweaks on in-flight/undelivered feature branches do not require raising new issues; make changes directly on the active branch. If you are unsure whether to raise a new GitHub issue or continue on a current active branch, always pause and ask the user directly first.
 2. **One Issue = One PR:** Never combine fixes for multiple unrelated issues into a single PR. Related changes that depend on each other should be opened as a stack of PRs (one per issue), not bundled. *Exception*: Trivial tweaks or closely related follow-up iterations can be added directly to the active branch rather than stack-PRing every detail.
 3. **Branch Naming:** Format: `issue-N_short_description` (e.g., `issue-42_add_avocado_toast`).
 4. **PR Titles:** Include the issue number: `#N: Description` (e.g., `#42: Add Avocado Toast output`).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,8 +54,8 @@ When updating project rules, update **all four files** to keep them consistent.
 ## Work Items
 - This project uses GitHub issues (not Jira). Reference the GitHub issue number in branch names and PR titles.
 - Branch names should include the issue number and a short description (e.g., `issue-26_filter_pr_authors`).
-- **A GitHub issue MUST exist before any work begins.** If the user requests a change and no issue exists yet, create one (or ask the user to create one) before starting implementation. Every branch, commit, and PR must reference an issue number.
-- **One issue = one branch = one PR.** Never combine fixes for multiple issues into a single PR. If changes are related and depend on each other, open them as a stack of PRs (one per issue) rather than bundling.
+- **A GitHub issue MUST exist before any work begins.** If the user requests a change and no issue exists yet, create one (or ask the user to create one) before starting implementation. Every branch, commit, and PR must reference an issue number. *Exception*: Refinements, feedback iterations, or trivial tweaks on in-flight/undelivered feature branches do not require raising new issues; make changes directly on the active branch.
+- **One issue = one branch = one PR.** Never combine fixes for multiple unrelated issues into a single PR. If changes are related and depend on each other, open them as a stack of PRs (one per issue) rather than bundling. *Exception*: Trivial tweaks or closely related follow-up iterations can be added directly to the active branch rather than stack-PRing every detail.
 
 ## Automated Workflows
 This repository provides standardized automated workflows for managing issues. All agents must refer to and execute these exact steps:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,6 +62,7 @@ This repository provides standardized automated workflows for managing issues. A
 - **Start work on an issue:** Follow the steps defined in [.agents/skills/start-issue/SKILL.md](.agents/skills/start-issue/SKILL.md).
 - **Finish work on an issue:** Follow the steps defined in [.agents/skills/finish-issue/SKILL.md](.agents/skills/finish-issue/SKILL.md).
 - **Raise a Pull Request:** Follow the steps defined in [.agents/skills/raise-pr/SKILL.md](.agents/skills/raise-pr/SKILL.md).
+- **Monitor Pull Request CI:** Follow the steps defined in [.agents/skills/monitor-pr/SKILL.md](.agents/skills/monitor-pr/SKILL.md).
 
 ## Commit Messages
 - Use Conventional Commits (e.g., `feat: ...`, `fix: ...`, `chore: ...`, `docs: ...`, `refactor: ...`, `test: ...`, `ci: ...`).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,6 +63,7 @@ This repository provides standardized automated workflows for managing issues. A
 - **Finish work on an issue:** Follow the steps defined in [.agents/skills/finish-issue/SKILL.md](.agents/skills/finish-issue/SKILL.md).
 - **Raise a Pull Request:** Follow the steps defined in [.agents/skills/raise-pr/SKILL.md](.agents/skills/raise-pr/SKILL.md).
 - **Monitor Pull Request CI:** Follow the steps defined in [.agents/skills/monitor-pr/SKILL.md](.agents/skills/monitor-pr/SKILL.md).
+- **Raise a new issue:** Follow the steps defined in [.agents/skills/raise-issue/SKILL.md](.agents/skills/raise-issue/SKILL.md).
 
 ## Commit Messages
 - Use Conventional Commits (e.g., `feat: ...`, `fix: ...`, `chore: ...`, `docs: ...`, `refactor: ...`, `test: ...`, `ci: ...`).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,7 +54,7 @@ When updating project rules, update **all four files** to keep them consistent.
 ## Work Items
 - This project uses GitHub issues (not Jira). Reference the GitHub issue number in branch names and PR titles.
 - Branch names should include the issue number and a short description (e.g., `issue-26_filter_pr_authors`).
-- **A GitHub issue MUST exist before any work begins.** If the user requests a change and no issue exists yet, create one (or ask the user to create one) before starting implementation. Every branch, commit, and PR must reference an issue number. *Exception*: Refinements, feedback iterations, or trivial tweaks on in-flight/undelivered feature branches do not require raising new issues; make changes directly on the active branch.
+- **A GitHub issue MUST exist before any work begins.** If the user requests a change and no issue exists yet, create one (or ask the user to create one) before starting implementation. Every branch, commit, and PR must reference an issue number. *Exception*: Refinements, feedback iterations, or trivial tweaks on in-flight/undelivered feature branches do not require raising new issues; make changes directly on the active branch. If you are unsure whether to raise a new GitHub issue or continue on a current active branch, always pause and ask the user directly first.
 - **One issue = one branch = one PR.** Never combine fixes for multiple unrelated issues into a single PR. If changes are related and depend on each other, open them as a stack of PRs (one per issue) rather than bundling. *Exception*: Trivial tweaks or closely related follow-up iterations can be added directly to the active branch rather than stack-PRing every detail.
 
 ## Automated Workflows

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,6 +61,7 @@ When updating project rules, update **all four files** to keep them consistent.
 This repository provides standardized automated workflows for managing issues. All agents must refer to and execute these exact steps:
 - **Start work on an issue:** Follow the steps defined in [.agents/skills/start-issue/SKILL.md](.agents/skills/start-issue/SKILL.md).
 - **Finish work on an issue:** Follow the steps defined in [.agents/skills/finish-issue/SKILL.md](.agents/skills/finish-issue/SKILL.md).
+- **Raise a Pull Request:** Follow the steps defined in [.agents/skills/raise-pr/SKILL.md](.agents/skills/raise-pr/SKILL.md).
 
 ## Commit Messages
 - Use Conventional Commits (e.g., `feat: ...`, `fix: ...`, `chore: ...`, `docs: ...`, `refactor: ...`, `test: ...`, `ci: ...`).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,8 +54,8 @@ When updating project rules, update **all four files** to keep them consistent.
 ## Work Items
 - This project uses GitHub issues (not Jira). Reference the GitHub issue number in branch names and PR titles.
 - Branch names should include the issue number and a short description (e.g., `issue-26_filter_pr_authors`).
-- **A GitHub issue MUST exist before any work begins.** If the user requests a change and no issue exists yet, create one (or ask the user to create one) before starting implementation. Every branch, commit, and PR must reference an issue number.
-- **One issue = one branch = one PR.** Never combine fixes for multiple issues into a single PR. If changes are related and depend on each other, open them as a stack of PRs (one per issue) rather than bundling.
+- **A GitHub issue MUST exist before any work begins.** If the user requests a change and no issue exists yet, create one (or ask the user to create one) before starting implementation. Every branch, commit, and PR must reference an issue number. *Exception*: Refinements, feedback iterations, or trivial tweaks on in-flight/undelivered feature branches do not require raising new issues; make changes directly on the active branch.
+- **One issue = one branch = one PR.** Never combine fixes for multiple unrelated issues into a single PR. If changes are related and depend on each other, open them as a stack of PRs (one per issue) rather than bundling. *Exception*: Trivial tweaks or closely related follow-up iterations can be added directly to the active branch rather than stack-PRing every detail.
 
 ## Automated Workflows
 This repository provides standardized automated workflows for managing issues. All agents must refer to and execute these exact steps:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,6 +62,7 @@ This repository provides standardized automated workflows for managing issues. A
 - **Start work on an issue:** Follow the steps defined in [.agents/skills/start-issue/SKILL.md](.agents/skills/start-issue/SKILL.md).
 - **Finish work on an issue:** Follow the steps defined in [.agents/skills/finish-issue/SKILL.md](.agents/skills/finish-issue/SKILL.md).
 - **Raise a Pull Request:** Follow the steps defined in [.agents/skills/raise-pr/SKILL.md](.agents/skills/raise-pr/SKILL.md).
+- **Monitor Pull Request CI:** Follow the steps defined in [.agents/skills/monitor-pr/SKILL.md](.agents/skills/monitor-pr/SKILL.md).
 
 ## Commit Messages
 - Use Conventional Commits (e.g., `feat: ...`, `fix: ...`, `chore: ...`, `docs: ...`, `refactor: ...`, `test: ...`, `ci: ...`).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,6 +63,7 @@ This repository provides standardized automated workflows for managing issues. A
 - **Finish work on an issue:** Follow the steps defined in [.agents/skills/finish-issue/SKILL.md](.agents/skills/finish-issue/SKILL.md).
 - **Raise a Pull Request:** Follow the steps defined in [.agents/skills/raise-pr/SKILL.md](.agents/skills/raise-pr/SKILL.md).
 - **Monitor Pull Request CI:** Follow the steps defined in [.agents/skills/monitor-pr/SKILL.md](.agents/skills/monitor-pr/SKILL.md).
+- **Raise a new issue:** Follow the steps defined in [.agents/skills/raise-issue/SKILL.md](.agents/skills/raise-issue/SKILL.md).
 
 ## Commit Messages
 - Use Conventional Commits (e.g., `feat: ...`, `fix: ...`, `chore: ...`, `docs: ...`, `refactor: ...`, `test: ...`, `ci: ...`).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,7 +54,7 @@ When updating project rules, update **all four files** to keep them consistent.
 ## Work Items
 - This project uses GitHub issues (not Jira). Reference the GitHub issue number in branch names and PR titles.
 - Branch names should include the issue number and a short description (e.g., `issue-26_filter_pr_authors`).
-- **A GitHub issue MUST exist before any work begins.** If the user requests a change and no issue exists yet, create one (or ask the user to create one) before starting implementation. Every branch, commit, and PR must reference an issue number. *Exception*: Refinements, feedback iterations, or trivial tweaks on in-flight/undelivered feature branches do not require raising new issues; make changes directly on the active branch.
+- **A GitHub issue MUST exist before any work begins.** If the user requests a change and no issue exists yet, create one (or ask the user to create one) before starting implementation. Every branch, commit, and PR must reference an issue number. *Exception*: Refinements, feedback iterations, or trivial tweaks on in-flight/undelivered feature branches do not require raising new issues; make changes directly on the active branch. If you are unsure whether to raise a new GitHub issue or continue on a current active branch, always pause and ask the user directly first.
 - **One issue = one branch = one PR.** Never combine fixes for multiple unrelated issues into a single PR. If changes are related and depend on each other, open them as a stack of PRs (one per issue) rather than bundling. *Exception*: Trivial tweaks or closely related follow-up iterations can be added directly to the active branch rather than stack-PRing every detail.
 
 ## Automated Workflows

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,6 +61,7 @@ When updating project rules, update **all four files** to keep them consistent.
 This repository provides standardized automated workflows for managing issues. All agents must refer to and execute these exact steps:
 - **Start work on an issue:** Follow the steps defined in [.agents/skills/start-issue/SKILL.md](.agents/skills/start-issue/SKILL.md).
 - **Finish work on an issue:** Follow the steps defined in [.agents/skills/finish-issue/SKILL.md](.agents/skills/finish-issue/SKILL.md).
+- **Raise a Pull Request:** Follow the steps defined in [.agents/skills/raise-pr/SKILL.md](.agents/skills/raise-pr/SKILL.md).
 
 ## Commit Messages
 - Use Conventional Commits (e.g., `feat: ...`, `fix: ...`, `chore: ...`, `docs: ...`, `refactor: ...`, `test: ...`, `ci: ...`).

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -16,7 +16,7 @@ This project maintains per-agent instruction files that all convey the same rule
 When updating project rules, update **all four files** to keep them consistent.
 
 ## Mandatory Workflow
-1. **GitHub Issues First:** An issue MUST exist before work begins. If none exists, create one via `gh issue create`. (Do not use conventional commit prefixes for issue titles). *Exception*: Refinements, feedback iterations, or trivial tweaks on in-flight/undelivered feature branches do not require raising new issues; make changes directly on the active branch.
+1. **GitHub Issues First:** An issue MUST exist before work begins. If none exists, create one via `gh issue create`. (Do not use conventional commit prefixes for issue titles). *Exception*: Refinements, feedback iterations, or trivial tweaks on in-flight/undelivered feature branches do not require raising new issues; make changes directly on the active branch. If you are unsure whether to raise a new GitHub issue or continue on a current active branch, always pause and ask the user directly first.
 2. **One Issue = One PR:** Never combine fixes for multiple unrelated issues into a single PR. Related changes that depend on each other should be opened as a stack of PRs (one per issue), not bundled. *Exception*: Trivial tweaks or closely related follow-up iterations can be added directly to the active branch rather than stack-PRing every detail.
 3. **Branch Naming:** Format: `issue-N_short_description` (e.g., `issue-42_add_avocado_toast`).
 4. **PR Titles:** Include the issue number: `#N: Description` (e.g., `#42: Add Avocado Toast output`).

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -29,6 +29,7 @@ When updating project rules, update **all four files** to keep them consistent.
 This repository provides standardized automated workflows for managing issues. All agents must refer to and execute these exact steps:
 - **Start work on an issue:** Follow the steps defined in [.agents/skills/start-issue/SKILL.md](.agents/skills/start-issue/SKILL.md).
 - **Finish work on an issue:** Follow the steps defined in [.agents/skills/finish-issue/SKILL.md](.agents/skills/finish-issue/SKILL.md).
+- **Raise a Pull Request:** Follow the steps defined in [.agents/skills/raise-pr/SKILL.md](.agents/skills/raise-pr/SKILL.md).
 
 ## Tooling & Environment
 - **Python:** >= 3.11

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -30,6 +30,7 @@ This repository provides standardized automated workflows for managing issues. A
 - **Start work on an issue:** Follow the steps defined in [.agents/skills/start-issue/SKILL.md](.agents/skills/start-issue/SKILL.md).
 - **Finish work on an issue:** Follow the steps defined in [.agents/skills/finish-issue/SKILL.md](.agents/skills/finish-issue/SKILL.md).
 - **Raise a Pull Request:** Follow the steps defined in [.agents/skills/raise-pr/SKILL.md](.agents/skills/raise-pr/SKILL.md).
+- **Monitor Pull Request CI:** Follow the steps defined in [.agents/skills/monitor-pr/SKILL.md](.agents/skills/monitor-pr/SKILL.md).
 
 ## Tooling & Environment
 - **Python:** >= 3.11

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -16,8 +16,8 @@ This project maintains per-agent instruction files that all convey the same rule
 When updating project rules, update **all four files** to keep them consistent.
 
 ## Mandatory Workflow
-1. **GitHub Issues First:** An issue MUST exist before work begins. If none exists, create one via `gh issue create`. (Do not use conventional commit prefixes for issue titles).
-2. **One Issue = One PR:** Never combine fixes for multiple issues into a single PR. Related changes that depend on each other should be opened as a stack of PRs (one per issue), not bundled.
+1. **GitHub Issues First:** An issue MUST exist before work begins. If none exists, create one via `gh issue create`. (Do not use conventional commit prefixes for issue titles). *Exception*: Refinements, feedback iterations, or trivial tweaks on in-flight/undelivered feature branches do not require raising new issues; make changes directly on the active branch.
+2. **One Issue = One PR:** Never combine fixes for multiple unrelated issues into a single PR. Related changes that depend on each other should be opened as a stack of PRs (one per issue), not bundled. *Exception*: Trivial tweaks or closely related follow-up iterations can be added directly to the active branch rather than stack-PRing every detail.
 3. **Branch Naming:** Format: `issue-N_short_description` (e.g., `issue-42_add_avocado_toast`).
 4. **PR Titles:** Include the issue number: `#N: Description` (e.g., `#42: Add Avocado Toast output`).
 5. **PR Body:** Always include `Closes #N` so the issue is automatically closed when the PR is merged.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -31,6 +31,7 @@ This repository provides standardized automated workflows for managing issues. A
 - **Finish work on an issue:** Follow the steps defined in [.agents/skills/finish-issue/SKILL.md](.agents/skills/finish-issue/SKILL.md).
 - **Raise a Pull Request:** Follow the steps defined in [.agents/skills/raise-pr/SKILL.md](.agents/skills/raise-pr/SKILL.md).
 - **Monitor Pull Request CI:** Follow the steps defined in [.agents/skills/monitor-pr/SKILL.md](.agents/skills/monitor-pr/SKILL.md).
+- **Raise a new issue:** Follow the steps defined in [.agents/skills/raise-issue/SKILL.md](.agents/skills/raise-issue/SKILL.md).
 
 ## Tooling & Environment
 - **Python:** >= 3.11

--- a/uv.lock
+++ b/uv.lock
@@ -41,7 +41,7 @@ wheels = [
 
 [[package]]
 name = "breakfast"
-version = "0.70.0"
+version = "0.71.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },

--- a/uv.lock
+++ b/uv.lock
@@ -41,7 +41,7 @@ wheels = [
 
 [[package]]
 name = "breakfast"
-version = "0.71.0"
+version = "0.72.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

- **Full Multi-Agent Skill Automation Suite**: Centralized and standardized four formal, high-depth agent skills under `.agents/skills/` to automate the issue and pull request lifecycle dynamically without hardcoding.
- **Pragmatic Workflow & Clarification Mandate**: Refined and relaxed workspace rules across all agent instructions to allow direct in-flight refinements on active branches without creating separate issues. Mandated that agents *always* ask the user first if unsure whether to raise a new GitHub issue or continue on the active branch.
- **Key Changes**:
  - **[raise-pr Skill](file:///Users/steve/git/breakfast/.agents/skills/raise-pr/SKILL.md)**: Extended to guide agents on regenerating PR bodies via `gh pr edit` and posting concise update summaries via `gh pr comment` to maintain a robust version-controlled paper trail of revisions.
  - **[monitor-pr Skill](file:///Users/steve/git/breakfast/.agents/skills/monitor-pr/SKILL.md)**: Implemented automated non-blocking polling and failure resolution strategies using `gh pr checks`.
  - **[raise-issue Skill](file:///Users/steve/git/breakfast/.agents/skills/raise-issue/SKILL.md)**: Introduced clear, highly structured bug and feature templates based on repository best practices.
  - **Developer Instruction Files**:
    - [GEMINI.md](file:///Users/steve/git/breakfast/GEMINI.md)
    - [CLAUDE.md](file:///Users/steve/git/breakfast/CLAUDE.md)
    - [AGENTS.md](file:///Users/steve/git/breakfast/AGENTS.md)
    - [.github/copilot-instructions.md](file:///Users/steve/git/breakfast/.github/copilot-instructions.md)
    - Refactored all instruction pages to point to the unified `.agents/skills/` path, allow active branch feedback iterations, and enforce asking the user when in doubt.
- **Abstractions & Design Decisions**:
  - Standardized custom tool/script execution paths under the generic `.agents/skills/` tree to remain cross-agent compatible and tool-agnostic.
  - Avoided any rigid, vendor-specific CLI configuration folder mappings.

## Test plan

- [x] `make format && make lint && make test` passes (all checks verified clean).
- [x] **All 444 unit tests pass successfully** (verified in 1.76s).
- [x] **E2E verification**: Successfully verified git, gh CLI integration, and branch workspace logic.

Closes #321

🤖 Prepared by [Antigravity](https://github.com/google-deepmind) (powered by Gemini 🥐)
