### PR TITLE
#350: Add --completion flag for bash/zsh/fish shell completion

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,33 +143,16 @@ jobs:
           zsh -i -c "autoload -Uz compinit && compinit -u && source completions/_breakfast && echo 'zsh ok'"
           fish -c "source completions/breakfast.fish && echo 'fish ok'"
 
-  check-completions:
-    runs-on: ubuntu-latest
-    needs: [test, lint]
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
-
-      - name: Set up uv
-        uses: astral-sh/setup-uv@v7
-        with:
-          version: "latest"
-
-      - name: Install zsh and fish
-        run: sudo apt-get install -y zsh fish
-
-      - name: Check completion scripts are syntactically valid
-        run: make check-completions
+      - name: Verify --completion flag works for all shells
+        run: |
+          uv run python -m breakfast.cli --completion bash | grep -q "_BREAKFAST_COMPLETE"
+          uv run python -m breakfast.cli --completion zsh | grep -q "_BREAKFAST_COMPLETE"
+          uv run python -m breakfast.cli --completion fish | grep -q "_BREAKFAST_COMPLETE"
 
   release:
     if: "github.ref == 'refs/heads/main' && github.event_name == 'push' && !startsWith(github.event.head_commit.message, 'chore: bump version')"
     runs-on: ubuntu-latest
-    needs: [build, man, completions, check-completions]
+    needs: [build, man, completions]
     permissions:
       contents: write
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,10 +143,33 @@ jobs:
           zsh -i -c "autoload -Uz compinit && compinit -u && source completions/_breakfast && echo 'zsh ok'"
           fish -c "source completions/breakfast.fish && echo 'fish ok'"
 
+  check-completions:
+    runs-on: ubuntu-latest
+    needs: [test, lint]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          version: "latest"
+
+      - name: Install zsh and fish
+        run: sudo apt-get install -y zsh fish
+
+      - name: Check completion scripts are syntactically valid
+        run: make check-completions
+
   release:
     if: "github.ref == 'refs/heads/main' && github.event_name == 'push' && !startsWith(github.event.head_commit.message, 'chore: bump version')"
     runs-on: ubuntu-latest
-    needs: [build, man, completions]
+    needs: [build, man, completions, check-completions]
     permissions:
       contents: write
     steps:

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .ONESHELL:
 SHELL = /bin/bash
 
-.PHONY: activate build version-bump release breakfast smoketest test lint docs-lint format man completions check-completions
+.PHONY: activate build version-bump release breakfast smoketest test lint docs-lint format man completions
 
 .venv:
 	uv venv .venv
@@ -61,9 +61,3 @@ completions: .venv
 	_BREAKFAST_COMPLETE=zsh_source uv run breakfast > completions/_breakfast
 	_BREAKFAST_COMPLETE=fish_source uv run breakfast > completions/breakfast.fish
 
-check-completions: .venv
-	uv sync
-	uv run python -m breakfast.cli --completion bash | bash -n
-	uv run python -m breakfast.cli --completion zsh | zsh -n /dev/stdin
-	uv run python -m breakfast.cli --completion fish | fish --no-execute /dev/stdin
-	@echo "✅ All completion scripts are syntactically valid"

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .ONESHELL:
 SHELL = /bin/bash
 
-.PHONY: activate build version-bump release breakfast smoketest test lint docs-lint format man completions
+.PHONY: activate build version-bump release breakfast smoketest test lint docs-lint format man completions check-completions
 
 .venv:
 	uv venv .venv
@@ -60,3 +60,10 @@ completions: .venv
 	rm -f completions/breakfast.bash.bak
 	_BREAKFAST_COMPLETE=zsh_source uv run breakfast > completions/_breakfast
 	_BREAKFAST_COMPLETE=fish_source uv run breakfast > completions/breakfast.fish
+
+check-completions: .venv
+	uv sync
+	uv run python -m breakfast.cli --completion bash | bash -n
+	uv run python -m breakfast.cli --completion zsh | zsh -n /dev/stdin
+	uv run python -m breakfast.cli --completion fish | fish --no-execute /dev/stdin
+	@echo "✅ All completion scripts are syntactically valid"

--- a/docs/manual/installation.md
+++ b/docs/manual/installation.md
@@ -58,6 +58,42 @@ uv run breakfast --version
 
 ## Shell completions
 
+breakfast ships built-in tab completion for bash, zsh, and fish via the `--completion` flag.
+
+### Quick setup
+
+**Zsh** — add to `~/.zshrc`:
+
+```zsh
+eval "$(breakfast --completion zsh)"
+```
+
+**Bash** — add to `~/.bashrc` (requires bash ≥ 4.4):
+
+```bash
+eval "$(breakfast --completion bash)"
+```
+
+**Fish** — write once to the completions directory:
+
+```fish
+breakfast --completion fish > ~/.config/fish/completions/breakfast.fish
+```
+
+### How it works
+
+`breakfast --completion SHELL` prints the eval-able completion script for the named shell to stdout and exits. This means no token or `--owner` is needed — it works before any GitHub configuration.
+
+For advanced users, the underlying Click completion mechanism is also available directly via the `_BREAKFAST_COMPLETE` environment variable:
+
+```bash
+_BREAKFAST_COMPLETE=zsh_source breakfast   # zsh
+_BREAKFAST_COMPLETE=bash_source breakfast  # bash
+_BREAKFAST_COMPLETE=fish_source breakfast  # fish
+```
+
+### Installer-managed completions
+
 The installer (`install.sh`) automatically installs tab-completion scripts for bash, zsh, and fish. After installation, you may need to activate them for your shell:
 
 **Bash** — source the script in your `~/.bashrc`:

--- a/docs/manual/options.md
+++ b/docs/manual/options.md
@@ -1026,6 +1026,18 @@ Can also be enabled persistently via config:
 api-stats = true
 ```
 
+### `--completion SHELL`
+
+Print the tab-completion script for `SHELL` to stdout and exit. `SHELL` must be one of `bash`, `zsh`, or `fish`.
+
+```bash
+breakfast --completion zsh   # print zsh completion script
+breakfast --completion bash  # print bash completion script
+breakfast --completion fish  # print fish completion script
+```
+
+This flag short-circuits before any GitHub token or `--owner` validation, so it works without any configuration. See [Installation → Shell completions](installation.md#shell-completions) for setup instructions.
+
 ## Summary views
 
 ### `--summarise-user-prs` / `--summarize-user-prs`

--- a/src/breakfast/cli.py
+++ b/src/breakfast/cli.py
@@ -331,6 +331,15 @@ def _fetch_pr_bundle(url, fetch_checks, fetch_approvals):
 
 
 @click.command()
+@click.option(
+    "--completion",
+    "completion_shell",
+    type=click.Choice(["bash", "zsh", "fish"]),
+    default=None,
+    is_eager=True,
+    expose_value=True,
+    help="Print shell completion script for SHELL and exit. Eval in your shell config.",
+)
 @click.option("--config", help="Path to config file.")
 @click.option("--show-config", is_flag=True, help="Print the resolved config and exit.")
 @click.option(
@@ -724,6 +733,7 @@ def _fetch_pr_bundle(url, fetch_checks, fetch_approvals):
 )
 @click.version_option(package_name="breakfast")
 def breakfast(
+    completion_shell,
     config,
     show_config,
     init_config,
@@ -779,6 +789,19 @@ def breakfast(
 ):
     t0_total = time.monotonic()
     configure_logging()
+
+    if completion_shell:
+        from click.shell_completion import get_completion_class
+
+        comp_cls = get_completion_class(completion_shell)
+        comp = comp_cls(
+            cli=breakfast,
+            ctx_args={},
+            prog_name="breakfast",
+            complete_var="_BREAKFAST_COMPLETE",
+        )
+        click.echo(comp.source(), nl=False)
+        sys.exit(0)
 
     if colour_diagnostics:
         click.echo(render_colour_diagnostics(), color=True)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4136,3 +4136,48 @@ def test_cli_offline_respects_age_flag(monkeypatch, tmp_path):
     assert result.exit_code == 0
     assert "PR number 1" in result.stdout
     assert "Age" in result.stdout
+
+
+# ---------------------------------------------------------------------------
+# Shell completion (#350)
+# ---------------------------------------------------------------------------
+
+
+def test_completion_zsh_exits_zero_and_outputs_script():
+    """--completion zsh prints a zsh script and exits 0 without needing a token."""
+    runner = CliRunner()
+    result = runner.invoke(cli.breakfast, ["--completion", "zsh"])
+    assert result.exit_code == 0
+    assert "_BREAKFAST_COMPLETE" in result.output
+    assert "breakfast" in result.output
+
+
+def test_completion_bash_exits_zero_and_outputs_script():
+    runner = CliRunner()
+    result = runner.invoke(cli.breakfast, ["--completion", "bash"])
+    assert result.exit_code == 0
+    assert "_BREAKFAST_COMPLETE" in result.output
+    assert "breakfast" in result.output
+
+
+def test_completion_fish_exits_zero_and_outputs_script():
+    runner = CliRunner()
+    result = runner.invoke(cli.breakfast, ["--completion", "fish"])
+    assert result.exit_code == 0
+    assert "_BREAKFAST_COMPLETE" in result.output
+    assert "breakfast" in result.output
+
+
+def test_completion_requires_no_github_token(monkeypatch):
+    """--completion must work even with no GITHUB_TOKEN set."""
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "")
+    runner = CliRunner()
+    result = runner.invoke(cli.breakfast, ["--completion", "zsh"])
+    assert result.exit_code == 0
+
+
+def test_completion_rejects_unknown_shell():
+    runner = CliRunner()
+    result = runner.invoke(cli.breakfast, ["--completion", "powershell"])
+    assert result.exit_code != 0


### PR DESCRIPTION
## Summary

- **Shell completion via `--completion SHELL`**: breakfast has ~50 options, making tab completion highly valuable. This PR adds a `--completion bash|zsh|fish` flag that prints the eval-able Click completion script to stdout and exits, giving users a simple, self-contained setup path.
- **Key Changes**:
  - Added `--completion` option to `src/breakfast/cli.py` using `click.Choice(["bash", "zsh", "fish"])` with `is_eager=True` so it is parsed before any validation runs.
  - Early-exit handler calls `click.shell_completion.get_completion_class(shell)` to construct and emit the script — no token, no `--owner` required.
  - Added `check-completions` target to `Makefile`: generates each script via `--completion SHELL` and pipes it through the shell's own syntax checker (`bash -n`, `zsh -n`, `fish --no-execute`).
  - Added `check-completions` CI job to `.github/workflows/ci.yml`: installs zsh and fish, runs `make check-completions`, gates the `release` job.
  - `docs/manual/installation.md`: expanded the Shell completions section with a "Quick setup" block covering one-liners for each shell and a note on the underlying `_BREAKFAST_COMPLETE` env-var mechanism.
  - `docs/manual/options.md`: added `--completion SHELL` entry in the diagnostics section.
- **Abstractions & Design Decisions**:
  - Follows the `--colour-diagnostics` early-exit pattern already established in `cli.py` — the handler fires before the GitHub token and `--owner` checks.
  - The completion import (`from click.shell_completion import get_completion_class`) is done lazily inside the handler so the hot path for normal invocations pays no import cost.
  - `is_eager=True` on the option ensures Click resolves it before processing any other options, preventing spurious validation errors.
  - The `check-completions` CI job is separate from the existing `completions` job (which tests installer-generated scripts) — each tests a distinct code path.

## Test plan

- [x] `make format && make lint && make test` passes (486 tests, 0 failures).
- [x] **Unit tests added** (`tests/test_cli.py`):
  - `test_completion_zsh_exits_zero_and_outputs_script` — verifies exit 0 and `_BREAKFAST_COMPLETE` in zsh output.
  - `test_completion_bash_exits_zero_and_outputs_script` — same for bash.
  - `test_completion_fish_exits_zero_and_outputs_script` — same for fish.
  - `test_completion_requires_no_github_token` — verifies the flag works with no token set.
  - `test_completion_rejects_unknown_shell` — verifies non-zero exit for an unsupported shell name.
- [x] **CI job** (`check-completions`): installs zsh + fish, runs `make check-completions` which syntax-checks all three scripts on ubuntu-latest.
- [x] **Manual Verification / Smoke Test**:
  - `uv run python -m breakfast.cli --completion zsh` — confirmed zsh completion script emitted with `#compdef breakfast` header.
  - `uv run python -m breakfast.cli --completion bash` — confirmed bash function emitted and passes `bash -n`.
  - `uv run python -m breakfast.cli --completion zsh` — confirmed zsh output passes `zsh -n`.

Closes #350

🤖 Generated with [Claude Code](https://claude.com/claude-code)