### PR TITLE
#295: Support user-owned repos, rename --org to --owner, deprecate old aliases

### DIFF
--- a/docs/manual/options.md
+++ b/docs/manual/options.md
@@ -2,24 +2,24 @@
 
 ## Required options
 
-### `--organization`, `-o`
+### `--owner`, `-o`
 
-The GitHub organization to query for pull requests. Repeat the flag to query
-multiple organizations at once — their PRs are combined and deduplicated.
+The GitHub owner (organization or personal account) to query for pull requests.
+Repeat the flag to query multiple owners at once — their PRs are combined and deduplicated.
 
-You can optionally append a **scoped repo filter** to any org using a colon separator:
+You can optionally append a **scoped repo filter** to any owner using a colon separator:
 
 | Flag form | Behaviour |
 | --- | --- |
 | `-o my-org` | Use the global `-r` filter (or all repos if no `-r`) |
-| `-o my-org:api` | Override: only repos matching `api` for this org |
-| `-o my-org:` | Override: all repos for this org, ignoring any global `-r` |
+| `-o my-org:api` | Override: only repos matching `api` for this owner |
+| `-o my-org:` | Override: all repos for this owner, ignoring any global `-r` |
 
 ```bash
 breakfast -o my-org -r my-app                           # global filter
-breakfast -o my-org -o another-org                      # two orgs, no filter
-breakfast -o my-org -o another-org -r platform          # global filter for both orgs
-breakfast -o my-org:api -o another-org:platform         # per-org filters
+breakfast -o my-org -o another-org                      # two owners, no filter
+breakfast -o my-org -o another-org -r platform          # global filter for both owners
+breakfast -o my-org:api -o another-org:platform         # per-owner filters
 breakfast -o my-org:api -o another-org -r platform      # scoped for my-org, global for another-org
 breakfast -o my-org: -o another-org -r platform         # all repos for my-org; filtered for another-org
 ```
@@ -27,18 +27,22 @@ breakfast -o my-org: -o another-org -r platform         # all repos for my-org; 
 Config key supports both a single string and a list, with optional scoped filters:
 
 ```toml
-# Single org
-organization = "my-org"
+# Single owner
+owner = "my-org"
 
-# Multiple orgs
-organization = ["my-org", "another-org"]
+# Multiple owners
+owner = ["my-org", "another-org"]
 
-# Per-org scoped filters
-organization = ["my-org:api", "another-org:platform"]
+# Per-owner scoped filters
+owner = ["my-org:api", "another-org:platform"]
 
 # Mixed: scoped for one, global -r for the other
-organization = ["my-org:api", "another-org"]
+owner = ["my-org:api", "another-org"]
 ```
+
+> **Deprecated aliases:** `--org` and `--organization` still work but print a deprecation
+> warning to stderr. The config key `organization` is also accepted but deprecated —
+> rename it to `owner`. Both deprecated forms will be removed in a future release.
 
 ### `--repo-filter`, `-r`
 
@@ -1094,7 +1098,7 @@ Options:
   --config TEXT                   Path to config file.
   --show-config                   Print the resolved config and exit.
   --init-config                   Generate a default config file and exit.
-  -o, --organization TEXT         One or multiple organizations to report on
+  -o, --owner TEXT                One or multiple owners (org or user) to report on
   -r, --repo-filter TEXT          Filter for specific repo(s)
   --ignore-author TEXT            Ignore PRs raised by one or more authors
                                   (case-insensitive). Repeat for multiple

--- a/docs/manual/troubleshooting.md
+++ b/docs/manual/troubleshooting.md
@@ -12,7 +12,7 @@ The token needs `repo` scope to access pull request data. Generate one at [githu
 
 ## No PRs displayed
 
-- Verify the organization name is correct (`-o`)
+- Verify the owner name is correct (`-o` / `--owner`)
 - Check that the repo filter (`-r`) matches at least one repository name (it's a substring match)
 - If using `--mine-only`, ensure the token belongs to the user whose PRs you want to see
 - If using `--ignore-author`, check you haven't accidentally filtered out the authors you want
@@ -31,7 +31,7 @@ PR details are fetched in parallel (up to 8 concurrent requests), and results ar
 
 - Use `--repo-filter` to narrow down the repos queried
 - Use `--ignore-author` to reduce the number of PRs processed
-- Large organizations with many repos will take longer on the initial GraphQL query
+- Owners with many repos will take longer on the initial GraphQL query
 
 Subsequent runs within the TTL window will be near-instant (served from the local cache). To force a fresh fetch, use `--no-cache`. To tune the cache window, use `--cache-ttl` (e.g. `--cache-ttl 10m`).
 
@@ -88,10 +88,21 @@ Example output:
 2026-03-23 08:00:05 INFO    render format=table row_count=38
 ```
 
-## "GraphQL request failed" errors
+## "Owner not found" errors
 
-This typically means the organization name is incorrect or your token doesn't have access to the organization. Verify:
+breakfast uses the `repositoryOwner` GitHub GraphQL field, which resolves both
+organizations and personal accounts. If you see an owner-not-found error:
+
+- Double-check the owner login (organization name or personal username) passed with `-o`
+- Verify your token has access to the account's repositories
+- For organizations, you can verify with:
 
 ```bash
 curl -H "Authorization: token $GITHUB_TOKEN" https://api.github.com/orgs/YOUR_ORG
+```
+
+- For personal accounts:
+
+```bash
+curl -H "Authorization: token $GITHUB_TOKEN" https://api.github.com/users/YOUR_USER
 ```

--- a/docs/manual/usage.md
+++ b/docs/manual/usage.md
@@ -2,7 +2,7 @@
 
 ## Basic usage
 
-Fetch and display open PRs for an organization, filtered by repo name:
+Fetch and display open PRs for an owner (organization or personal account), filtered by repo name:
 
 ```bash
 breakfast -o my-org -r my-app
@@ -207,8 +207,8 @@ breakfast -o my-org -r platform --cache-ttl 10m   # cache for 10 minutes
 
 ## How it works
 
-1. **Check cache** - Looks for a recent on-disk cache for the `(organization, repo-filter)` pair; if found and within the TTL, skips steps 2–3 entirely
-2. **Fetch repositories** - Uses the GitHub GraphQL API to paginate through all repositories in the organization
+1. **Check cache** - Looks for a recent on-disk cache for the `(owner, repo-filter)` pair; if found and within the TTL, skips steps 2–3 entirely
+2. **Fetch repositories** - Uses the GitHub GraphQL API to paginate through all repositories for the owner (organization or personal account)
 3. **Filter repos** - Keeps only repos whose name contains the `--repo-filter` substring
 4. **Fetch PR details** - Uses the GitHub REST API to fetch full details for each open PR (parallelized for speed); writes results to disk cache
 5. **Filter PRs** - Applies author filters (`--ignore-author`, `--mine-only`), title search (`--search`), and other filters

--- a/src/breakfast/api.py
+++ b/src/breakfast/api.py
@@ -35,6 +35,17 @@ class GitHubRateLimitError(Exception):
             super().__init__("GitHub API rate limit exceeded.")
 
 
+class OwnerNotFoundError(Exception):
+    """Raised when a GitHub owner (org or user) cannot be resolved."""
+
+    def __init__(self, login):
+        self.login = login
+        super().__init__(
+            f"Could not resolve a GitHub organization or user with the login '{login}'."
+            " Check that the owner name is correct and your token has access."
+        )
+
+
 _MAX_RETRIES = 3
 _RETRY_STATUSES = {502, 503, 504}
 
@@ -274,12 +285,12 @@ _FETCH_STATE_MAP = {
 }
 
 
-def get_github_prs(organization, repo_filters, fetch_state="open"):
+def get_github_prs(owner, repo_filters, fetch_state="open"):
     states_list = _FETCH_STATE_MAP.get(fetch_state.lower(), ["OPEN"])
     states_gql = ", ".join(states_list)
     base_query = f"""
-    query($organization: String!, $cursor: String){{
-      organization(login: $organization){{
+    query($owner: String!, $cursor: String){{
+      repositoryOwner(login: $owner){{
         repositories(after: $cursor, first:100){{
           nodes{{
             name
@@ -297,15 +308,17 @@ def get_github_prs(organization, repo_filters, fetch_state="open"):
       }}
     }}
         """
-    variables = {"organization": organization}
+    variables = {"owner": owner}
 
     gql_responses = []
 
-    click.echo(f"Fetching {organization} PRs...", nl=False, err=True)
+    click.echo(f"Fetching {owner} PRs...", nl=False, err=True)
     while True:
         response = make_github_graphql_request(base_query, variables)
+        if response["data"]["repositoryOwner"] is None:
+            raise OwnerNotFoundError(owner)
         gql_responses.append(response)
-        page_info = response["data"]["organization"]["repositories"]["pageInfo"]
+        page_info = response["data"]["repositoryOwner"]["repositories"]["pageInfo"]
         if not page_info["hasNextPage"]:
             break
         variables["cursor"] = page_info["endCursor"]
@@ -314,7 +327,7 @@ def get_github_prs(organization, repo_filters, fetch_state="open"):
 
     prs = []
     for response in gql_responses:
-        for repo in response["data"]["organization"]["repositories"]["nodes"]:
+        for repo in response["data"]["repositoryOwner"]["repositories"]["nodes"]:
             if repo is None:
                 continue
             if _match_repo_filter(repo["name"], repo_filters):

--- a/src/breakfast/cli.py
+++ b/src/breakfast/cli.py
@@ -17,6 +17,7 @@ from tabulate import tabulate
 from .api import (
     SECRET_GITHUB_TOKEN,
     GitHubRateLimitError,
+    OwnerNotFoundError,
     _fetch_pr_detail,
     _match_exclude_repos,
     get_api_stats,
@@ -647,16 +648,31 @@ def _fetch_pr_bundle(url, fetch_checks, fetch_approvals):
     ),
 )
 @click.option(
-    "--organization",
+    "--owner",
     "-o",
+    "owner",
     multiple=True,
     help=(
-        "GitHub organization to query for PRs. Repeat for multiple"
-        " organizations, e.g. -o my-org -o another-org."
+        "GitHub owner (organization or personal account) to query for PRs."
+        " Repeat for multiple owners, e.g. -o my-org -o my-user."
         " Optionally append a scoped repo filter with a colon:"
-        " -o my-org:api (only 'api' repos for that org),"
-        " -o my-org: (all repos for that org, ignoring global -r)."
+        " -o my-org:api (only 'api' repos for that owner),"
+        " -o my-org: (all repos for that owner, ignoring global -r)."
     ),
+)
+@click.option(
+    "--org",
+    "org_deprecated",
+    multiple=True,
+    hidden=True,
+    help="Deprecated. Use --owner instead.",
+)
+@click.option(
+    "--organization",
+    "organization_deprecated",
+    multiple=True,
+    hidden=True,
+    help="Deprecated. Use --owner instead.",
 )
 @click.option(
     "--repo-filter",
@@ -1008,7 +1024,9 @@ def breakfast(
     show_config,
     init_config,
     update_config_cmd,
-    organization,
+    owner,
+    org_deprecated,
+    organization_deprecated,
     repo_filter,
     exclude_repo,
     ignore_author,
@@ -1100,11 +1118,32 @@ def breakfast(
         if "base-branch" in _spec_names and base_branch is None:
             base_branch = True
 
-    # organization is a tuple from multiple=True; merge with config
-    if organization:
-        organizations = list(organization)
+    # --owner / deprecated --org / --organization flags; merge and warn on deprecated
+    if org_deprecated:
+        click.echo(
+            click.style(
+                "⚠️  --org is deprecated and will be removed in a future release."
+                " Use --owner instead.",
+                fg="yellow",
+            ),
+            err=True,
+        )
+    if organization_deprecated:
+        click.echo(
+            click.style(
+                "⚠️  --organization is deprecated and will be removed in a future"
+                " release. Use --owner instead.",
+                fg="yellow",
+            ),
+            err=True,
+        )
+    effective_owner = (
+        tuple(owner) + tuple(org_deprecated) + tuple(organization_deprecated)
+    )
+    if effective_owner:
+        organizations = list(effective_owner)
     else:
-        cfg_org = cfg.get("organization")
+        cfg_org = cfg.get("owner")
         if isinstance(cfg_org, list):
             organizations = cfg_org
         elif cfg_org:
@@ -1272,7 +1311,7 @@ def breakfast(
     if show_config:
         click.echo("Resolved config:")
         resolved = {
-            "organization": [
+            "owner": [
                 org if scoped is None else (org + ":" + (scoped[0] if scoped else ""))
                 for org, scoped in org_specs
             ],
@@ -1349,8 +1388,7 @@ def breakfast(
 
     if not organizations:
         message = (
-            "Organization must be provided via CLI (-o) "
-            "or config file (organization)."
+            "Owner must be provided via CLI (-o / --owner) " "or config file (owner)."
         )
         click.echo(click.style(message, fg="red", bold=True), err=True, color=colour)
         sys.exit(1)
@@ -1414,6 +1452,24 @@ def breakfast(
                 )
                 try:
                     prs.extend(get_github_prs(org, effective_filters, fetch_state))
+                except OwnerNotFoundError as exc:
+                    logger.warning(
+                        "graphql_owner_not_found owner=%s error=%r",
+                        org,
+                        str(exc),
+                    )
+                    click.echo(
+                        click.style(
+                            f"🍳 Owner not found: '{org}' could not be resolved as a"
+                            " GitHub organization or user account."
+                            " Check the name and your token's access.",
+                            fg="red",
+                            bold=True,
+                        ),
+                        err=True,
+                        color=colour,
+                    )
+                    sys.exit(1)
                 except (
                     requests.exceptions.ConnectionError,
                     requests.exceptions.Timeout,

--- a/src/breakfast/config.py
+++ b/src/breakfast/config.py
@@ -29,14 +29,15 @@ _DEFAULT_CONFIG_CONTENT = """\
 
 # -----------------------------------------------------------------------------
 # Target
-# Which organisation and repos to query by default.
+# Which owner and repos to query by default.
 # -----------------------------------------------------------------------------
 
-# GitHub organisation(s) to query for open pull requests.
-# Equivalent to: breakfast -o <value> (repeat -o for multiple orgs).
+# GitHub owner (organization or personal account) to query for open pull requests.
+# Equivalent to: breakfast -o <value> (repeat -o for multiple owners).
 # Required (must be set here or passed with -o on every run).
-# For multiple orgs, use a list: organization = ["my-org", "another-org"]
-# organization = "my-org"
+# For multiple owners, use a list: owner = ["my-org", "another-org"]
+# Note: the old 'organization' key still works but is deprecated — use 'owner'.
+# owner = "my-org"
 
 # Filter repositories by name. Only repos whose name matches are included.
 # Supports substring matching and glob patterns (* ? [). Use a list to match
@@ -191,7 +192,7 @@ _DEFAULT_CONFIG_CONTENT = """\
 # -----------------------------------------------------------------------------
 # Caching
 # Cache results on disk so repeated runs are near-instant.
-# The cache is keyed by (organization, repo-filter) — each pair gets its own
+# The cache is keyed by (owner, repo-filter) — each pair gets its own
 # file stored in ~/.cache/breakfast/ (or $XDG_CACHE_HOME/breakfast/).
 # -----------------------------------------------------------------------------
 
@@ -433,6 +434,17 @@ def load_config(config_path=None):
             # seasonal-colours = false → seasonal-calendar = "off" (backward compat)
             if not data.get("seasonal-colours", True):
                 data.setdefault("seasonal-calendar", "off")
+            # organization → owner (deprecated key, backward compat)
+            if "organization" in data:
+                click.echo(
+                    click.style(
+                        "⚠️  Config key 'organization' is deprecated and will be"
+                        " removed in a future release. Rename it to 'owner'.",
+                        fg="yellow",
+                    ),
+                    err=True,
+                )
+                data.setdefault("owner", data.pop("organization"))
             for key in _LIST_KEYS:
                 if key in data and not isinstance(data[key], list):
                     logger.warning(

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -131,7 +131,7 @@ def test_get_github_prs_filters_and_paginates(monkeypatch):
     responses = [
         {
             "data": {
-                "organization": {
+                "repositoryOwner": {
                     "repositories": {
                         "nodes": [
                             {
@@ -162,7 +162,7 @@ def test_get_github_prs_filters_and_paginates(monkeypatch):
         },
         {
             "data": {
-                "organization": {
+                "repositoryOwner": {
                     "repositories": {
                         "nodes": [
                             {
@@ -201,7 +201,7 @@ def test_get_github_prs_filters_and_paginates(monkeypatch):
 def _single_page_response(repos):
     return {
         "data": {
-            "organization": {
+            "repositoryOwner": {
                 "repositories": {
                     "nodes": repos,
                     "pageInfo": {"endCursor": None, "hasNextPage": False},
@@ -215,7 +215,7 @@ def _single_page_graphql(pr_urls):
     """Return a one-page GraphQL response with a single repo containing pr_urls."""
     return {
         "data": {
-            "organization": {
+            "repositoryOwner": {
                 "repositories": {
                     "nodes": [
                         {
@@ -233,7 +233,7 @@ def _single_page_graphql(pr_urls):
 def test_get_github_prs_skips_null_repo_nodes(monkeypatch):
     response = {
         "data": {
-            "organization": {
+            "repositoryOwner": {
                 "repositories": {
                     "nodes": [
                         None,
@@ -255,6 +255,17 @@ def test_get_github_prs_skips_null_repo_nodes(monkeypatch):
     prs = api.get_github_prs("org", None)
 
     assert prs == ["https://example.com/valid-repo/1"]
+
+
+def test_get_github_prs_raises_owner_not_found_when_null(monkeypatch):
+    response = {"data": {"repositoryOwner": None}}
+    monkeypatch.setattr(api, "make_github_graphql_request", lambda _q, _v: response)
+    monkeypatch.setattr(api, "BREAKFAST_ITEMS", ["*"])
+
+    with pytest.raises(api.OwnerNotFoundError) as exc_info:
+        api.get_github_prs("ghost-login", None)
+
+    assert "ghost-login" in str(exc_info.value)
 
 
 def test_match_exclude_repos_exact():

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -584,7 +584,7 @@ def test_cli_checks_not_shown_by_default(monkeypatch):
 def test_cli_show_config_includes_status_style_from_config(tmp_path):
     cfg_path = tmp_path / "breakfast.toml"
     cfg_path.write_text(
-        'organization = "org"\n'
+        'owner = "org"\n'
         'repo-filter = "repo"\n'
         "checks = true\n"
         'status-style = "ascii"\n'
@@ -956,9 +956,7 @@ def test_cli_json_excludes_approval_by_default(monkeypatch):
 
 def test_cli_approvals_config_file(tmp_path):
     cfg_path = tmp_path / "breakfast.toml"
-    cfg_path.write_text(
-        'organization = "org"\nrepo-filter = "repo"\napprovals = true\n'
-    )
+    cfg_path.write_text('owner = "org"\nrepo-filter = "repo"\napprovals = true\n')
 
     runner = CliRunner()
     result = runner.invoke(cli.breakfast, ["--config", str(cfg_path), "--show-config"])
@@ -2984,7 +2982,7 @@ def test_error_messages_go_to_stderr(monkeypatch):
 
 def test_config_format_json_enables_json_output(monkeypatch, tmp_path):
     cfg_file = tmp_path / "config.toml"
-    cfg_file.write_text('format = "json"\norganization = "org"\n')
+    cfg_file.write_text('format = "json"\nowner = "org"\n')
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
     monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
@@ -3002,7 +3000,7 @@ def test_config_format_json_enables_json_output(monkeypatch, tmp_path):
 
 def test_config_format_table_produces_table_output(monkeypatch, tmp_path):
     cfg_file = tmp_path / "config.toml"
-    cfg_file.write_text('format = "table"\norganization = "org"\n')
+    cfg_file.write_text('format = "table"\nowner = "org"\n')
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
     monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
@@ -3019,7 +3017,7 @@ def test_config_format_table_produces_table_output(monkeypatch, tmp_path):
 
 def test_config_format_invalid_warns_and_falls_back_to_table(monkeypatch, tmp_path):
     cfg_file = tmp_path / "config.toml"
-    cfg_file.write_text('format = "tofu"\norganization = "org"\n')
+    cfg_file.write_text('format = "tofu"\nowner = "org"\n')
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
     monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
@@ -3039,7 +3037,7 @@ def test_config_format_invalid_warns_and_falls_back_to_table(monkeypatch, tmp_pa
 def test_cli_no_json_flag_overrides_config_format_json(monkeypatch, tmp_path):
     """--no-json on CLI overrides format = "json" in config."""
     cfg_file = tmp_path / "config.toml"
-    cfg_file.write_text('format = "json"\norganization = "org"\n')
+    cfg_file.write_text('format = "json"\nowner = "org"\n')
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
     monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
@@ -3120,7 +3118,7 @@ def test_format_markdown_output_goes_to_stdout(monkeypatch):
 
 def test_config_format_markdown_produces_markdown_output(monkeypatch, tmp_path):
     cfg_file = tmp_path / "config.toml"
-    cfg_file.write_text('format = "markdown"\norganization = "org"\n')
+    cfg_file.write_text('format = "markdown"\nowner = "org"\n')
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
     monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
@@ -3300,7 +3298,7 @@ def test_format_csv_includes_optional_age_column(monkeypatch):
 
 def test_config_format_csv_produces_csv_output(monkeypatch, tmp_path):
     cfg_file = tmp_path / "config.toml"
-    cfg_file.write_text('format = "csv"\norganization = "org"\n')
+    cfg_file.write_text('format = "csv"\nowner = "org"\n')
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
     monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
@@ -3618,7 +3616,69 @@ def test_missing_organization_exits_with_error(monkeypatch):
     result = runner.invoke(cli.breakfast, [])
 
     assert result.exit_code == 1
-    assert "Organization must be provided" in result.stderr
+    assert "Owner must be provided" in result.stderr
+
+
+# ---------------------------------------------------------------------------
+# Owner flag / deprecation (#295, #325, #327)
+# ---------------------------------------------------------------------------
+
+
+def test_deprecated_org_flag_warns_and_works(monkeypatch, tmp_path):
+    monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "tok")
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
+    monkeypatch.setattr(cli, "get_github_prs", lambda *_: [])
+
+    result = CliRunner().invoke(cli.breakfast, ["--org", "my-org"])
+
+    assert "deprecated" in result.stderr
+    assert "--owner" in result.stderr
+
+
+def test_deprecated_organization_flag_warns_and_works(monkeypatch, tmp_path):
+    monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "tok")
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
+    monkeypatch.setattr(cli, "get_github_prs", lambda *_: [])
+
+    result = CliRunner().invoke(cli.breakfast, ["--organization", "my-org"])
+
+    assert "deprecated" in result.stderr
+    assert "--owner" in result.stderr
+
+
+def test_deprecated_organization_config_key_warns(monkeypatch, tmp_path):
+    monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "tok")
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
+    monkeypatch.setattr(cli, "get_github_prs", lambda *_: [])
+
+    cfg_file = tmp_path / "config.toml"
+    cfg_file.write_text('organization = "my-org"\n')
+
+    result = CliRunner().invoke(cli.breakfast, ["--config", str(cfg_file)])
+
+    assert "deprecated" in result.stderr
+    assert "'organization'" in result.stderr
+    assert "'owner'" in result.stderr
+
+
+def test_owner_not_found_exits_cleanly(monkeypatch, tmp_path):
+    from breakfast.api import OwnerNotFoundError
+
+    def _raise(*_):
+        raise OwnerNotFoundError("ghost")
+
+    monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "tok")
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
+    monkeypatch.setattr(cli, "get_github_prs", _raise)
+
+    cfg_file = tmp_path / "config.toml"
+    cfg_file.write_text('owner = "ghost"\n')
+
+    result = CliRunner().invoke(cli.breakfast, ["--config", str(cfg_file)])
+
+    assert result.exit_code == 1
+    assert "ghost" in result.stderr
+    assert "Traceback" not in result.output
 
 
 # ---------------------------------------------------------------------------
@@ -3670,7 +3730,7 @@ def test_multiple_repo_filters_config_list(monkeypatch, tmp_path):
     monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
 
     config_file = tmp_path / "breakfast.toml"
-    config_file.write_text('organization = "org"\nrepo-filter = ["api", "platform"]\n')
+    config_file.write_text('owner = "org"\nrepo-filter = ["api", "platform"]\n')
 
     captured = []
 
@@ -3778,7 +3838,7 @@ def test_scoped_filter_from_config(monkeypatch, tmp_path):
 
     config_file = tmp_path / "breakfast.toml"
     config_file.write_text(
-        'organization = ["my-org:api", "other-org"]\nrepo-filter = "platform"\n'
+        'owner = ["my-org:api", "other-org"]\nrepo-filter = "platform"\n'
     )
 
     captured = {}
@@ -3941,7 +4001,7 @@ def test_template_config_implies_format(monkeypatch, tmp_path):
     monkeypatch.setattr(api, "make_github_api_request", _fake_pr_detail)
 
     config_content = """
-organization = "org"
+owner = "org"
 template = "{repo} -> {title}"
 """
     config_file = tmp_path / "config.toml"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -84,13 +84,14 @@ def test_normalize_ignore_authors_multiple():
 def test_load_config_expand_user(tmp_path, monkeypatch):
     # Mock HOME to tmp_path
     monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setattr(config.click, "echo", lambda *a, **kw: None)
 
     cfg_file = tmp_path / "myconfig.toml"
-    cfg_file.write_text('organization = "home-org"')
+    cfg_file.write_text('owner = "home-org"')
 
     # Test path with ~
     result = config.load_config(str(cfg_file).replace(str(tmp_path), "~"))
-    assert result["organization"] == "home-org"
+    assert result["owner"] == "home-org"
 
 
 def test_generate_default_config(tmp_path, monkeypatch):
@@ -103,8 +104,9 @@ def test_generate_default_config(tmp_path, monkeypatch):
     assert result is True
     config_file = tmp_path / ".config" / "breakfast" / "config.toml"
     assert config_file.exists()
-    assert 'organization = "my-org"' in config_file.read_text()
-    assert 'status-style = "emoji"' in config_file.read_text()
+    content = config_file.read_text()
+    assert '# owner = "my-org"' in content
+    assert 'status-style = "emoji"' in content
 
     # Second run: should not overwrite
     result2 = config.generate_default_config()
@@ -435,7 +437,7 @@ def test_extract_option_blocks_finds_all_keys():
     keys = [k for k, _ in blocks]
     # Spot-check a representative sample from every section
     for expected in [
-        "organization",
+        "owner",
         "repo-filter",
         "ignore-author",
         "mine-only",
@@ -460,9 +462,11 @@ def test_extract_option_blocks_finds_all_keys():
 
 def test_extract_option_blocks_block_includes_description():
     blocks = dict(config._extract_option_blocks(config._DEFAULT_CONFIG_CONTENT))
-    # The organization block should include its description comment
-    assert "GitHub organisation" in blocks["organization"]
-    assert "# organization" in blocks["organization"]
+    # The owner block should include its description comment
+    assert "GitHub owner" in blocks["owner"]
+    assert "# owner" in blocks["owner"]
+    # 'organization' is not a standalone template key; deprecated via load_config only
+    assert "organization" not in blocks
 
 
 def test_extract_option_blocks_no_duplicate_keys():
@@ -534,20 +538,20 @@ def test_update_config_appends_missing_options(tmp_path, monkeypatch):
     config_dir.mkdir(parents=True)
     config_file = config_dir / "config.toml"
     # Write a minimal config that is missing most options
-    config_file.write_text('organization = "my-org"\n')
+    config_file.write_text('owner = "my-org"\n')
 
     result = config.update_config()
     assert result is True
 
     updated = config_file.read_text()
     # The original content is preserved
-    assert 'organization = "my-org"' in updated
+    assert 'owner = "my-org"' in updated
     # Missing options were appended
     assert "# workers = 64" in updated
     assert "# no-colour = false" in updated
     assert "# update-summary = false" in updated
-    # organization should NOT be duplicated
-    assert updated.count("organization") == 1
+    # owner should NOT be duplicated
+    assert updated.count('owner = "my-org"') == 1
     # Separator includes version and timestamp
     pattern = (
         r"# --- Added by --update-config \(breakfast v.+\)"
@@ -558,7 +562,7 @@ def test_update_config_appends_missing_options(tmp_path, monkeypatch):
     # A backup was created
     backups = list(config_dir.glob("config.toml.bak.*"))
     assert len(backups) == 1
-    assert backups[0].read_text() == 'organization = "my-org"\n'
+    assert backups[0].read_text() == 'owner = "my-org"\n'
 
 
 def test_update_config_does_not_duplicate_commented_key(tmp_path, monkeypatch):
@@ -616,7 +620,7 @@ def test_load_config_continues_after_invalid_toml(tmp_path, monkeypatch):
     bad_file = tmp_path / "bad.toml"
     bad_file.write_text("not valid [[[ toml")
     good_file = tmp_path / "good.toml"
-    good_file.write_text('organization = "test-org"')
+    good_file.write_text('owner = "test-org"')
 
     monkeypatch.setattr(
         config,
@@ -626,7 +630,7 @@ def test_load_config_continues_after_invalid_toml(tmp_path, monkeypatch):
     monkeypatch.setattr(config.click, "echo", lambda *a, **kw: None)
 
     result = config.load_config()
-    assert result.get("organization") == "test-org"
+    assert result.get("owner") == "test-org"
 
 
 def test_load_config_wraps_scalar_ignore_author_to_list(tmp_path, monkeypatch):
@@ -738,3 +742,35 @@ def test_parse_columns_config_all_invalid_returns_none(monkeypatch):
     monkeypatch.setattr(config.click, "echo", lambda *a, **kw: None)
     result = config.parse_columns_config(["not-a-column"])
     assert result is None
+
+
+def test_load_config_organization_key_deprecated_and_normalized(monkeypatch, tmp_path):
+    """Config key 'organization' is normalized to 'owner' with a deprecation warning."""
+    warnings = []
+    monkeypatch.setattr(
+        config.click, "echo", lambda msg, **kw: warnings.append(str(msg))
+    )
+
+    cfg_file = tmp_path / "config.toml"
+    cfg_file.write_text('organization = "my-org"\n')
+    monkeypatch.setattr(config, "get_config_paths", lambda: [cfg_file])
+
+    result = config.load_config()
+
+    assert result.get("owner") == "my-org"
+    assert "organization" not in result
+    assert any("deprecated" in w for w in warnings)
+    assert any("'owner'" in w for w in warnings)
+
+
+def test_load_config_owner_takes_precedence_over_organization(monkeypatch, tmp_path):
+    """When both 'owner' and 'organization' are present, 'owner' wins."""
+    monkeypatch.setattr(config.click, "echo", lambda *a, **kw: None)
+
+    cfg_file = tmp_path / "config.toml"
+    cfg_file.write_text('owner = "new-owner"\norganization = "old-org"\n')
+    monkeypatch.setattr(config, "get_config_paths", lambda: [cfg_file])
+
+    result = config.load_config()
+
+    assert result.get("owner") == "new-owner"


### PR DESCRIPTION
## Summary

- **Root cause fix for #295, #325, #327**: The GraphQL query previously used `organization(login:)`, which only resolves GitHub *org* accounts — personal accounts like `mrsixw` returned a `NOT_FOUND` error and crashed with a raw Python traceback. The fix switches to `repositoryOwner(login:)`, which resolves both organizations and personal user accounts.

- **Key Changes**:
  - `src/breakfast/api.py`: New `OwnerNotFoundError` exception class. `get_github_prs` now uses `repositoryOwner(login: $owner)` in its GraphQL query; if the response returns `null` (owner not resolvable), raises `OwnerNotFoundError` with a clear message.
  - `src/breakfast/cli.py`: Imports and catches `OwnerNotFoundError` in the fetch loop, printing a clean user-facing error to stderr (`🍳 Owner not found: ...`) and exiting cleanly. `--owner` is now the canonical primary flag (`-o` unchanged); `--org` and `--organization` are kept as hidden deprecated aliases that emit a `⚠️` deprecation warning to stderr. The function signature gains `owner`, `org_deprecated`, and `organization_deprecated` params merged in the body. `--show-config` output key renamed from `"organization"` to `"owner"`.
  - `src/breakfast/config.py`: `load_config` now detects the old `organization` config key, emits a deprecation warning to stderr, and normalizes it to `owner` automatically. The `_DEFAULT_CONFIG_CONTENT` template updated to use `owner = "my-org"` as canonical; the old `organization` key is mentioned only as a prose note (not as a parseable option block, so `--update-config` won't inject it into existing configs).

- **Abstractions & Design Decisions**:
  - `OwnerNotFoundError` is raised at the API layer (api.py) and caught at the CLI layer (cli.py), keeping error handling concerns separated.
  - Deprecated flag detection uses three separate Click options (hidden) merged in the function body with explicit warnings — avoids Click callback complexity while remaining explicit and testable.
  - Config normalization happens per-file in `load_config` so the deprecation warning fires once per config file that has the old key.

## Test plan

- [x] `make format && make lint && make test` passes — 464 tests, all green.
- [x] **New unit tests added**:
  - `test_get_github_prs_raises_owner_not_found_when_null` — verifies `OwnerNotFoundError` is raised when `repositoryOwner` returns `null`.
  - `test_deprecated_org_flag_warns_and_works` — verifies `--org` emits a deprecation warning to stderr.
  - `test_deprecated_organization_flag_warns_and_works` — verifies `--organization` emits a deprecation warning to stderr.
  - `test_deprecated_organization_config_key_warns` — verifies `organization = ...` in config emits a deprecation warning on stderr.
  - `test_owner_not_found_exits_cleanly` — verifies the CLI exits with code 1 and no traceback when `OwnerNotFoundError` is raised.
  - `test_load_config_organization_key_deprecated_and_normalized` — verifies `organization` key is normalized to `owner` in the merged config result.
  - `test_load_config_owner_takes_precedence_over_organization` — verifies `owner` wins when both keys are present.
- [x] All existing tests updated: GraphQL response fixtures updated from `"organization"` to `"repositoryOwner"` key; config strings updated from `organization = "org"` to `owner = "org"`.
- [x] **Docs updated**: `docs/manual/options.md` (new `--owner` section, deprecated aliases noted), `docs/manual/usage.md`, `docs/manual/troubleshooting.md` (new "Owner not found" section).

Closes #295
Closes #325
Closes #327

🤖 Generated with [Claude Code](https://claude.com/claude-code)