### PR TITLE
#353: Forbid agents from merging pull requests

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -40,6 +40,7 @@ When updating project rules, update **all four files** to keep them consistent.
 8. **CI Checks:** After pushing to a branch with an open PR, wait for all CI checks to complete (`gh pr checks`). If any check fails, investigate and fix the root cause — do not ignore failures or proceed without understanding them.
 9. **Release notes format:** Releases are created by CI via `gh release create --generate-notes`. If editing release notes manually (e.g. via the GitHub UI), use bullet points (`- item`) for each change. The `update-summary` feature extracts the first three bullets, strips Markdown headers and URLs, and caps at 200 characters — prose paragraphs at the top of the body produce poor summaries.
 10. **Conventional Git Commits:** Use standard prefixes for git commits: `feat:`, `fix:`, `chore:`, `docs:`, `refactor:`, `test:`, `ci:`.
+11. **No PR Merges by Agents:** CRITICAL: Agents must NEVER, under any circumstances, merge pull requests. Merging PRs is strictly reserved for the human user. Any automated merge commands or attempts to merge are strictly forbidden.
 
 ## Automated Workflows
 This repository provides standardized automated workflows for managing issues. All agents must refer to and execute these exact steps:

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -41,6 +41,7 @@ When updating project rules, update **all four files** to keep them consistent.
 9. **Release notes format:** Releases are created by CI via `gh release create --generate-notes`. If editing release notes manually (e.g. via the GitHub UI), use bullet points (`- item`) for each change. The `update-summary` feature extracts the first three bullets, strips Markdown headers and URLs, and caps at 200 characters — prose paragraphs at the top of the body produce poor summaries.
 10. **Conventional Git Commits:** Use standard prefixes for git commits: `feat:`, `fix:`, `chore:`, `docs:`, `refactor:`, `test:`, `ci:`.
 11. **No PR Merges by Agents:** CRITICAL: Agents must NEVER, under any circumstances, merge pull requests. Merging PRs is strictly reserved for the human user. Any automated merge commands or attempts to merge are strictly forbidden.
+12. **No Force Pushing:** Agents must NOT use force pushing (`git push --force` or similar). If force pushing is absolutely necessary, the agent must first explain the reason to the user, list all other alternatives that were exhausted, and obtain explicit user confirmation before proceeding.
 
 ## Automated Workflows
 This repository provides standardized automated workflows for managing issues. All agents must refer to and execute these exact steps:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,6 +86,7 @@ This repository provides standardized automated workflows for managing issues. A
 - **Before merging a PR, tick off all acceptance criteria checkboxes in the linked GitHub issue** that were satisfied by the PR's changes. Use `gh issue edit <N> --body "..."` to update the body. If a criterion was not met, leave it unchecked and add a comment explaining why.
 - **After pushing to a branch with an open PR, wait for all CI checks to complete.** Use `gh pr checks` to monitor status. If any check fails, investigate and fix the root cause before proceeding — do not ignore failures or re-push without understanding them.
 - **No PR Merges by Agents:** CRITICAL: Agents must NEVER, under any circumstances, merge pull requests. Merging PRs is strictly reserved for the human user. Any automated merge commands or attempts to merge are strictly forbidden.
+- **No Force Pushing:** Agents must NOT use force pushing (`git push --force` or similar). If force pushing is absolutely necessary, the agent must first explain the reason to the user, list all other alternatives that were exhausted, and obtain explicit user confirmation before proceeding.
 
 ## mkver Usage
 - `git mkver patch` mutates the version file; avoid running it as part of routine local builds on feature branches.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,6 +85,7 @@ This repository provides standardized automated workflows for managing issues. A
 - Always include `Closes #N` in the PR body so the issue is automatically closed when the PR is merged.
 - **Before merging a PR, tick off all acceptance criteria checkboxes in the linked GitHub issue** that were satisfied by the PR's changes. Use `gh issue edit <N> --body "..."` to update the body. If a criterion was not met, leave it unchecked and add a comment explaining why.
 - **After pushing to a branch with an open PR, wait for all CI checks to complete.** Use `gh pr checks` to monitor status. If any check fails, investigate and fix the root cause before proceeding — do not ignore failures or re-push without understanding them.
+- **No PR Merges by Agents:** CRITICAL: Agents must NEVER, under any circumstances, merge pull requests. Merging PRs is strictly reserved for the human user. Any automated merge commands or attempts to merge are strictly forbidden.
 
 ## mkver Usage
 - `git mkver patch` mutates the version file; avoid running it as part of routine local builds on feature branches.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,6 +86,7 @@ This repository provides standardized automated workflows for managing issues. A
 - **Before merging a PR, tick off all acceptance criteria checkboxes in the linked GitHub issue** that were satisfied by the PR's changes. Use `gh issue edit <N> --body "..."` to update the body. If a criterion was not met, leave it unchecked and add a comment explaining why.
 - **After pushing to a branch with an open PR, wait for all CI checks to complete.** Use `gh pr checks` to monitor status. If any check fails, investigate and fix the root cause before proceeding — do not ignore failures or re-push without understanding them.
 - **No PR Merges by Agents:** CRITICAL: Agents must NEVER, under any circumstances, merge pull requests. Merging PRs is strictly reserved for the human user. Any automated merge commands or attempts to merge are strictly forbidden.
+- **No Force Pushing:** Agents must NOT use force pushing (`git push --force` or similar). If force pushing is absolutely necessary, the agent must first explain the reason to the user, list all other alternatives that were exhausted, and obtain explicit user confirmation before proceeding.
 
 ## mkver Usage
 - `git mkver patch` mutates the version file; avoid running it as part of routine local builds on feature branches.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,6 +85,7 @@ This repository provides standardized automated workflows for managing issues. A
 - Always include `Closes #N` in the PR body so the issue is automatically closed when the PR is merged.
 - **Before merging a PR, tick off all acceptance criteria checkboxes in the linked GitHub issue** that were satisfied by the PR's changes. Use `gh issue edit <N> --body "..."` to update the body. If a criterion was not met, leave it unchecked and add a comment explaining why.
 - **After pushing to a branch with an open PR, wait for all CI checks to complete.** Use `gh pr checks` to monitor status. If any check fails, investigate and fix the root cause before proceeding — do not ignore failures or re-push without understanding them.
+- **No PR Merges by Agents:** CRITICAL: Agents must NEVER, under any circumstances, merge pull requests. Merging PRs is strictly reserved for the human user. Any automated merge commands or attempts to merge are strictly forbidden.
 
 ## mkver Usage
 - `git mkver patch` mutates the version file; avoid running it as part of routine local builds on feature branches.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -36,6 +36,7 @@ When updating project rules, update **all four files** to keep them consistent.
 9. **Release notes format:** Releases are created by CI via `gh release create --generate-notes`. If editing release notes manually (e.g. via the GitHub UI), use bullet points (`- item`) for each change. The `update-summary` feature extracts the first three bullets, strips Markdown headers and URLs, and caps at 200 characters — prose paragraphs at the top of the body produce poor summaries.
 10. **Conventional Git Commits:** Use standard prefixes for git commits: `feat:`, `fix:`, `chore:`, `docs:`, `refactor:`, `test:`, `ci:`.
 11. **No PR Merges by Agents:** CRITICAL: Agents must NEVER, under any circumstances, merge pull requests. Merging PRs is strictly reserved for the human user. Any automated merge commands or attempts to merge are strictly forbidden.
+12. **No Force Pushing:** Agents must NOT use force pushing (`git push --force` or similar). If force pushing is absolutely necessary, the agent must first explain the reason to the user, list all other alternatives that were exhausted, and obtain explicit user confirmation before proceeding.
 
 ## Automated Workflows
 This repository provides standardized automated workflows for managing issues. All agents must refer to and execute these exact steps:

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -35,6 +35,7 @@ When updating project rules, update **all four files** to keep them consistent.
 8. **CI Checks:** After pushing to a branch with an open PR, wait for all CI checks to complete (`gh pr checks`). If any check fails, investigate and fix the root cause — do not ignore failures or proceed without understanding them.
 9. **Release notes format:** Releases are created by CI via `gh release create --generate-notes`. If editing release notes manually (e.g. via the GitHub UI), use bullet points (`- item`) for each change. The `update-summary` feature extracts the first three bullets, strips Markdown headers and URLs, and caps at 200 characters — prose paragraphs at the top of the body produce poor summaries.
 10. **Conventional Git Commits:** Use standard prefixes for git commits: `feat:`, `fix:`, `chore:`, `docs:`, `refactor:`, `test:`, `ci:`.
+11. **No PR Merges by Agents:** CRITICAL: Agents must NEVER, under any circumstances, merge pull requests. Merging PRs is strictly reserved for the human user. Any automated merge commands or attempts to merge are strictly forbidden.
 
 ## Automated Workflows
 This repository provides standardized automated workflows for managing issues. All agents must refer to and execute these exact steps:


### PR DESCRIPTION
## Summary

- **Forbid agents from merging pull requests**: Updated all agent instruction files with critical rules explicitly forbidding agents from merging pull requests under any circumstances. This guarantees human-in-the-loop control.
- **Restricted force-pushing by agents**: Added strict rules to prevent agents from force-pushing branches without first obtaining explicit confirmation from the user after explaining precisely why and exhausting all other options.
- **Key Changes**:
  - Modified [CLAUDE.md](file:///Users/steve/git/breakfast/CLAUDE.md): Added the critical merge prohibition and force push rules under `## Pull Requests`.
  - Modified [AGENTS.md](file:///Users/steve/git/breakfast/AGENTS.md): Added the critical merge prohibition and force push rules under `## Pull Requests`.
  - Modified [GEMINI.md](file:///Users/steve/git/breakfast/GEMINI.md): Added critical rules 11 and 12 to the `## Mandatory Workflow` section.
  - Modified [.github/copilot-instructions.md](file:///Users/steve/git/breakfast/.github/copilot-instructions.md): Added critical rules 11 and 12 to the `## Mandatory Workflow` section.

## Test plan

- [x] `make format && make lint && make test` passes.
- [x] Verified consistency of rules across all updated files.

Closes #353

🤖 Prepared by [Antigravity](https://github.com/google-deepmind)
