### PR TITLE
#309: Add mandatory sync-to-main rule to agent instruction files

### DIFF
--- a/.agents/skills/start-issue/SKILL.md
+++ b/.agents/skills/start-issue/SKILL.md
@@ -14,10 +14,16 @@ Standardized procedure to initialize work on a new issue branch.
 
 ### Steps
 
-1. **Sync main first:**
+1. **Sync main and check its CI status:**
+   Sync the local `main` branch first:
    ```bash
    git fetch origin main && git checkout main && git pull origin main
    ```
+   Then check the CI status of the latest completed run on `main`:
+   ```bash
+   gh run list --branch main --status completed --limit 1 --json conclusion --jq '.[0].conclusion'
+   ```
+   If the output is not `success`, stop immediately, report the failure to the user, and ask for instructions before creating a branch from a broken `main`.
 
 2. **Look up the issue title dynamically using the GitHub CLI (`gh`):**
    ```bash

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -23,12 +23,17 @@ When updating project rules, update **all four files** to keep them consistent.
 ## Mandatory Workflow
 1. **GitHub Issues First:** An issue MUST exist before work begins. If none exists, create one via `gh issue create`. (Do not use conventional commit prefixes for issue titles). *Exception*: Refinements, feedback iterations, or trivial tweaks on in-flight/undelivered feature branches do not require raising new issues; make changes directly on the active branch. If you are unsure whether to raise a new GitHub issue or continue on a current active branch, always pause and ask the user directly first.
 2. **One Issue = One PR:** Never combine fixes for multiple unrelated issues into a single PR. Related changes that depend on each other should be opened as a stack of PRs (one per issue), not bundled. *Exception*: Trivial tweaks or closely related follow-up iterations can be added directly to the active branch rather than stack-PRing every detail.
-3. **Branch Naming:** Format: `issue-N_short_description` (e.g., `issue-42_add_avocado_toast`).
-4. **PR Titles:** Include the issue number: `#N: Description` (e.g., `#42: Add Avocado Toast output`).
-5. **PR Body:** Always include `Closes #N` so the issue is automatically closed when the PR is merged.
-6. **CI Checks:** After pushing to a branch with an open PR, wait for all CI checks to complete (`gh pr checks`). If any check fails, investigate and fix the root cause — do not ignore failures or proceed without understanding them.
-7. **Release notes format:** Releases are created by CI via `gh release create --generate-notes`. If editing release notes manually (e.g. via the GitHub UI), use bullet points (`- item`) for each change. The `update-summary` feature extracts the first three bullets, strips Markdown headers and URLs, and caps at 200 characters — prose paragraphs at the top of the body produce poor summaries.
-8. **Conventional Git Commits:** Use standard prefixes for git commits: `feat:`, `fix:`, `chore:`, `docs:`, `refactor:`, `test:`, `ci:`.
+3. **Sync Main First:** Before creating a new branch, always sync `main` first:
+   ```bash
+   git fetch origin main && git checkout main && git pull origin main
+   ```
+   Branch off the updated `main`. Never start a feature branch from a stale local copy.
+4. **Branch Naming:** Format: `issue-N_short_description` (e.g., `issue-42_add_avocado_toast`).
+5. **PR Titles:** Include the issue number: `#N: Description` (e.g., `#42: Add Avocado Toast output`).
+6. **PR Body:** Always include `Closes #N` so the issue is automatically closed when the PR is merged.
+7. **CI Checks:** After pushing to a branch with an open PR, wait for all CI checks to complete (`gh pr checks`). If any check fails, investigate and fix the root cause — do not ignore failures or proceed without understanding them.
+8. **Release notes format:** Releases are created by CI via `gh release create --generate-notes`. If editing release notes manually (e.g. via the GitHub UI), use bullet points (`- item`) for each change. The `update-summary` feature extracts the first three bullets, strips Markdown headers and URLs, and caps at 200 characters — prose paragraphs at the top of the body produce poor summaries.
+9. **Conventional Git Commits:** Use standard prefixes for git commits: `feat:`, `fix:`, `chore:`, `docs:`, `refactor:`, `test:`, `ci:`.
 
 ## Automated Workflows
 This repository provides standardized automated workflows for managing issues. All agents must refer to and execute these exact steps:

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -23,10 +23,15 @@ When updating project rules, update **all four files** to keep them consistent.
 ## Mandatory Workflow
 1. **GitHub Issues First:** An issue MUST exist before work begins. If none exists, create one via `gh issue create`. (Do not use conventional commit prefixes for issue titles). *Exception*: Refinements, feedback iterations, or trivial tweaks on in-flight/undelivered feature branches do not require raising new issues; make changes directly on the active branch. If you are unsure whether to raise a new GitHub issue or continue on a current active branch, always pause and ask the user directly first.
 2. **One Issue = One PR:** Never combine fixes for multiple unrelated issues into a single PR. Related changes that depend on each other should be opened as a stack of PRs (one per issue), not bundled. *Exception*: Trivial tweaks or closely related follow-up iterations can be added directly to the active branch rather than stack-PRing every detail.
-3. **Sync Main First:** Before creating a new branch, always sync `main` first:
+3. **Sync Main and Check CI First:** Before creating a new branch, always sync `main` first:
    ```bash
    git fetch origin main && git checkout main && git pull origin main
    ```
+   Then check the CI status of the latest completed run on `main`:
+   ```bash
+   gh run list --branch main --status completed --limit 1 --json conclusion --jq '.[0].conclusion'
+   ```
+   If the output is not `success`, stop immediately, report the failure to the user, and do not create a branch from a broken `main` until resolved.
    Branch off the updated `main`. Never start a feature branch from a stale local copy.
 4. **Branch Naming:** Format: `issue-N_short_description` (e.g., `issue-42_add_avocado_toast`).
 5. **PR Titles:** Include the issue number: `#N: Description` (e.g., `#42: Add Avocado Toast output`).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,6 +55,11 @@ When updating project rules, update **all four files** to keep them consistent.
 ## Work Items
 - This project uses GitHub issues (not Jira). Reference the GitHub issue number in branch names and PR titles.
 - Branch names should include the issue number and a short description (e.g., `issue-26_filter_pr_authors`).
+- **Before creating a new branch, always sync `main` first:**
+  ```bash
+  git fetch origin main && git checkout main && git pull origin main
+  ```
+  Branch off the updated `main`. Never start a feature branch from a stale local copy.
 - **A GitHub issue MUST exist before any work begins.** If the user requests a change and no issue exists yet, create one (or ask the user to create one) before starting implementation. Every branch, commit, and PR must reference an issue number. *Exception*: Refinements, feedback iterations, or trivial tweaks on in-flight/undelivered feature branches do not require raising new issues; make changes directly on the active branch. If you are unsure whether to raise a new GitHub issue or continue on a current active branch, always pause and ask the user directly first.
 - **One issue = one branch = one PR.** Never combine fixes for multiple unrelated issues into a single PR. If changes are related and depend on each other, open them as a stack of PRs (one per issue) rather than bundling. *Exception*: Trivial tweaks or closely related follow-up iterations can be added directly to the active branch rather than stack-PRing every detail.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,10 +55,15 @@ When updating project rules, update **all four files** to keep them consistent.
 ## Work Items
 - This project uses GitHub issues (not Jira). Reference the GitHub issue number in branch names and PR titles.
 - Branch names should include the issue number and a short description (e.g., `issue-26_filter_pr_authors`).
-- **Before creating a new branch, always sync `main` first:**
+- **Before creating a new branch, always sync `main` first and check its CI status:**
   ```bash
   git fetch origin main && git checkout main && git pull origin main
   ```
+  Then, check the CI status of the latest completed run on `main`:
+  ```bash
+  gh run list --branch main --status completed --limit 1 --json conclusion --jq '.[0].conclusion'
+  ```
+  If the output is not `success`, stop immediately, report the build failure to the user, and do not create a branch from a broken `main` until resolved.
   Branch off the updated `main`. Never start a feature branch from a stale local copy.
 - **A GitHub issue MUST exist before any work begins.** If the user requests a change and no issue exists yet, create one (or ask the user to create one) before starting implementation. Every branch, commit, and PR must reference an issue number. *Exception*: Refinements, feedback iterations, or trivial tweaks on in-flight/undelivered feature branches do not require raising new issues; make changes directly on the active branch. If you are unsure whether to raise a new GitHub issue or continue on a current active branch, always pause and ask the user directly first.
 - **One issue = one branch = one PR.** Never combine fixes for multiple unrelated issues into a single PR. If changes are related and depend on each other, open them as a stack of PRs (one per issue) rather than bundling. *Exception*: Trivial tweaks or closely related follow-up iterations can be added directly to the active branch rather than stack-PRing every detail.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,6 +55,11 @@ When updating project rules, update **all four files** to keep them consistent.
 ## Work Items
 - This project uses GitHub issues (not Jira). Reference the GitHub issue number in branch names and PR titles.
 - Branch names should include the issue number and a short description (e.g., `issue-26_filter_pr_authors`).
+- **Before creating a new branch, always sync `main` first:**
+  ```bash
+  git fetch origin main && git checkout main && git pull origin main
+  ```
+  Branch off the updated `main`. Never start a feature branch from a stale local copy.
 - **A GitHub issue MUST exist before any work begins.** If the user requests a change and no issue exists yet, create one (or ask the user to create one) before starting implementation. Every branch, commit, and PR must reference an issue number. *Exception*: Refinements, feedback iterations, or trivial tweaks on in-flight/undelivered feature branches do not require raising new issues; make changes directly on the active branch. If you are unsure whether to raise a new GitHub issue or continue on a current active branch, always pause and ask the user directly first.
 - **One issue = one branch = one PR.** Never combine fixes for multiple unrelated issues into a single PR. If changes are related and depend on each other, open them as a stack of PRs (one per issue) rather than bundling. *Exception*: Trivial tweaks or closely related follow-up iterations can be added directly to the active branch rather than stack-PRing every detail.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,10 +55,15 @@ When updating project rules, update **all four files** to keep them consistent.
 ## Work Items
 - This project uses GitHub issues (not Jira). Reference the GitHub issue number in branch names and PR titles.
 - Branch names should include the issue number and a short description (e.g., `issue-26_filter_pr_authors`).
-- **Before creating a new branch, always sync `main` first:**
+- **Before creating a new branch, always sync `main` first and check its CI status:**
   ```bash
   git fetch origin main && git checkout main && git pull origin main
   ```
+  Then, check the CI status of the latest completed run on `main`:
+  ```bash
+  gh run list --branch main --status completed --limit 1 --json conclusion --jq '.[0].conclusion'
+  ```
+  If the output is not `success`, stop immediately, report the build failure to the user, and do not create a branch from a broken `main` until resolved.
   Branch off the updated `main`. Never start a feature branch from a stale local copy.
 - **A GitHub issue MUST exist before any work begins.** If the user requests a change and no issue exists yet, create one (or ask the user to create one) before starting implementation. Every branch, commit, and PR must reference an issue number. *Exception*: Refinements, feedback iterations, or trivial tweaks on in-flight/undelivered feature branches do not require raising new issues; make changes directly on the active branch. If you are unsure whether to raise a new GitHub issue or continue on a current active branch, always pause and ask the user directly first.
 - **One issue = one branch = one PR.** Never combine fixes for multiple unrelated issues into a single PR. If changes are related and depend on each other, open them as a stack of PRs (one per issue) rather than bundling. *Exception*: Trivial tweaks or closely related follow-up iterations can be added directly to the active branch rather than stack-PRing every detail.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -18,12 +18,17 @@ When updating project rules, update **all four files** to keep them consistent.
 ## Mandatory Workflow
 1. **GitHub Issues First:** An issue MUST exist before work begins. If none exists, create one via `gh issue create`. (Do not use conventional commit prefixes for issue titles). *Exception*: Refinements, feedback iterations, or trivial tweaks on in-flight/undelivered feature branches do not require raising new issues; make changes directly on the active branch. If you are unsure whether to raise a new GitHub issue or continue on a current active branch, always pause and ask the user directly first.
 2. **One Issue = One PR:** Never combine fixes for multiple unrelated issues into a single PR. Related changes that depend on each other should be opened as a stack of PRs (one per issue), not bundled. *Exception*: Trivial tweaks or closely related follow-up iterations can be added directly to the active branch rather than stack-PRing every detail.
-3. **Branch Naming:** Format: `issue-N_short_description` (e.g., `issue-42_add_avocado_toast`).
-4. **PR Titles:** Include the issue number: `#N: Description` (e.g., `#42: Add Avocado Toast output`).
-5. **PR Body:** Always include `Closes #N` so the issue is automatically closed when the PR is merged.
-6. **CI Checks:** After pushing to a branch with an open PR, wait for all CI checks to complete (`gh pr checks`). If any check fails, investigate and fix the root cause — do not ignore failures or proceed without understanding them.
-7. **Release notes format:** Releases are created by CI via `gh release create --generate-notes`. If editing release notes manually (e.g. via the GitHub UI), use bullet points (`- item`) for each change. The `update-summary` feature extracts the first three bullets, strips Markdown headers and URLs, and caps at 200 characters — prose paragraphs at the top of the body produce poor summaries.
-8. **Conventional Git Commits:** Use standard prefixes for git commits: `feat:`, `fix:`, `chore:`, `docs:`, `refactor:`, `test:`, `ci:`.
+3. **Sync Main First:** Before creating a new branch, always sync `main` first:
+   ```bash
+   git fetch origin main && git checkout main && git pull origin main
+   ```
+   Branch off the updated `main`. Never start a feature branch from a stale local copy.
+4. **Branch Naming:** Format: `issue-N_short_description` (e.g., `issue-42_add_avocado_toast`).
+5. **PR Titles:** Include the issue number: `#N: Description` (e.g., `#42: Add Avocado Toast output`).
+6. **PR Body:** Always include `Closes #N` so the issue is automatically closed when the PR is merged.
+7. **CI Checks:** After pushing to a branch with an open PR, wait for all CI checks to complete (`gh pr checks`). If any check fails, investigate and fix the root cause — do not ignore failures or proceed without understanding them.
+8. **Release notes format:** Releases are created by CI via `gh release create --generate-notes`. If editing release notes manually (e.g. via the GitHub UI), use bullet points (`- item`) for each change. The `update-summary` feature extracts the first three bullets, strips Markdown headers and URLs, and caps at 200 characters — prose paragraphs at the top of the body produce poor summaries.
+9. **Conventional Git Commits:** Use standard prefixes for git commits: `feat:`, `fix:`, `chore:`, `docs:`, `refactor:`, `test:`, `ci:`.
 
 ## Automated Workflows
 This repository provides standardized automated workflows for managing issues. All agents must refer to and execute these exact steps:

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -18,10 +18,15 @@ When updating project rules, update **all four files** to keep them consistent.
 ## Mandatory Workflow
 1. **GitHub Issues First:** An issue MUST exist before work begins. If none exists, create one via `gh issue create`. (Do not use conventional commit prefixes for issue titles). *Exception*: Refinements, feedback iterations, or trivial tweaks on in-flight/undelivered feature branches do not require raising new issues; make changes directly on the active branch. If you are unsure whether to raise a new GitHub issue or continue on a current active branch, always pause and ask the user directly first.
 2. **One Issue = One PR:** Never combine fixes for multiple unrelated issues into a single PR. Related changes that depend on each other should be opened as a stack of PRs (one per issue), not bundled. *Exception*: Trivial tweaks or closely related follow-up iterations can be added directly to the active branch rather than stack-PRing every detail.
-3. **Sync Main First:** Before creating a new branch, always sync `main` first:
+3. **Sync Main and Check CI First:** Before creating a new branch, always sync `main` first:
    ```bash
    git fetch origin main && git checkout main && git pull origin main
    ```
+   Then check the CI status of the latest completed run on `main`:
+   ```bash
+   gh run list --branch main --status completed --limit 1 --json conclusion --jq '.[0].conclusion'
+   ```
+   If the output is not `success`, stop immediately, report the failure to the user, and do not create a branch from a broken `main` until resolved.
    Branch off the updated `main`. Never start a feature branch from a stale local copy.
 4. **Branch Naming:** Format: `issue-N_short_description` (e.g., `issue-42_add_avocado_toast`).
 5. **PR Titles:** Include the issue number: `#N: Description` (e.g., `#42: Add Avocado Toast output`).


### PR DESCRIPTION
## Summary

- **Add mandatory sync-to-main rule**: Updates all four agent instruction files and the `start-issue` skill description to explicitly require fetching and syncing the `main` branch before starting work on any new issue branch.
- **Enforce CI status check on main**: Instructs agents to check the CI status of the latest completed run on `main` right after syncing, stopping immediately if the build is not clean to prevent branch creation off a broken codebase.
- **Key Changes**:
  - Added the `sync-to-main` requirement, the CI status check command (`gh run list --branch main --status completed --limit 1 --json conclusion --jq '.[0].conclusion'`), and the failure-stop rule to the Work Items / Mandatory Workflow sections of `CLAUDE.md`, `GEMINI.md`, `AGENTS.md`, and `.github/copilot-instructions.md`.
  - Added the same verification steps to the `start-issue` skill configuration in `.agents/skills/start-issue/SKILL.md`.
  - Realigned and renumbered list items in files where sequential lists are maintained to keep instructions consistent.

## Test plan

- [x] `make format && make lint && make test` passes (verify all checks are clean).

Closes #309

🥐 Prepared by [Gemini](https://deepmind.google/technologies/gemini/)