### PR TITLE
#343: Add --filter-mergeable to filter PRs by mergeable status

### DIFF
--- a/docs/manual/options.md
+++ b/docs/manual/options.md
@@ -178,6 +178,18 @@ breakfast -o my-org -r my-app --filter-approval pending --filter-approval change
 
 > **Note:** Review and check statuses are cached alongside PR details, so repeated runs with these flags skip redundant API calls.
 
+### `--filter-mergeable`
+
+Only show PRs with a specific mergeable status. Accepted values: `clean` (no conflicts), `conflict` (needs a rebase), `unknown` (GitHub is still computing mergeability). Repeat the flag to match multiple statuses (OR logic).
+
+```bash
+breakfast -o my-org --filter-mergeable conflict                                           # needs a rebase
+breakfast -o my-org --filter-mergeable clean --filter-approval approved                   # ready to merge
+breakfast -o my-org --filter-mergeable conflict --filter-mergeable unknown                # needs attention
+```
+
+> **Note:** GitHub computes mergeability lazily — a PR may briefly appear as `unknown` immediately after a push while GitHub catches up. See [Troubleshooting](troubleshooting.md#mergeable-status-shows-unknown-unexpectedly) for details.
+
 ### `--filter-reviewer`
 
 Only show PRs that have a specific user listed as a requested reviewer. Matching is **case-insensitive**. Repeat the flag to include any of the given reviewers (OR logic).

--- a/docs/manual/troubleshooting.md
+++ b/docs/manual/troubleshooting.md
@@ -114,3 +114,14 @@ curl -H "Authorization: token $GITHUB_TOKEN" https://api.github.com/orgs/YOUR_OR
 ```bash
 curl -H "Authorization: token $GITHUB_TOKEN" https://api.github.com/users/YOUR_USER
 ```
+
+## Mergeable status shows "unknown" unexpectedly
+
+GitHub computes PR mergeability **lazily** — it does not calculate whether a PR has conflicts until someone (or something) asks. Immediately after a push to a PR branch or its base branch, GitHub marks `mergeable` as `null` while it queues the computation. This typically resolves within a few seconds.
+
+When `--filter-mergeable` is used, breakfast maps `mergeable: null` to `unknown`. This means:
+
+- A PR may briefly appear as `unknown` right after a push, even if it is actually clean.
+- Running breakfast again a few seconds later will show the correct `clean` or `conflict` status.
+
+If you consistently see `unknown` for a PR that has been idle for a while, it may indicate a GitHub API issue. Try refreshing with `--refresh` to bypass the local cache and fetch fresh data.

--- a/src/breakfast/cli.py
+++ b/src/breakfast/cli.py
@@ -594,6 +594,15 @@ def _fetch_pr_bundle(url, fetch_checks, fetch_approvals):
     help="Only show PRs with this review approval status. Repeat for multiple values.",
 )
 @click.option(
+    "--filter-mergeable",
+    type=click.Choice(["clean", "conflict", "unknown"], case_sensitive=False),
+    multiple=True,
+    help=(
+        "Only show PRs with this mergeable status. Repeat for multiple values"
+        " (OR logic). Values: clean, conflict, unknown."
+    ),
+)
+@click.option(
     "--filter-reviewer",
     multiple=True,
     help=(
@@ -771,6 +780,7 @@ def breakfast(
     filter_state,
     filter_check,
     filter_approval,
+    filter_mergeable,
     filter_reviewer,
     filter_label,
     exclude_label,
@@ -1583,6 +1593,7 @@ def breakfast(
         filter_state=filter_state,
         filter_check=filter_check,
         filter_approval=filter_approval,
+        filter_mergeable=filter_mergeable,
         check_statuses=check_statuses,
         approval_statuses=approval_statuses,
         search_title=search,

--- a/src/breakfast/config.py
+++ b/src/breakfast/config.py
@@ -585,6 +585,7 @@ def filter_pr_details(
     filter_state=None,
     filter_check=None,
     filter_approval=None,
+    filter_mergeable=None,
     check_statuses=None,
     approval_statuses=None,
     search_title=None,
@@ -634,6 +635,16 @@ def filter_pr_details(
         if filter_approval and approval_statuses is not None:
             pr_approval = approval_statuses.get(pr_detail["id"], "pending")
             if pr_approval not in filter_approval:
+                continue
+        if filter_mergeable:
+            raw = pr_detail.get("mergeable")
+            if raw is True:
+                mergeable_status = "clean"
+            elif raw is False:
+                mergeable_status = "conflict"
+            else:
+                mergeable_status = "unknown"
+            if mergeable_status not in filter_mergeable:
                 continue
         if search_title is not None:
             title = pr_detail.get("title", "")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4181,3 +4181,53 @@ def test_completion_rejects_unknown_shell():
     runner = CliRunner()
     result = runner.invoke(cli.breakfast, ["--completion", "powershell"])
     assert result.exit_code != 0
+
+
+# ---------------------------------------------------------------------------
+# --filter-mergeable (#343)
+# ---------------------------------------------------------------------------
+
+
+def test_cli_filter_mergeable_conflict(monkeypatch):
+    """--filter-mergeable conflict shows only PRs with mergeable=False."""
+    monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
+    monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
+
+    def fake_get_prs(_org, _repo_filter, _state="open"):
+        return [
+            "https://github.com/org/repo/pull/1",
+            "https://github.com/org/repo/pull/2",
+        ]
+
+    def fake_api_request(path):
+        number = 1 if path.endswith("/1") else 2
+        return {
+            "base": {"repo": {"name": "repo", "owner": {"login": "org"}}},
+            "mergeable": False if number == 1 else True,
+            "mergeable_state": "dirty" if number == 1 else "clean",
+            "additions": 1,
+            "deletions": 0,
+            "title": f"PR {number} {'conflict' if number == 1 else 'clean'}",
+            "user": {"login": "alice"},
+            "state": "open",
+            "changed_files": 1,
+            "commits": 1,
+            "review_comments": 0,
+            "created_at": "2026-01-10T00:00:00Z",
+            "html_url": f"https://github.com/org/repo/pull/{number}",
+            "number": number,
+        }
+
+    monkeypatch.setattr(cli, "get_github_prs", fake_get_prs)
+    monkeypatch.setattr(api, "make_github_api_request", fake_api_request)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli.breakfast,
+        ["-o", "org", "-r", "repo", "--filter-mergeable", "conflict"],
+    )
+
+    assert result.exit_code == 0
+    assert "PR 1 conflict" in result.stdout
+    assert "PR 2 clean" not in result.stdout

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -182,6 +182,59 @@ def test_filter_pr_details_filter_approval():
     assert result[0]["id"] == 1
 
 
+def test_filter_pr_details_filter_mergeable_clean():
+    pr_details = [
+        {**_make_pr(pr_id=1), "mergeable": True},
+        {**_make_pr(pr_id=2), "mergeable": False},
+        {**_make_pr(pr_id=3), "mergeable": None},
+    ]
+    result = config.filter_pr_details(pr_details, [], filter_mergeable=("clean",))
+    assert len(result) == 1
+    assert result[0]["id"] == 1
+
+
+def test_filter_pr_details_filter_mergeable_conflict():
+    pr_details = [
+        {**_make_pr(pr_id=1), "mergeable": True},
+        {**_make_pr(pr_id=2), "mergeable": False},
+        {**_make_pr(pr_id=3), "mergeable": None},
+    ]
+    result = config.filter_pr_details(pr_details, [], filter_mergeable=("conflict",))
+    assert len(result) == 1
+    assert result[0]["id"] == 2
+
+
+def test_filter_pr_details_filter_mergeable_unknown():
+    pr_details = [
+        {**_make_pr(pr_id=1), "mergeable": True},
+        {**_make_pr(pr_id=2), "mergeable": False},
+        {**_make_pr(pr_id=3), "mergeable": None},
+    ]
+    result = config.filter_pr_details(pr_details, [], filter_mergeable=("unknown",))
+    assert len(result) == 1
+    assert result[0]["id"] == 3
+
+
+def test_filter_pr_details_filter_mergeable_missing_field():
+    pr_details = [_make_pr(pr_id=1)]  # no "mergeable" key — treated as unknown
+    result = config.filter_pr_details(pr_details, [], filter_mergeable=("unknown",))
+    assert len(result) == 1
+    result = config.filter_pr_details(pr_details, [], filter_mergeable=("clean",))
+    assert len(result) == 0
+
+
+def test_filter_pr_details_filter_mergeable_multi():
+    pr_details = [
+        {**_make_pr(pr_id=1), "mergeable": True},
+        {**_make_pr(pr_id=2), "mergeable": False},
+        {**_make_pr(pr_id=3), "mergeable": None},
+    ]
+    result = config.filter_pr_details(
+        pr_details, [], filter_mergeable=("clean", "conflict")
+    )
+    assert sorted(r["id"] for r in result) == [1, 2]
+
+
 def test_filter_pr_details_combined_filters():
     pr_details = [
         _make_pr(user="alice", state="open", repo="api", pr_id=1),


### PR DESCRIPTION
## Summary

- **Add \`--filter-mergeable clean|conflict|unknown\`**: Breakfast can already filter by CI check result and approval status; this PR closes the gap for mergeability. Mirrors \`--filter-check\` exactly — \`click.Choice\` with \`multiple=True\` for OR logic, no config key (consistent with the other filter flags).
- **Key Changes**:
  - \`src/breakfast/cli.py\`: new \`@click.option(\"--filter-mergeable\", type=click.Choice([\"clean\", \"conflict\", \"unknown\"]), multiple=True)\` decorator; \`filter_mergeable\` added to the function signature and passed through to \`filter_pr_details\`.
  - \`src/breakfast/config.py\`: \`filter_mergeable\` parameter added to \`filter_pr_details\`; maps \`pr_detail.get(\"mergeable\")\` — \`True\` → \`clean\`, \`False\` → \`conflict\`, \`None\` (or missing) → \`unknown\` — then filters with OR logic.
  - \`docs/manual/options.md\`: \`--filter-mergeable\` section added after \`--filter-approval\`, with examples including the combined \`--filter-mergeable clean --filter-approval approved\` triage pattern.
  - \`docs/manual/troubleshooting.md\`: new section explaining GitHub's lazy mergeability computation and why PRs may briefly show as \`unknown\` after a push.
- **Abstractions & Design Decisions**:
  - Used the raw \`mergeable\` boolean/None field rather than \`mergeable_state\` (which has fine-grained values like \`dirty\`, \`blocked\`, \`behind\`, \`unstable\`) — the three user-facing choices map cleanly onto \`True/False/None\` with no ambiguity.
  - Missing \`mergeable\` key (PR not yet fetched in full) is treated as \`unknown\`, consistent with GitHub's own semantics.

## Test plan

- [x] \`make format && make lint && make test\` passes (492 tests, 0 failures).
- [x] **Unit tests added** (\`tests/test_config.py\`):
  - \`test_filter_pr_details_filter_mergeable_clean\` — \`mergeable=True\` passes, others excluded.
  - \`test_filter_pr_details_filter_mergeable_conflict\` — \`mergeable=False\` passes.
  - \`test_filter_pr_details_filter_mergeable_unknown\` — \`mergeable=None\` passes.
  - \`test_filter_pr_details_filter_mergeable_missing_field\` — absent \`mergeable\` key treated as \`unknown\`.
  - \`test_filter_pr_details_filter_mergeable_multi\` — OR logic: \`(\"clean\", \"conflict\")\` passes both, excludes unknown.
- [x] **Integration test added** (\`tests/test_cli.py\`):
  - \`test_cli_filter_mergeable_conflict\` — CliRunner test with two fake PRs (one \`mergeable=False\`, one \`mergeable=True\`); asserts only the conflict PR appears in stdout.
- [x] **Manual smoke test**: confirmed \`uv run python -m breakfast.cli --help\` lists \`--filter-mergeable\` with the correct choices.

Closes #343

🤖 Generated with [Claude Code](https://claude.com/claude-code)