### PR TITLE
#340: Add --needs-my-review to show PRs awaiting your review

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ breakfast -o my-org -o another-org -r platform
 breakfast -o my-org:api -o another-org:platform
 breakfast -o my-org -r my-app --ignore-author dependabot[bot] --ignore-author renovate[bot]
 breakfast -o my-org -r my-app --mine-only
+breakfast -o my-org --needs-my-review
 breakfast -o my-org -r my-app --age
 breakfast -o my-org -r my-app --checks
 breakfast -o my-org -r my-app --approvals
@@ -87,6 +88,7 @@ breakfast --completion bash
 - `--ignore-author`: Exclude PRs by author (case-insensitive, repeatable).
 - `--no-ignore-author`: Clear `ignore-author` config defaults for this run.
 - `--mine-only`: Show only your own PRs.
+- `--needs-my-review`: Show only PRs where you are a requested reviewer.
 - `--no-drafts`: Hide draft PRs.
 - `--drafts-only`: Show only draft PRs.
 - `--fetch-state`: Which PR states to fetch from GitHub: `open` (default), `closed`, `merged`, `all`.

--- a/docs/manual/options.md
+++ b/docs/manual/options.md
@@ -272,6 +272,25 @@ Processing platform PRs...🍳...Done
 +---------+----------------+-----------------+--------+---------+-------+---------+------------+----------+--------------+--------+
 ```
 
+### `--needs-my-review`
+
+Show only PRs where the authenticated GitHub user (determined from `GITHUB_TOKEN`) is a requested reviewer. Ideal for the morning triage: skip everything that isn't waiting on you.
+
+```bash
+breakfast -o my-org --needs-my-review
+breakfast -o my-org --needs-my-review --checks --age --sort age --reverse
+```
+
+Can also be set in the config file:
+
+```toml
+needs-my-review = true
+```
+
+Composable with all other filters, including `--mine-only` (the intersection of PRs you authored and PRs awaiting your review is usually empty, but breakfast won't error).
+
+Config key: `needs-my-review = false`
+
 ### `--no-drafts`
 
 Exclude draft PRs from results. Useful when you only want to review PRs that are ready for review.

--- a/docs/manual/usage.md
+++ b/docs/manual/usage.md
@@ -43,6 +43,14 @@ breakfast -o my-org -r my-app \
   --ignore-author renovate[bot]
 ```
 
+### Morning triage: PRs waiting on you
+
+The most actionable morning view — show only PRs where you are a requested reviewer, sorted oldest-first so the most overdue appear at the top:
+
+```bash
+breakfast -o my-org --needs-my-review --checks --age --sort age --reverse
+```
+
 ### Show only your own PRs
 
 ```text

--- a/src/breakfast/cli.py
+++ b/src/breakfast/cli.py
@@ -418,6 +418,11 @@ def _fetch_pr_bundle(url, fetch_checks, fetch_approvals):
     help="Only include PRs authored by the currently authenticated GitHub user.",
 )
 @click.option(
+    "--needs-my-review/--no-needs-my-review",
+    default=None,
+    help="Only show PRs where you are a requested reviewer.",
+)
+@click.option(
     "--no-drafts",
     is_flag=True,
     default=False,
@@ -755,6 +760,7 @@ def breakfast(
     ignore_author,
     no_ignore_author,
     mine_only,
+    needs_my_review,
     no_drafts,
     drafts_only,
     age,
@@ -916,6 +922,11 @@ def breakfast(
     ignore_author = merged_ignore_authors
 
     mine_only = mine_only if mine_only is not None else cfg.get("mine-only", False)
+    needs_my_review = (
+        needs_my_review
+        if needs_my_review is not None
+        else cfg.get("needs-my-review", False)
+    )
     no_drafts = no_drafts or cfg.get("no-drafts", False)
     drafts_only = drafts_only or cfg.get("drafts-only", False)
     age = age if age is not None else cfg.get("age", False)
@@ -1139,7 +1150,7 @@ def breakfast(
         click.echo(click.style(message, fg="red", bold=True), err=True, color=colour)
         sys.exit(1)
     current_user_login = None
-    if mine_only and not offline:
+    if (mine_only or needs_my_review) and not offline:
         try:
             current_user_login = get_authenticated_user_login()
         except GitHubRateLimitError as exc:
@@ -1571,7 +1582,7 @@ def breakfast(
         if refresh or refresh_prs:
             click.echo("🔄 Cache refreshed.", err=True)
 
-    if mine_only and offline_mode and current_user_login is None:
+    if (mine_only or needs_my_review) and offline_mode and current_user_login is None:
         click.echo(
             click.style(
                 "🔌 Offline Mode: Displaying all cached PRs because "
@@ -1581,6 +1592,10 @@ def breakfast(
             err=True,
             color=colour,
         )
+
+    effective_filter_reviewer = list(filter_reviewer)
+    if needs_my_review and current_user_login:
+        effective_filter_reviewer.append(current_user_login)
 
     before_filter = len(pr_details)
     pr_details = filter_pr_details(
@@ -1597,7 +1612,7 @@ def breakfast(
         check_statuses=check_statuses,
         approval_statuses=approval_statuses,
         search_title=search,
-        filter_reviewer=filter_reviewer,
+        filter_reviewer=effective_filter_reviewer,
         filter_label=filter_label,
         exclude_label=exclude_label,
         filter_stale=filter_stale,

--- a/src/breakfast/config.py
+++ b/src/breakfast/config.py
@@ -73,6 +73,10 @@ _DEFAULT_CONFIG_CONTENT = """\
 # Equivalent to: --mine-only
 # mine-only = false
 
+# Show only PRs where you are a requested reviewer.
+# Equivalent to: --needs-my-review
+# needs-my-review = false
+
 # Maximum number of PRs to display. Applied after all other filters.
 # Unset means show all results.
 # Equivalent to: --limit <n>

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -417,6 +417,81 @@ def test_cli_mine_only_exits_cleanly_on_rate_limit(monkeypatch):
     assert "2026-04-10 16:04:48" in result.stderr
 
 
+def test_cli_needs_my_review_filters_to_requested_reviewer(monkeypatch):
+    monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
+    monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
+
+    def fake_get_prs(_org, _repo_filter, _state="open"):
+        return [
+            "https://github.com/org/repo/pull/1",
+            "https://github.com/org/repo/pull/2",
+        ]
+
+    def fake_api_request(path):
+        number = 1 if path.endswith("/1") else 2
+        title = "Needs Alice Review" if number == 1 else "No Alice Review"
+        reviewers = [{"login": "alice"}] if number == 1 else []
+        return {
+            "base": {"repo": {"name": "repo"}},
+            "mergeable": True,
+            "mergeable_state": "clean",
+            "additions": 5,
+            "deletions": 2,
+            "title": title,
+            "user": {"login": "bob"},
+            "state": "open",
+            "changed_files": 1,
+            "commits": 1,
+            "review_comments": 0,
+            "requested_reviewers": reviewers,
+            "created_at": "2026-01-10T00:00:00Z",
+            "html_url": f"https://github.com/org/repo/pull/{number}",
+            "number": number,
+        }
+
+    monkeypatch.setattr(cli, "get_github_prs", fake_get_prs)
+    monkeypatch.setattr(api, "make_github_api_request", fake_api_request)
+    monkeypatch.setattr(cli, "get_authenticated_user_login", lambda: "alice")
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli.breakfast,
+        ["-o", "org", "-r", "repo", "--needs-my-review"],
+    )
+
+    assert result.exit_code == 0
+    assert "Needs Alice Review" in result.stdout
+    assert "No Alice Review" not in result.stdout
+
+
+def test_cli_needs_my_review_login_fetched_once_with_mine_only(monkeypatch):
+    monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
+    monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
+
+    call_count = {"n": 0}
+
+    def counting_login():
+        call_count["n"] += 1
+        return "alice"
+
+    def fake_get_prs(_org, _repo_filter, _state="open"):
+        return []
+
+    monkeypatch.setattr(cli, "get_github_prs", fake_get_prs)
+    monkeypatch.setattr(cli, "get_authenticated_user_login", counting_login)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli.breakfast,
+        ["-o", "org", "-r", "repo", "--needs-my-review", "--mine-only"],
+    )
+
+    assert result.exit_code == 0
+    assert call_count["n"] == 1
+
+
 def test_cli_outputs_checks_column(monkeypatch):
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])


### PR DESCRIPTION
## Summary

- **Add `--needs-my-review`**: The most actionable morning slice of PRs is the ones waiting on *you*. This flag filters to PRs where the authenticated GitHub user is a requested reviewer — no need to know your own login or type `--filter-reviewer <me>` every morning.
- **Key Changes**:
  - `src/breakfast/cli.py`: new `--needs-my-review/--no-needs-my-review` boolean flag; config resolution (`needs-my-review` key); login fetch (`get_authenticated_user_login`) now triggers on `mine_only or needs_my_review` so it is called at most once even when both flags are set; builds `effective_filter_reviewer` by appending the current user's login when `needs_my_review` is set, then passes that to `filter_pr_details` — no new filtering code path needed; offline warning extended to cover `needs_my_review` too.
  - `src/breakfast/config.py`: `needs-my-review = false` commented entry added to `_DEFAULT_CONFIG_CONTENT` so `--init-config` includes it.
  - `docs/manual/options.md`: full `--needs-my-review` section with config key, examples, and composability note.
  - `docs/manual/usage.md`: new "Morning triage" section with the canonical `--needs-my-review --checks --age --sort age --reverse` invocation.
  - `README.md`: usage example and filtering option entry.
- **Abstractions & Design Decisions**: Rather than adding a new filter branch in `config.py`, `--needs-my-review` appends the authenticated login to the existing `filter_reviewer` list in `cli.py`. This means zero new filter logic — the existing OR-based reviewer filter handles it. Composable with all other filters; combining with `--mine-only` is allowed (the intersection is usually empty) and the login is still fetched only once.

## Test plan

- [x] `make format && make lint && make test` passes (498 tests, 0 failures).
- [x] **Unit tests added** (`tests/test_cli.py`):
  - `test_cli_needs_my_review_filters_to_requested_reviewer` — two PRs, one with alice as a requested reviewer and one without; asserts only the first appears with `--needs-my-review` and login monkeypatched to `"alice"`.
  - `test_cli_needs_my_review_login_fetched_once_with_mine_only` — both `--needs-my-review` and `--mine-only` set; asserts `get_authenticated_user_login` is called exactly once.
- [x] **Manual smoke test**: `uv run python -m breakfast.cli --help` lists `--needs-my-review / --no-needs-my-review` with correct help text.

Closes #340

🤖 Generated with [Claude Code](https://claude.com/claude-code)