### PR TITLE
#333: Add request timeouts to GitHub REST and GraphQL calls

### DIFF
--- a/docs/manual/troubleshooting.md
+++ b/docs/manual/troubleshooting.md
@@ -17,9 +17,13 @@ The token needs `repo` scope to access pull request data. Generate one at [githu
 - If using `--mine-only`, ensure the token belongs to the user whose PRs you want to see
 - If using `--ignore-author`, check you haven't accidentally filtered out the authors you want
 
-## API errors (502, 503, 504)
+## API errors (502, 503, 504) and timeouts
 
-breakfast automatically retries REST API requests on transient server errors with exponential backoff (up to 3 retries). If errors persist:
+breakfast automatically retries REST and GraphQL API requests on transient server errors and network timeouts with exponential backoff (up to 3 retries).
+
+To prevent the CLI from hanging indefinitely on stalled or flaky connections (e.g. captive portals or misconfigured VPNs), an explicit timeout is set on all API requests: a connection timeout of 5 seconds and a read timeout of 30 seconds.
+
+If errors or timeouts persist:
 
 - Check [GitHub Status](https://www.githubstatus.com/) for ongoing incidents
 - Verify your token hasn't been revoked

--- a/src/breakfast/api.py
+++ b/src/breakfast/api.py
@@ -48,6 +48,7 @@ class OwnerNotFoundError(Exception):
 
 _MAX_RETRIES = 3
 _RETRY_STATUSES = {502, 503, 504}
+_REQUEST_TIMEOUT = (5, 30)
 
 _api_stats_lock = threading.Lock()
 _api_stats = {
@@ -94,7 +95,7 @@ def make_github_api_request(query_string):
             time.sleep(2 ** (attempt - 1) + random.uniform(0, 0.5))
         try:
             t0 = time.monotonic()
-            req = requests.get(url, headers=headers)
+            req = requests.get(url, headers=headers, timeout=_REQUEST_TIMEOUT)
             elapsed_ms = int((time.monotonic() - t0) * 1000)
             if req.status_code in _RETRY_STATUSES and attempt < _MAX_RETRIES:
                 logger.debug(
@@ -200,7 +201,12 @@ def make_github_graphql_request(query, variables=None):
             time.sleep(2 ** (attempt - 1) + random.uniform(0, 0.5))
         try:
             t0 = time.monotonic()
-            response = requests.post(GITHUB_GRAPHQL_URL, json=payload, headers=headers)
+            response = requests.post(
+                GITHUB_GRAPHQL_URL,
+                json=payload,
+                headers=headers,
+                timeout=_REQUEST_TIMEOUT,
+            )
             elapsed_ms = int((time.monotonic() - t0) * 1000)
             if response.status_code in _RETRY_STATUSES and attempt < _MAX_RETRIES:
                 logger.debug(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,3 +8,33 @@ def isolate_cache(tmp_path, monkeypatch):
     """Redirect the PR cache to a per-test temp dir so tests don't share cache state."""
     monkeypatch.setattr(cache, "_CACHE_DIR", tmp_path / "breakfast_cache")
     api.get_required_approving_review_count.cache_clear()
+
+
+@pytest.fixture(autouse=True)
+def wrap_monkeypatch(monkeypatch):
+    original_setattr = monkeypatch.setattr
+
+    def custom_setattr(target, name, value, *args, **kwargs):
+        if target is api.requests and name in ("get", "post"):
+            original_value = value
+            import inspect
+
+            def wrapped(*w_args, **w_kwargs):
+                if not callable(original_value):
+                    return original_value
+                try:
+                    sig = inspect.signature(original_value)
+                    has_kwargs = any(
+                        p.kind == p.VAR_KEYWORD for p in sig.parameters.values()
+                    )
+                    has_timeout = "timeout" in sig.parameters
+                    if not (has_kwargs or has_timeout):
+                        w_kwargs.pop("timeout", None)
+                except (ValueError, TypeError):
+                    pass
+                return original_value(*w_args, **w_kwargs)
+
+            value = wrapped
+        return original_setattr(target, name, value, *args, **kwargs)
+
+    monkeypatch.setattr = custom_setattr

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1188,3 +1188,72 @@ def test_get_check_status_all_completed_with_none_filtered(monkeypatch):
 
     monkeypatch.setattr(api, "make_github_api_request", fake_api)
     assert api.get_check_status("org", "repo", "abc123") == "pass"
+
+
+def test_make_github_api_request_asserts_timeout(monkeypatch):
+    """Verifies that make_github_api_request passes the correct timeout kwarg."""
+    timeout_passed = []
+
+    class DummyResponse:
+        status_code = 200
+
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return {"ok": True}
+
+    def fake_get(url, headers, timeout=None):
+        timeout_passed.append(timeout)
+        return DummyResponse()
+
+    monkeypatch.setattr(api, "SECRET_GITHUB_TOKEN", "token-123")
+    monkeypatch.setattr(api.requests, "get", fake_get)
+
+    result = api.make_github_api_request("/repos/org/repo")
+    assert result == {"ok": True}
+    assert timeout_passed == [(5, 30)]
+
+
+def test_make_github_graphql_request_asserts_timeout(monkeypatch):
+    """Verifies that make_github_graphql_request passes the correct timeout kwarg."""
+    timeout_passed = []
+
+    class DummyResponse:
+        status_code = 200
+
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return {"data": {"ok": True}}
+
+    def fake_post(url, json, headers, timeout=None):
+        timeout_passed.append(timeout)
+        return DummyResponse()
+
+    monkeypatch.setattr(api, "SECRET_GITHUB_TOKEN", "token-123")
+    monkeypatch.setattr(api.requests, "post", fake_post)
+
+    result = api.make_github_graphql_request("{ viewer { login } }")
+    assert result == {"data": {"ok": True}}
+    assert timeout_passed == [(5, 30)]
+
+
+def test_make_github_api_request_retries_on_timeout_and_propagates(monkeypatch):
+    """Verifies that a Timeout is retried _MAX_RETRIES times and then raises."""
+    attempts = []
+    monkeypatch.setattr(api, "SECRET_GITHUB_TOKEN", "token-123")
+    monkeypatch.setattr(api.time, "sleep", lambda _: None)
+
+    def fake_get(url, headers, timeout=None):
+        attempts.append(1)
+        raise requests.exceptions.Timeout("timed out")
+
+    monkeypatch.setattr(api.requests, "get", fake_get)
+
+    with pytest.raises(requests.exceptions.Timeout):
+        api.make_github_api_request("/repos/org/repo")
+
+    # 1 initial attempt + 3 retries = 4 attempts total
+    assert len(attempts) == 4


### PR DESCRIPTION
## Summary

- **Add request timeouts to GitHub REST and GraphQL calls**: Implemented explicit connection and read timeouts for all requests made to the GitHub REST and GraphQL APIs. This prevents the CLI from hanging indefinitely on stalled/flaky network connections and allows the offline fallback mechanism to engage correctly when a request times out.
- **Key Changes**:
  - Modified [src/breakfast/api.py](file:///Users/steve/git/breakfast/src/breakfast/api.py):
    - Added `_REQUEST_TIMEOUT = (5, 30)` constant (5 seconds connection timeout, 30 seconds read timeout).
    - Passed `timeout=_REQUEST_TIMEOUT` parameter to `requests.get` inside `make_github_api_request` and to `requests.post` inside `make_github_graphql_request`.
  - Modified [tests/conftest.py](file:///Users/steve/git/breakfast/tests/conftest.py): Added `wrap_monkeypatch` autouse fixture to automatically strip the `timeout` parameter from intercepted/mocked requests calls if the mocked function's signature does not accept it. This preserves transparency and compatibility for older tests.
  - Modified [docs/manual/troubleshooting.md](file:///Users/steve/git/breakfast/docs/manual/troubleshooting.md): Updated API errors troubleshooting documentation with details on connection timeouts and retry behavior.
- **Abstractions & Design Decisions**:
  - Implemented a monkeypatch wrapper in `conftest.py` utilizing `inspect.signature` to dynamically inspect mock functions, ensuring full backward compatibility of existing test mock handlers without modifying 16+ different testing scopes.

## Test plan

- [x] `make format && make lint && make test` passes.
- [x] **Targeted unit tests added**:
  - `test_make_github_api_request_asserts_timeout` — verifies that REST requests receive the `timeout` parameter.
  - `test_make_github_graphql_request_asserts_timeout` — verifies that GraphQL requests receive the `timeout` parameter.
  - `test_make_github_api_request_retries_on_timeout_and_propagates` — verifies that timeout exceptions trigger standard retry backoffs up to `_MAX_RETRIES` times and then propagate.

Closes #333

🤖 Prepared by [Antigravity](https://github.com/google-deepmind)