### PR TITLE
#348: Add size and files options to --sort

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ breakfast -o my-org -r my-app --filter-inactive 7
 breakfast -o my-org -r my-app --search "hotfix"
 breakfast -o my-org -r my-app --sort age
 breakfast -o my-org -r my-app --sort comments --reverse
+breakfast -o my-org -r my-app --sort size
+breakfast -o my-org -r my-app --sort size --reverse
 breakfast -o my-org -r my-app --format json
 breakfast -o my-org -r my-app --format markdown
 breakfast -o my-org -r my-app --format template --template "{repo}: {title} ({url})"
@@ -101,7 +103,7 @@ breakfast --completion bash
 
 ### Sorting
 
-- `--sort`: Sort by field: `repo` (default), `age`, `updated`, `author`, `comments`, `reviews`.
+- `--sort`: Sort by field: `repo` (default), `age`, `updated`, `author`, `comments`, `reviews`, `size`, `files`.
 - `--reverse`: Reverse the sort order.
 
 ### Summary views

--- a/docs/manual/options.md
+++ b/docs/manual/options.md
@@ -1110,10 +1110,14 @@ Sort the PR list by a named field. By default PRs are grouped by repository
 | `author`   | PR author login (alphabetical)                |
 | `comments` | Total comment count (issue + review comments) |
 | `reviews`  | Review comment count only                     |
+| `size`     | Total lines changed (additions + deletions)   |
+| `files`    | Number of files modified                      |
 
 ```bash
 breakfast -o my-org --sort age          # oldest PRs first
 breakfast -o my-org --sort comments     # most commented first
+breakfast -o my-org --sort size         # smallest diffs first
+breakfast -o my-org --sort size --reverse  # chonkers first
 ```
 
 Config key: `sort = "repo"`

--- a/src/breakfast/cli.py
+++ b/src/breakfast/cli.py
@@ -669,13 +669,13 @@ def _fetch_pr_bundle(url, fetch_checks, fetch_approvals):
     "--sort",
     "sort_by",
     type=click.Choice(
-        ["repo", "age", "updated", "author", "comments", "reviews"],
+        ["repo", "age", "updated", "author", "comments", "reviews", "size", "files"],
         case_sensitive=False,
     ),
     default=None,
     help=(
         "Sort PRs by field. Choices: repo (default), age, updated,"
-        " author, comments, reviews."
+        " author, comments, reviews, size, files."
     ),
 )
 @click.option(
@@ -1625,6 +1625,8 @@ def breakfast(
         "author": lambda pr: pr.get("user", {}).get("login", "").lower(),
         "comments": lambda pr: pr.get("comments", 0) + pr.get("review_comments", 0),
         "reviews": lambda pr: pr.get("review_comments", 0),
+        "size": lambda pr: pr.get("additions", 0) + pr.get("deletions", 0),
+        "files": lambda pr: pr.get("changed_files", 0),
     }
     pr_details.sort(
         key=_SORT_KEYS.get(sort_by or "repo", _SORT_KEYS["repo"]),

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3214,6 +3214,62 @@ def test_sort_reverse(monkeypatch):
     assert result.stdout.index("zebra") < result.stdout.index("alpha")
 
 
+def test_sort_by_size(monkeypatch):
+    prs = [
+        _make_sort_pr(1, "repo", "alice", _TS_A, _TS_A),
+        _make_sort_pr(2, "repo", "bob", _TS_A, _TS_A),
+    ]
+    prs[0]["additions"] = 200
+    prs[0]["deletions"] = 50
+    prs[1]["additions"] = 10
+    prs[1]["deletions"] = 5
+    result = _sort_invoke(monkeypatch, prs, "--sort", "size")
+    assert result.exit_code == 0
+    # ascending: smallest diff (PR 2, total 15) before largest (PR 1, total 250)
+    assert result.stdout.index("PR 2") < result.stdout.index("PR 1")
+
+
+def test_sort_by_size_reverse(monkeypatch):
+    prs = [
+        _make_sort_pr(1, "repo", "alice", _TS_A, _TS_A),
+        _make_sort_pr(2, "repo", "bob", _TS_A, _TS_A),
+    ]
+    prs[0]["additions"] = 200
+    prs[0]["deletions"] = 50
+    prs[1]["additions"] = 10
+    prs[1]["deletions"] = 5
+    result = _sort_invoke(monkeypatch, prs, "--sort", "size", "--reverse")
+    assert result.exit_code == 0
+    # reversed: largest diff (PR 1) first
+    assert result.stdout.index("PR 1") < result.stdout.index("PR 2")
+
+
+def test_sort_by_size_missing_fields(monkeypatch):
+    prs = [
+        _make_sort_pr(1, "repo", "alice", _TS_A, _TS_A),
+        _make_sort_pr(2, "repo", "bob", _TS_A, _TS_A),
+    ]
+    del prs[0]["additions"]
+    del prs[0]["deletions"]
+    result = _sort_invoke(monkeypatch, prs, "--sort", "size")
+    assert result.exit_code == 0
+    # PR 1 missing fields → treated as 0; PR 2 has additions=1, deletions=0 → 1
+    assert result.stdout.index("PR 1") < result.stdout.index("PR 2")
+
+
+def test_sort_by_files(monkeypatch):
+    prs = [
+        _make_sort_pr(1, "repo", "alice", _TS_A, _TS_A),
+        _make_sort_pr(2, "repo", "bob", _TS_A, _TS_A),
+    ]
+    prs[0]["changed_files"] = 30
+    prs[1]["changed_files"] = 3
+    result = _sort_invoke(monkeypatch, prs, "--sort", "files")
+    assert result.exit_code == 0
+    # ascending: fewest files (PR 2) before most (PR 1)
+    assert result.stdout.index("PR 2") < result.stdout.index("PR 1")
+
+
 # ---------------------------------------------------------------------------
 # --format template (#183)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- **Add `--sort size` and `--sort files`**: `--sort` previously covered `repo`, `age`, `updated`, `author`, `comments`, `reviews` but had no diff-size option. These two new choices let users surface quick-win small reviews first (or the monsters last) during morning triage — the natural complement to the existing comment/review sorts.
- **Key Changes**:
  - `src/breakfast/cli.py`: added `"size"` and `"files"` to the `click.Choice` list and help text; added two lambdas to `_SORT_KEYS`:
    - `"size": lambda pr: pr.get("additions", 0) + pr.get("deletions", 0)`
    - `"files": lambda pr: pr.get("changed_files", 0)`
  - No changes to the sort call itself — it already resolves keys dynamically via `_SORT_KEYS.get(sort_by or "repo", ...)`.
  - `docs/manual/options.md`: two new rows in the sort-values table plus two usage examples.
  - `README.md`: two new usage examples and updated `--sort` option description.
- **Abstractions & Design Decisions**: Missing `additions`/`deletions`/`changed_files` fields default to `0` via `.get(..., 0)`, consistent with how other numeric sort keys handle absent data. The `sort = "size"` config key works automatically with no extra wiring — `_SORT_KEYS` lookup covers it.

## Test plan

- [x] `make format && make lint && make test` passes (496 tests, 0 failures).
- [x] **Unit tests added** (`tests/test_cli.py`):
  - `test_sort_by_size` — two PRs with different `additions + deletions` totals; asserts smallest diff appears first.
  - `test_sort_by_size_reverse` — same setup with `--reverse`; asserts largest diff appears first.
  - `test_sort_by_size_missing_fields` — PR with no `additions`/`deletions` keys is treated as 0 and sorts correctly without crashing.
  - `test_sort_by_files` — two PRs with different `changed_files`; asserts fewest files appears first.
- [x] **Manual smoke test**: confirmed `uv run python -m breakfast.cli --help` lists `size` and `files` in the `--sort` choices.

Closes #348

🤖 Generated with [Claude Code](https://claude.com/claude-code)