### PR TITLE
feat: add columns config with inline table format (Option A)

### DIFF
--- a/docs/manual/options.md
+++ b/docs/manual/options.md
@@ -665,38 +665,130 @@ max-title-length = 72
 
 ### `columns` (config only)
 
-Control which columns appear in the table, their order, custom headers, and per-column alignment. Specified as a list of inline TOML tables in your config file.
+Control which columns appear in the table, their order, custom headers, and per-column alignment. Set this in your config file (`~/.config/breakfast/config.toml` or `.breakfast.toml` in the current directory).
 
-Each entry requires a `name` key (the internal column identifier) and accepts two optional keys:
+When `columns` is **not set**, breakfast uses its built-in default layout:
 
-| Key | Description |
-| --- | --- |
-| `name` | Internal column name (required). See the full list below. |
-| `header` | Override the column header text (optional). |
-| `align` | Column alignment: `left`, `center`, or `right` (optional). |
+```text
+Repo | PR Title | Author | State | Files | Commits | +/- | Comments | Mergeable? | Link
+```
 
-**Available column names:** `org`, `repo`, `title`, `author`, `state`, `files`, `commits`, `diff`, `comments`, `age`, `checks`, `approvals`, `head-branch`, `base-branch`, `mergeable`, `link`
+plus any optional columns you've enabled via their individual flags (`--age`, `--checks`, etc.).
 
-When `columns` is set, **optional columns** (`age`, `checks`, `approvals`, `head-branch`, `base-branch`) are automatically enabled if listed — you do not need to also set their individual flags.
+When `columns` **is set**, only the columns you list are shown, in the order you list them. You are in full control.
+
+#### Entry format
+
+Each entry in the list is an inline TOML table with a required `name` key and two optional keys:
+
+| Key | Type | Description |
+| --- | --- | --- |
+| `name` | string (required) | Internal column identifier. See the reference table below. |
+| `header` | string (optional) | Override the column header text shown in the table. |
+| `align` | string (optional) | Cell alignment: `left`, `center`, or `right`. Defaults to `left`. |
+
+#### Column reference
+
+| Name | Default header | Always shown | Description |
+| --- | --- | --- | --- |
+| `org` | `Org` | Only with multiple `-o` flags | GitHub organisation name, hyperlinked. |
+| `repo` | `Repo` | Yes | Repository name, hyperlinked to the repo on GitHub. |
+| `title` | `PR Title` | Yes | PR title, hyperlinked. Seasonal colours apply. |
+| `author` | `Author` | Yes | PR author login, hyperlinked to their GitHub profile. |
+| `state` | `State` | Yes | `open`, `draft`, or `closed`. Colour-coded green/grey/red. |
+| `files` | `Files` | Yes | Number of changed files. Colour-graded by magnitude. |
+| `commits` | `Commits` | Yes | Number of commits. Colour-graded by magnitude. |
+| `diff` | `+/-` | Yes | Additions and deletions, e.g. `+42/-10`. |
+| `comments` | `Comments` | Yes | Number of review comments. Colour-graded by magnitude. |
+| `age` | `Age` | **Optional** (off by default) | Days since the PR was opened. Colour-graded: green < 10d, yellow < 20d, orange < 50d, red 50d+. |
+| `checks` | `Checks` | **Optional** (off by default) | CI check result: ✅ pass, ❌ fail, ⚠️ pending, ➖ none. Requires an extra API call per PR. |
+| `approvals` | `Approved` | **Optional** (off by default) | Review approval status: ✅ approved, ❌ changes, ⏳ pending. Requires an extra API call per PR. |
+| `head-branch` | `Head Branch` | **Optional** (off by default) | Source branch the PR was raised from, hyperlinked. |
+| `base-branch` | `Base Branch` | **Optional** (off by default) | Target branch the PR merges into, hyperlinked. |
+| `mergeable` | `Mergeable?` | Yes | GitHub's mergeability status: ✅ (clean), ❌ (dirty), ⚠️ (behind), ⏳ computing. |
+| `link` | `Link` | Yes | Clickable `PR-N` hyperlink to the PR on GitHub. |
+
+#### Auto-enabling optional columns
+
+Optional columns (`age`, `checks`, `approvals`, `head-branch`, `base-branch`) are **automatically enabled** when they appear in your `columns` list. You do not need to also set `age = true` or pass `--age` on every run.
+
+#### Worked examples
+
+**Minimal morning view** — just what you need at a glance:
 
 ```toml
-# Minimal — just control order
 columns = [
   {name = "repo"},
   {name = "title"},
   {name = "author"},
-  {name = "link"},
-]
-
-# With custom headers and alignment
-columns = [
-  {name = "repo"},
-  {name = "title", header = "Pull Request"},
   {name = "age",   align = "right"},
-  {name = "checks"},
   {name = "link"},
 ]
 ```
+
+**Review-focused view** — hide noise, surface approval and CI state:
+
+```toml
+columns = [
+  {name = "repo"},
+  {name = "title",     header = "Pull Request"},
+  {name = "author"},
+  {name = "checks"},
+  {name = "approvals", header = "Reviews"},
+  {name = "link"},
+]
+```
+
+**Compact view** — useful on narrower terminals:
+
+```toml
+columns = [
+  {name = "repo"},
+  {name = "title", header = "PR"},
+  {name = "link"},
+]
+```
+
+**Stacked-PR view** — see where each PR targets:
+
+```toml
+columns = [
+  {name = "repo"},
+  {name = "title"},
+  {name = "head-branch", header = "From"},
+  {name = "base-branch", header = "Into"},
+  {name = "mergeable"},
+  {name = "link"},
+]
+```
+
+**Full custom view** — everything with numeric columns right-aligned:
+
+```toml
+columns = [
+  {name = "repo"},
+  {name = "title",       header = "Pull Request"},
+  {name = "author"},
+  {name = "state"},
+  {name = "age",         align = "right"},
+  {name = "checks",      header = "CI"},
+  {name = "approvals",   header = "Reviews"},
+  {name = "diff",        align = "right"},
+  {name = "comments",    align = "right"},
+  {name = "mergeable",   header = "Merge?"},
+  {name = "link"},
+]
+```
+
+#### Interaction with CLI flags
+
+When `columns` is set in config, it controls the table layout for all runs. CLI flags still override individual behaviours:
+
+- `--no-age` will suppress age data even if `age` is in `columns` (the column will be absent).
+- `--age` has no effect if `age` is not in `columns` (the column still won't appear).
+- All other flags (`--checks`, `--approvals`, etc.) follow the same logic.
+
+For a one-off column layout without changing your config, use the individual flags directly rather than `columns`.
 
 > **Note:** The `org` column is only shown when multiple organisations are queried (`-o org1 -o org2`). Listing it in `columns` while querying a single org is a no-op.
 

--- a/docs/manual/options.md
+++ b/docs/manual/options.md
@@ -663,6 +663,43 @@ Can also be set in the config file to apply to all runs:
 max-title-length = 72
 ```
 
+### `columns` (config only)
+
+Control which columns appear in the table, their order, custom headers, and per-column alignment. Specified as a list of inline TOML tables in your config file.
+
+Each entry requires a `name` key (the internal column identifier) and accepts two optional keys:
+
+| Key | Description |
+| --- | --- |
+| `name` | Internal column name (required). See the full list below. |
+| `header` | Override the column header text (optional). |
+| `align` | Column alignment: `left`, `center`, or `right` (optional). |
+
+**Available column names:** `org`, `repo`, `title`, `author`, `state`, `files`, `commits`, `diff`, `comments`, `age`, `checks`, `approvals`, `head-branch`, `base-branch`, `mergeable`, `link`
+
+When `columns` is set, **optional columns** (`age`, `checks`, `approvals`, `head-branch`, `base-branch`) are automatically enabled if listed — you do not need to also set their individual flags.
+
+```toml
+# Minimal — just control order
+columns = [
+  {name = "repo"},
+  {name = "title"},
+  {name = "author"},
+  {name = "link"},
+]
+
+# With custom headers and alignment
+columns = [
+  {name = "repo"},
+  {name = "title", header = "Pull Request"},
+  {name = "age",   align = "right"},
+  {name = "checks"},
+  {name = "link"},
+]
+```
+
+> **Note:** The `org` column is only shown when multiple organisations are queried (`-o org1 -o org2`). Listing it in `columns` while querying a single org is a no-op.
+
 ### `--workers`
 
 Number of parallel workers used to fetch PR details, check statuses, and approval statuses. Defaults to `64`. Lower values reduce API concurrency (useful if you're hitting rate limits); higher values may speed things up on very large organisations.

--- a/docs/manual/usage.md
+++ b/docs/manual/usage.md
@@ -96,6 +96,25 @@ Combine with `--head-branch` for the full picture:
 breakfast -o my-org -r platform --head-branch --base-branch
 ```
 
+### Customise your table layout
+
+The `columns` config key lets you choose which columns appear, in what order, with custom headers and alignment. Add it to your config file (`~/.config/breakfast/config.toml`):
+
+```toml
+columns = [
+  {name = "repo"},
+  {name = "title",     header = "Pull Request"},
+  {name = "author"},
+  {name = "age",       align = "right"},
+  {name = "approvals", header = "Reviews"},
+  {name = "link"},
+]
+```
+
+Optional columns (`age`, `checks`, `approvals`, `head-branch`, `base-branch`) are auto-enabled when listed — no extra flags needed.
+
+See the [`columns` option reference](options.md#columns-config-only) for the full column list, alignment options, and more examples.
+
 ### Get machine-readable output
 
 Progress messages go to stderr, so JSON can be piped cleanly:

--- a/src/breakfast/cli.py
+++ b/src/breakfast/cli.py
@@ -40,6 +40,7 @@ from .config import (
     filter_pr_details,
     generate_default_config,
     load_config,
+    parse_columns_config,
     update_config,
 )
 from .logger import configure as configure_logging
@@ -57,6 +58,25 @@ from .ui import (
     render_pr_summary,
 )
 from .updater import check_for_update
+
+_COLUMN_DISPLAY_NAMES: dict[str, str] = {
+    "org": "Org",
+    "repo": "Repo",
+    "title": "PR Title",
+    "author": "Author",
+    "state": "State",
+    "files": "Files",
+    "commits": "Commits",
+    "diff": "+/-",
+    "comments": "Comments",
+    "age": "Age",
+    "checks": "Checks",
+    "approvals": "Approved",
+    "head-branch": "Head Branch",
+    "base-branch": "Base Branch",
+    "mergeable": "Mergeable?",
+    "link": "Link",
+}
 
 # Columns dropped as last resort (least important first)
 _DROPPABLE_COLUMNS = [
@@ -317,6 +337,50 @@ def _auto_fit(pr_data, terminal_width, explicit_max_title_length):
             pr_data = [{k: v for k, v in row.items() if k != col} for row in pr_data]
 
     return pr_data
+
+
+def _apply_column_specs(
+    pr_data: list[dict],
+    column_specs: list[dict],
+    multi_org: bool,
+) -> tuple[list[dict], tuple | None]:
+    """Reorder, filter, and rename columns per user column specs.
+
+    Returns ``(new_pr_data, colalign)`` where *colalign* is either a tuple of
+    alignment strings (one per column) for tabulate, or ``None`` when no custom
+    alignments are set.
+    """
+    if not pr_data:
+        return pr_data, None
+
+    first = pr_data[0]
+    ordered: list[tuple[str, str, str | None]] = []
+    for spec in column_specs:
+        display_key = _COLUMN_DISPLAY_NAMES.get(spec["name"])
+        if not display_key:
+            continue
+        if spec["name"] == "org" and not multi_org:
+            continue
+        if display_key not in first:
+            continue
+        header = spec["header"] if spec["header"] else display_key
+        ordered.append((display_key, header, spec["align"]))
+
+    if not ordered:
+        return pr_data, None
+
+    new_pr_data = [
+        {header: row[display_key] for display_key, header, _ in ordered}
+        for row in pr_data
+    ]
+
+    has_custom_align = any(align is not None for _, _, align in ordered)
+    colalign = (
+        tuple(align if align else "left" for _, _, align in ordered)
+        if has_custom_align
+        else None
+    )
+    return new_pr_data, colalign
 
 
 def _stdout_is_tty():
@@ -1021,6 +1085,20 @@ def breakfast(
         sys.exit(0)
 
     cfg = load_config(config)
+
+    column_specs = parse_columns_config(cfg.get("columns"))
+    if column_specs:
+        _spec_names = {s["name"] for s in column_specs}
+        if "age" in _spec_names and age is None:
+            age = True
+        if "checks" in _spec_names and checks is None:
+            checks = True
+        if "approvals" in _spec_names and approvals is None:
+            approvals = True
+        if "head-branch" in _spec_names and head_branch is None:
+            head_branch = True
+        if "base-branch" in _spec_names and base_branch is None:
+            base_branch = True
 
     # organization is a tuple from multiple=True; merge with config
     if organization:
@@ -2053,7 +2131,7 @@ def breakfast(
         pr_data.append(row)
 
     # Apply explicit title truncation, then auto-fit to terminal if interactive
-    if max_title_length:
+    if max_title_length and pr_data and "PR Title" in pr_data[0]:
         pr_data = [
             {
                 **row,
@@ -2065,6 +2143,12 @@ def breakfast(
         terminal_width = shutil.get_terminal_size().columns
         pr_data = _auto_fit(pr_data, terminal_width, max_title_length)
 
+    colalign = None
+    if column_specs:
+        pr_data, colalign = _apply_column_specs(
+            pr_data, column_specs, len(organizations) > 1
+        )
+
     click.echo(
         tabulate(
             pr_data,
@@ -2072,6 +2156,7 @@ def breakfast(
             showindex=colored_indices,
             tablefmt="outline",
             disable_numparse=True,
+            **({"colalign": colalign} if colalign else {}),
         ),
         color=_stdout_is_tty() and colour,
     )

--- a/src/breakfast/config.py
+++ b/src/breakfast/config.py
@@ -113,6 +113,21 @@ _DEFAULT_CONFIG_CONTENT = """\
 # Equivalent to: --max-title-length <n>
 # max-title-length = 72
 
+# Control which columns appear, their order, headers, and alignment.
+# Each entry is {name = "..."} with optional header = "..." and align = "...".
+# Optional columns (age, checks, approvals, head-branch, base-branch) are
+# automatically enabled when included — no need to set their individual flags.
+# Available names: org, repo, title, author, state, files, commits, diff,
+#   comments, age, checks, approvals, head-branch, base-branch, mergeable, link
+# Expand to multi-line in your config for readability:
+#   columns = [
+#     {name = "repo"},
+#     {name = "title", header = "PR"},
+#     {name = "age", align = "right"},
+#     {name = "link"},
+#   ]
+# columns = [{name = "repo"}, {name = "title"}, {name = "author"}, {name = "link"}]
+
 
 # -----------------------------------------------------------------------------
 # Display
@@ -304,6 +319,98 @@ def _key_present_in_file(key: str, content: str) -> bool:
 
 
 _LIST_KEYS = {"ignore-author", "exclude-repos"}
+
+_VALID_COLUMN_NAMES = frozenset(
+    {
+        "org",
+        "repo",
+        "title",
+        "author",
+        "state",
+        "files",
+        "commits",
+        "diff",
+        "comments",
+        "age",
+        "checks",
+        "approvals",
+        "head-branch",
+        "base-branch",
+        "mergeable",
+        "link",
+    }
+)
+
+_VALID_ALIGNMENTS = frozenset({"left", "center", "right"})
+
+
+def parse_columns_config(columns_raw):
+    """Parse the ``columns`` config value into a list of column spec dicts.
+
+    Accepts either a plain list of column-name strings or a list of inline TOML
+    tables with ``name``, optional ``header``, and optional ``align`` keys.
+
+    Returns ``None`` when *columns_raw* is falsy (no custom column config).
+    Returns a list of ``{"name": str, "header": str|None, "align": str|None}``
+    dicts preserving the user's requested order.
+    """
+    if not columns_raw:
+        return None
+
+    specs = []
+    for item in columns_raw:
+        if isinstance(item, str):
+            name = item.lower()
+            if name not in _VALID_COLUMN_NAMES:
+                click.echo(
+                    click.style(
+                        f"Warning: unknown column name '{name}' in config — skipping.",
+                        fg="yellow",
+                    ),
+                    err=True,
+                )
+                continue
+            specs.append({"name": name, "header": None, "align": None})
+        elif isinstance(item, dict):
+            name = str(item.get("name", "")).lower()
+            if not name or name not in _VALID_COLUMN_NAMES:
+                click.echo(
+                    click.style(
+                        f"Warning: unknown or missing column name '{name}'"
+                        " in config — skipping.",
+                        fg="yellow",
+                    ),
+                    err=True,
+                )
+                continue
+            header = item.get("header") or None
+            raw_align = item.get("align")
+            if raw_align is not None:
+                align = str(raw_align).lower()
+                if align not in _VALID_ALIGNMENTS:
+                    click.echo(
+                        click.style(
+                            f"Warning: invalid align '{raw_align}' for column"
+                            f" '{name}' — must be left, center, or right."
+                            " Ignoring.",
+                            fg="yellow",
+                        ),
+                        err=True,
+                    )
+                    align = None
+            else:
+                align = None
+            specs.append({"name": name, "header": header, "align": align})
+        else:
+            click.echo(
+                click.style(
+                    f"Warning: invalid columns entry {item!r} in config — skipping.",
+                    fg="yellow",
+                ),
+                err=True,
+            )
+
+    return specs or None
 
 
 def load_config(config_path=None):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4041,3 +4041,106 @@ def test_index_column_coloured_when_enabled_by_config(monkeypatch, tmp_path):
     assert result.exit_code == 0
     # ANSI escape codes should wrap the index digit
     assert not re.search(r"\| 0 +\|", result.stdout)
+
+
+# ---------------------------------------------------------------------------
+# Column config (Option A inline table format)
+# ---------------------------------------------------------------------------
+
+_COLUMN_CONFIG_PR = {
+    "base": {
+        "repo": {
+            "name": "my-repo",
+            "html_url": "https://github.com/org/my-repo",
+            "owner": {"login": "org"},
+        }
+    },
+    "mergeable": True,
+    "mergeable_state": "clean",
+    "additions": 5,
+    "deletions": 2,
+    "title": "Fix the thing",
+    "user": {"login": "alice", "html_url": "https://github.com/alice"},
+    "state": "open",
+    "draft": False,
+    "changed_files": 1,
+    "commits": 1,
+    "review_comments": 0,
+    "labels": [],
+    "requested_reviewers": [],
+    "created_at": "2026-01-10T00:00:00Z",
+    "html_url": "https://github.com/org/my-repo/pull/42",
+    "number": 42,
+    "id": 42,
+}
+
+
+def _setup_column_config_mocks(monkeypatch):
+    monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
+    monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
+    monkeypatch.setattr(
+        cli,
+        "get_github_prs",
+        lambda _org, _rf, _s="open": ["https://github.com/org/my-repo/pull/42"],
+    )
+    monkeypatch.setattr(api, "make_github_api_request", lambda _p: _COLUMN_CONFIG_PR)
+
+
+def test_columns_config_reorders_columns(monkeypatch, tmp_path):
+    _setup_column_config_mocks(monkeypatch)
+    cfg_file = tmp_path / "test.toml"
+    cfg_file.write_text(
+        'columns = [{name = "title"}, {name = "repo"}, {name = "link"}]\n'
+    )
+    result = CliRunner().invoke(cli.breakfast, ["-o", "org", "--config", str(cfg_file)])
+    assert result.exit_code == 0
+    # Title column should appear before Repo
+    title_pos = result.stdout.find("PR Title")
+    repo_pos = result.stdout.find("Repo")
+    assert title_pos < repo_pos
+    # Columns not in spec should be absent
+    assert "Author" not in result.stdout
+    assert "State" not in result.stdout
+
+
+def test_columns_config_custom_header(monkeypatch, tmp_path):
+    _setup_column_config_mocks(monkeypatch)
+    cfg_file = tmp_path / "test.toml"
+    cfg_file.write_text(
+        "columns = ["
+        '{name = "repo"}, '
+        '{name = "title", header = "Pull Request"}, '
+        '{name = "link"}]\n'
+    )
+    result = CliRunner().invoke(cli.breakfast, ["-o", "org", "--config", str(cfg_file)])
+    assert result.exit_code == 0
+    assert "Pull Request" in result.stdout
+    assert "PR Title" not in result.stdout
+
+
+def test_columns_config_autoenables_age(monkeypatch, tmp_path):
+    _setup_column_config_mocks(monkeypatch)
+    cfg_file = tmp_path / "test.toml"
+    cfg_file.write_text(
+        "columns = ["
+        '{name = "repo"}, '
+        '{name = "title"}, '
+        '{name = "age"}, '
+        '{name = "link"}]\n'
+    )
+    result = CliRunner().invoke(cli.breakfast, ["-o", "org", "--config", str(cfg_file)])
+    assert result.exit_code == 0
+    assert "Age" in result.stdout
+
+
+def test_columns_config_plain_string_list(monkeypatch, tmp_path):
+    _setup_column_config_mocks(monkeypatch)
+    cfg_file = tmp_path / "test.toml"
+    cfg_file.write_text('columns = ["repo", "title", "link"]\n')
+    result = CliRunner().invoke(cli.breakfast, ["-o", "org", "--config", str(cfg_file)])
+    assert result.exit_code == 0
+    assert "Repo" in result.stdout
+    assert "PR Title" in result.stdout
+    assert "Link" in result.stdout
+    assert "Author" not in result.stdout

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -678,3 +678,63 @@ def test_load_config_list_ignore_author_not_wrapped(tmp_path, monkeypatch):
     assert result["ignore-author"] == ["alice", "bob"]
     warning_calls = [c for c in echo_calls if "ignore-author" in str(c[0])]
     assert len(warning_calls) == 0
+
+
+def test_parse_columns_config_none():
+    assert config.parse_columns_config(None) is None
+
+
+def test_parse_columns_config_empty():
+    assert config.parse_columns_config([]) is None
+
+
+def test_parse_columns_config_plain_strings():
+    result = config.parse_columns_config(["repo", "title", "link"])
+    assert result == [
+        {"name": "repo", "header": None, "align": None},
+        {"name": "title", "header": None, "align": None},
+        {"name": "link", "header": None, "align": None},
+    ]
+
+
+def test_parse_columns_config_inline_tables():
+    raw = [
+        {"name": "repo"},
+        {"name": "title", "header": "PR"},
+        {"name": "age", "align": "right"},
+    ]
+    result = config.parse_columns_config(raw)
+    assert result == [
+        {"name": "repo", "header": None, "align": None},
+        {"name": "title", "header": "PR", "align": None},
+        {"name": "age", "header": None, "align": "right"},
+    ]
+
+
+def test_parse_columns_config_unknown_name_skipped(monkeypatch):
+    echo_calls = []
+    monkeypatch.setattr(
+        config.click, "echo", lambda msg, **kw: echo_calls.append((msg, kw))
+    )
+    result = config.parse_columns_config(["repo", "bogus", "link"])
+    assert result == [
+        {"name": "repo", "header": None, "align": None},
+        {"name": "link", "header": None, "align": None},
+    ]
+    assert any("bogus" in str(c[0]) for c in echo_calls)
+
+
+def test_parse_columns_config_invalid_align_ignored(monkeypatch):
+    echo_calls = []
+    monkeypatch.setattr(
+        config.click, "echo", lambda msg, **kw: echo_calls.append((msg, kw))
+    )
+    result = config.parse_columns_config([{"name": "age", "align": "diagonal"}])
+    assert result == [{"name": "age", "header": None, "align": None}]
+    assert any("diagonal" in str(c[0]) for c in echo_calls)
+
+
+def test_parse_columns_config_all_invalid_returns_none(monkeypatch):
+    monkeypatch.setattr(config.click, "echo", lambda *a, **kw: None)
+    result = config.parse_columns_config(["not-a-column"])
+    assert result is None


### PR DESCRIPTION
Introduces a `columns` config key that lets users control which columns
appear, their order, custom headers, and per-column alignment using an
inline TOML table array:

  columns = [
    {name = "repo"},
    {name = "title", header = "PR"},
    {name = "age",   align = "right"},
    {name = "link"},
  ]

Optional columns (age, checks, approvals, head-branch, base-branch) are
auto-enabled when listed — no separate flag needed. Plain string lists
are also accepted for backward compatibility. Unknown column names and
invalid alignments emit warnings and are skipped gracefully.

Closes #289

https://claude.ai/code/session_016ShaUCYnXkNwD8sA8p29t8