### PR TITLE
#356: Clean up legacy CLI test imports and remove re-exports

### DIFF
--- a/src/breakfast/cli.py
+++ b/src/breakfast/cli.py
@@ -42,16 +42,6 @@ from .config import (
 from .logger import configure as configure_logging
 from .logger import logger
 from .renderers import (
-    _apply_column_specs,  # noqa: F401
-    _auto_fit,  # noqa: F401
-    _compress_styled,  # noqa: F401
-    _osc8_to_markdown,  # noqa: F401
-    _strip_ansi,  # noqa: F401
-    _styled_hyperlink,  # noqa: F401
-    _table_width,  # noqa: F401
-    _truncate_col,  # noqa: F401
-    _truncate_formatted_text,  # noqa: F401
-    _visible_width,  # noqa: F401
     is_legendary,
     render_csv,
     render_json,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -10,7 +10,7 @@ import pytest
 import requests
 from click.testing import CliRunner
 
-from breakfast import api, cache, cli
+from breakfast import api, cache, cli, renderers
 
 
 @pytest.fixture(autouse=True)
@@ -1261,7 +1261,7 @@ def test_cli_status_columns_use_ascii_to_keep_rows_aligned(monkeypatch):
     assert "➖" not in result.stdout
 
     table_lines = [
-        cli._strip_ansi(line)
+        renderers._strip_ansi(line)
         for line in result.stdout.splitlines()
         if line.startswith(("+", "|"))
     ]
@@ -1342,7 +1342,7 @@ def test_auto_fit_truncates_repo_and_author_before_dropping(monkeypatch):
         result = runner.invoke(cli.breakfast, ["-o", "org", "-r", "repo"])
 
     assert result.exit_code == 0
-    visible_output = cli._strip_ansi(result.stdout)
+    visible_output = renderers._strip_ansi(result.stdout)
     # Full long names should have been truncated
     assert "a-very-long-repository-name" not in visible_output
     assert "a-very-long-author-name" not in visible_output


### PR DESCRIPTION
## Summary

- **Remove unused re-exports and noqa comments from cli.py**: Cleaned up the re-exported private helper functions and their `# noqa: F401` comments from [src/breakfast/cli.py](file:///Users/steve/git/breakfast/src/breakfast/cli.py). We updated the legacy unit tests in [tests/test_cli.py](file:///Users/steve/git/breakfast/tests/test_cli.py) to import and access these helpers from [src/breakfast/renderers.py](file:///Users/steve/git/breakfast/src/breakfast/renderers.py) directly.
- **Key Changes**:
  - Modified [src/breakfast/cli.py](file:///Users/steve/git/breakfast/src/breakfast/cli.py): Removed unused renderer helpers from the import block, eliminating `# noqa: F401` comments.
  - Modified [tests/test_cli.py](file:///Users/steve/git/breakfast/tests/test_cli.py): Imported `renderers` and updated `cli._strip_ansi` calls to `renderers._strip_ansi`.

## Test plan

- [x] `make format && make lint && make test` passes.
- [x] **Targeted unit tests updated**:
  - Legacy tests utilizing `_strip_ansi` updated and passing successfully.

Closes #356

🤖 Prepared by [Antigravity](https://github.com/google-deepmind)
