### PR TITLE
#342: Add reviewers and labels optional columns

### DIFF
--- a/docs/manual/options.md
+++ b/docs/manual/options.md
@@ -563,6 +563,52 @@ Both flags can be combined to show the full branch path at a glance:
 breakfast -o my-org -r platform --head-branch --base-branch
 ```
 
+### `--reviewers`
+
+Add a "Reviewers" column showing the requested reviewers for each PR. Shows up to 2 logins, then `+N` overflow (e.g. `alice, bob +1`). Off by default.
+
+```text
+$ breakfast -o my-org -r platform --reviewers
+Fetching my-org PRs...🥐...Done
+Processing platform PRs...🍩🧇...Done
++---------+----------------+-----------------+--------+---------+-------+---------+------------+----------+--------------------+--------------+--------+
+|         | Repo           | PR Title        | Author | State   | Files | Commits |    +/-     | Comments | Reviewers          | Mergeable?   | Link   |
++---------+----------------+-----------------+--------+---------+-------+---------+------------+----------+--------------------+--------------+--------+
+|       0 | platform-api   | Add user search | alice  | open    |   3   |    1    |  +42/-10   |    0     | dave, ellen        | ✅ (clean)   | PR-142 |
+|       1 | platform-api   | Fix login bug   | bob    | open    |   1   |    1    |  +5/-2     |    3     | frank, grace +1    | ✅ (clean)   | PR-138 |
+|       2 | platform-ui    | Update nav bar  | carol  | open    |  12   |    4    |  +280/-95  |    1     | -                  | ❌ (dirty)   | PR-87  |
++---------+----------------+-----------------+--------+---------+-------+---------+------------+----------+--------------------+--------------+--------+
+```
+
+Enable in config:
+
+```toml
+reviewers = true
+```
+
+### `--show-labels`
+
+Add a "Labels" column showing the labels applied to each PR. Shows up to 2 labels, then `+N` overflow (e.g. `bug, enhancement +1`). Off by default.
+
+```text
+$ breakfast -o my-org -r platform --show-labels
+Fetching my-org PRs...🥐...Done
+Processing platform PRs...🍩🧇...Done
++---------+----------------+-----------------+--------+---------+-------+---------+------------+----------+--------------------+--------------+--------+
+|         | Repo           | PR Title        | Author | State   | Files | Commits |    +/-     | Comments | Labels             | Mergeable?   | Link   |
++---------+----------------+-----------------+--------+---------+-------+---------+------------+----------+--------------------+--------------+--------+
+|       0 | platform-api   | Add user search | alice  | open    |   3   |    1    |  +42/-10   |    0     | bug, urgent        | ✅ (clean)   | PR-142 |
+|       1 | platform-api   | Fix login bug   | bob    | open    |   1   |    1    |  +5/-2     |    3     | feat               | ✅ (clean)   | PR-138 |
+|       2 | platform-ui    | Update nav bar  | carol  | open    |  12   |    4    |  +280/-95  |    1     | docs, chore +3     | ❌ (dirty)   | PR-87  |
++---------+----------------+-----------------+--------+---------+-------+---------+------------+----------+--------------------+--------------+--------+
+```
+
+Enable in config:
+
+```toml
+show-labels = true
+```
+
 ### `--status-style`
 
 Choose how the `Checks`, `Approved`, and `Mergeable?` columns are rendered in table output.
@@ -721,12 +767,14 @@ Each entry in the list is an inline TOML table with a required `name` key and tw
 | `approvals` | `Approved` | **Optional** (off by default) | Review approval status: ✅ approved, ❌ changes, ⏳ pending. Requires an extra API call per PR. |
 | `head-branch` | `Head Branch` | **Optional** (off by default) | Source branch the PR was raised from, hyperlinked. |
 | `base-branch` | `Base Branch` | **Optional** (off by default) | Target branch the PR merges into, hyperlinked. |
+| `reviewers` | `Reviewers` | **Optional** (off by default) | Requested reviewers for the PR, up to 2 logins, then `+N` overflow. |
+| `labels` | `Labels` | **Optional** (off by default) | Labels applied to the PR, up to 2 labels, then `+N` overflow. |
 | `mergeable` | `Mergeable?` | Yes | GitHub's mergeability status: ✅ (clean), ❌ (dirty), ⚠️ (behind), ⏳ computing. |
 | `link` | `Link` | Yes | Clickable `PR-N` hyperlink to the PR on GitHub. |
 
 #### Auto-enabling optional columns
 
-Optional columns (`age`, `checks`, `approvals`, `head-branch`, `base-branch`) are **automatically enabled** when they appear in your `columns` list. You do not need to also set `age = true` or pass `--age` on every run.
+Optional columns (`age`, `checks`, `approvals`, `head-branch`, `base-branch`, `reviewers`, `labels`) are **automatically enabled** when they appear in your `columns` list. You do not need to also set `age = true` or pass `--age` on every run.
 
 #### Worked examples
 

--- a/docs/manual/options.md
+++ b/docs/manual/options.md
@@ -849,10 +849,7 @@ columns = [
 When `columns` is set in config, it controls the table layout for all runs. CLI flags still override individual behaviours:
 
 - `--no-age` will suppress age data even if `age` is in `columns` (the column will be absent).
-- `--age` has no effect if `age` is not in `columns` (the column still won't appear).
-- All other flags (`--checks`, `--approvals`, etc.) follow the same logic.
-
-For a one-off column layout without changing your config, use the individual flags directly rather than `columns`.
+- If an optional column flag is passed on the CLI (e.g. `--age`, `--reviewers`, `--show-labels`, `--head-branch`, `--base-branch`), but that column is **not** in your custom `columns` list, it will be automatically appended to the end of the displayed columns. This allows easily toggling optional columns for a one-off run without modifying your configuration file.
 
 > **Note:** The `org` column is only shown when multiple organisations are queried (`-o org1 -o org2`). Listing it in `columns` while querying a single org is a no-op.
 

--- a/docs/manual/output-formats.md
+++ b/docs/manual/output-formats.md
@@ -99,7 +99,7 @@ platform-api,138,Fix login bug,bob,https://github.com/my-org/platform-api/pull/1
 - Header row is always present.
 - ANSI colour codes are stripped — all values are plain text.
 - Multi-value fields (`labels`, `requested_reviewers`) are joined with `|` within the cell.
-- Optional columns (`--age`, `--checks`, `--approvals`) are appended when their flags are set.
+- Optional columns (`--age`, `--checks`, `--approvals`, `--reviewers`, `--show-labels`) are appended when their flags are set.
 - Progress messages still go to stderr, so the output can be redirected cleanly.
 - `format = "csv"` in `config.toml` sets CSV as the persistent default.
 
@@ -110,6 +110,8 @@ platform-api,138,Fix login bug,bob,https://github.com/my-org/platform-api/pull/1
 | `--age` | `age_days` |
 | `--checks` | `checks` |
 | `--approvals` | `approval`, `approval_current`, `approval_required` |
+| `--reviewers` | `requested_reviewers` |
+| `--show-labels` | `labels` |
 
 ### Shell examples
 
@@ -129,6 +131,8 @@ breakfast -o my-org -r platform --format csv 2>/dev/null | csvgrep -c author -m 
 With `--format json` (or the `--json` alias), output is a JSON array of objects.
 
 ### Schema
+
+Each PR object contains the default fields by default. Optional fields (`labels`, `requested_reviewers`, `checks`, and `approval` fields) are only included when their respective CLI flags or configuration keys are set.
 
 Each PR object contains:
 

--- a/docs/manual/output-formats.md
+++ b/docs/manual/output-formats.md
@@ -48,6 +48,8 @@ The default output is a colour-coded terminal table with the following columns:
 | Checks | CI/check run status: pass, fail, pending, none (only with `--checks`) — clickable link to the PR's checks tab |
 | Head Branch | Source branch the PR was raised from (only with `--head-branch`) — clickable link to the branch on GitHub |
 | Base Branch | Target branch the PR merges into (only with `--base-branch`) — clickable link to the branch on GitHub |
+| Reviewers | Requested reviewers for the PR (only with `--reviewers`) |
+| Labels | Labels applied to the PR (only with `--show-labels`) |
 | Mergeable? | Whether the PR can be merged cleanly. `✅` means truly ready (`clean`); `⚠️` means no conflicts but not ready (`behind`, `unstable`, or `blocked`); `❌` means conflicts exist. Also shows `🏁 merged`, `🚫 closed`, or `⏳ computing` as appropriate |
 | Link | Clickable link to the PR |
 
@@ -80,7 +82,7 @@ $ breakfast -o my-org -r platform --format markdown 2>/dev/null
 
 - ANSI colour codes are stripped — Markdown renderers don't support them.
 - OSC 8 terminal hyperlinks are converted to `[text](url)` Markdown links.
-- Optional columns (`--age`, `--checks`, `--approvals`, `--head-branch`, `--base-branch`) are included when their flags are set.
+- Optional columns (`--age`, `--checks`, `--approvals`, `--head-branch`, `--base-branch`, `--reviewers`, `--show-labels`) are included when their flags are set.
 - Progress messages still go to stderr, so the output can be redirected cleanly.
 
 ## CSV output (`--format csv`)

--- a/src/breakfast/cli.py
+++ b/src/breakfast/cli.py
@@ -1689,6 +1689,8 @@ def breakfast(
             check_statuses=check_statuses,
             approval_statuses=approval_statuses,
             approval_details=approval_details,
+            reviewers=reviewers,
+            show_labels=show_labels,
         )
     elif fmt == "markdown":
         render_markdown(
@@ -1714,6 +1716,8 @@ def breakfast(
             check_statuses=check_statuses,
             approval_statuses=approval_statuses,
             approval_details=approval_details,
+            reviewers=reviewers,
+            show_labels=show_labels,
         )
     elif fmt == "template":
         render_template(

--- a/src/breakfast/cli.py
+++ b/src/breakfast/cli.py
@@ -491,6 +491,16 @@ def _fetch_pr_bundle(url, fetch_checks, fetch_approvals):
     help="Include a column showing the target branch the PR merges into.",
 )
 @click.option(
+    "--reviewers/--no-reviewers",
+    default=None,
+    help="Include a column showing requested reviewers for each PR.",
+)
+@click.option(
+    "--show-labels/--no-show-labels",
+    default=None,
+    help="Include a column showing labels for each PR.",
+)
+@click.option(
     "--status-style",
     type=click.Choice(["emoji", "ascii"], case_sensitive=False),
     default=None,
@@ -766,6 +776,8 @@ def breakfast(
     approvals,
     head_branch,
     base_branch,
+    reviewers,
+    show_labels,
     status_style,
     limit,
     workers,
@@ -855,6 +867,10 @@ def breakfast(
             head_branch = True
         if "base-branch" in _spec_names and base_branch is None:
             base_branch = True
+        if "reviewers" in _spec_names and reviewers is None:
+            reviewers = True
+        if "labels" in _spec_names and show_labels is None:
+            show_labels = True
 
     # --owner / deprecated --org / --organization flags; merge and warn on deprecated
     if org_deprecated:
@@ -963,6 +979,10 @@ def breakfast(
     )
     base_branch = (
         base_branch if base_branch is not None else cfg.get("base-branch", False)
+    )
+    reviewers = reviewers if reviewers is not None else cfg.get("reviewers", False)
+    show_labels = (
+        show_labels if show_labels is not None else cfg.get("show-labels", False)
     )
     if status_style is None:
         status_style = str(cfg.get("status-style", "emoji")).lower()
@@ -1682,6 +1702,8 @@ def breakfast(
             head_branch=head_branch,
             base_branch=base_branch,
             status_style=status_style,
+            reviewers=reviewers,
+            show_labels=show_labels,
         )
     elif fmt == "csv":
         render_csv(
@@ -1712,6 +1734,8 @@ def breakfast(
             approval_details=approval_details,
             head_branch=head_branch,
             base_branch=base_branch,
+            reviewers=reviewers,
+            show_labels=show_labels,
             status_style=status_style,
             seasonal_calendar=seasonal_calendar,
             colour=colour,

--- a/src/breakfast/config.py
+++ b/src/breakfast/config.py
@@ -109,6 +109,14 @@ _DEFAULT_CONFIG_CONTENT = """\
 # Equivalent to: --base-branch
 # base-branch = false
 
+# Show a column with the requested reviewers for each PR.
+# Equivalent to: --reviewers
+# reviewers = false
+
+# Show a column with the labels for each PR.
+# Equivalent to: --show-labels
+# show-labels = false
+
 # Truncate PR titles to this many characters (appends … when truncated).
 # Useful on narrow terminals. Unset means no truncation.
 # Equivalent to: --max-title-length <n>
@@ -116,10 +124,12 @@ _DEFAULT_CONFIG_CONTENT = """\
 
 # Control which columns appear, their order, headers, and alignment.
 # Each entry is {name = "..."} with optional header = "..." and align = "...".
-# Optional columns (age, checks, approvals, head-branch, base-branch) are
-# automatically enabled when included — no need to set their individual flags.
+# Optional columns (age, checks, approvals, head-branch, base-branch,
+# reviewers, labels) are automatically enabled when included — no need to
+# set their individual flags.
 # Available names: org, repo, title, author, state, files, commits, diff,
-#   comments, age, checks, approvals, head-branch, base-branch, mergeable, link
+#   comments, age, checks, approvals, head-branch, base-branch, reviewers,
+#   labels, mergeable, link
 # Expand to multi-line in your config for readability:
 #   columns = [
 #     {name = "repo"},
@@ -337,6 +347,8 @@ _VALID_COLUMN_NAMES = frozenset(
         "approvals",
         "head-branch",
         "base-branch",
+        "reviewers",
+        "labels",
         "mergeable",
         "link",
     }

--- a/src/breakfast/renderers.py
+++ b/src/breakfast/renderers.py
@@ -99,28 +99,29 @@ def _strip_ansi(s):
     return _ANSI_RE.sub("", str(s))
 
 
-def format_reviewers(reviewers_list: list[dict] | None) -> str:
-    """Format requested reviewers with +N overflow rule."""
-    if not reviewers_list:
+def _format_overflow_list(values: list[str], limit: int = 2) -> str:
+    """Format a list of strings with +N overflow rule."""
+    if not values:
         return "-"
-    logins = [r["login"] for r in reviewers_list if "login" in r]
-    if not logins:
-        return "-"
-    if len(logins) > 2:
-        return f"{logins[0]}, {logins[1]} +{len(logins) - 2}"
-    return ", ".join(logins)
+    if len(values) > limit:
+        head = ", ".join(values[:limit])
+        return f"{head} +{len(values) - limit}"
+    return ", ".join(values)
+
+
+def format_reviewers(
+    reviewers_list: list[dict] | None, teams_list: list[dict] | None = None
+) -> str:
+    """Format requested reviewers and teams with +N overflow rule."""
+    logins = [r["login"] for r in (reviewers_list or []) if "login" in r]
+    team_slugs = [f"@{t['slug']}" for t in (teams_list or []) if "slug" in t]
+    return _format_overflow_list(logins + team_slugs)
 
 
 def format_labels(labels_list: list[dict] | None) -> str:
     """Format label names with +N overflow rule."""
-    if not labels_list:
-        return "-"
-    names = [lbl["name"] for lbl in labels_list if "name" in lbl]
-    if not names:
-        return "-"
-    if len(names) > 2:
-        return f"{names[0]}, {names[1]} +{len(names) - 2}"
-    return ", ".join(names)
+    names = [lbl["name"] for lbl in (labels_list or []) if "name" in lbl]
+    return _format_overflow_list(names)
 
 
 def _visible_width(s):
@@ -374,8 +375,23 @@ def _apply_column_specs(
         return pr_data, None
 
     first = pr_data[0]
+    spec_names = {spec["name"] for spec in column_specs}
+    optional_mapping = {
+        "Age": "age",
+        "Checks": "checks",
+        "Approved": "approvals",
+        "Head Branch": "head-branch",
+        "Base Branch": "base-branch",
+        "Reviewers": "reviewers",
+        "Labels": "labels",
+    }
+    resolved_specs = list(column_specs)
+    for display_key, spec_name in optional_mapping.items():
+        if display_key in first and spec_name not in spec_names:
+            resolved_specs.append({"name": spec_name, "header": None, "align": None})
+
     ordered: list[tuple[str, str, str | None]] = []
-    for spec in column_specs:
+    for spec in resolved_specs:
         display_key = _COLUMN_DISPLAY_NAMES.get(spec["name"])
         if not display_key:
             continue
@@ -413,6 +429,8 @@ def render_json(
     check_statuses,
     approval_statuses,
     approval_details,
+    reviewers=False,
+    show_labels=False,
 ):
     from .logger import logger
 
@@ -435,11 +453,13 @@ def render_json(
             "changed_files": pr_detail.get("changed_files"),
             "commits": pr_detail.get("commits"),
             "review_comments": pr_detail.get("review_comments"),
-            "labels": [lb["name"] for lb in pr_detail.get("labels", [])],
-            "requested_reviewers": [
-                r["login"] for r in pr_detail.get("requested_reviewers", [])
-            ],
         }
+        if show_labels:
+            entry["labels"] = [lb["name"] for lb in pr_detail.get("labels", [])]
+        if reviewers:
+            logins = [r["login"] for r in pr_detail.get("requested_reviewers", [])]
+            teams = [f"@{t['slug']}" for t in pr_detail.get("requested_teams", [])]
+            entry["requested_reviewers"] = logins + teams
         if checks:
             entry["checks"] = check_statuses.get(pr_detail["id"], "none")
         if approvals:
@@ -527,7 +547,10 @@ def render_markdown(
             _bb_url = f"https://github.com/{_bb_owner}/{_bb_repo}/tree/{_bb_name}"
             row["Base Branch"] = f"[{_bb_name}]({_bb_url})"
         if reviewers:
-            row["Reviewers"] = format_reviewers(pr_detail.get("requested_reviewers"))
+            row["Reviewers"] = format_reviewers(
+                pr_detail.get("requested_reviewers"),
+                pr_detail.get("requested_teams"),
+            )
         if show_labels:
             row["Labels"] = format_labels(pr_detail.get("labels"))
         row["Mergeable?"] = _osc8_to_markdown(
@@ -562,6 +585,8 @@ def render_csv(
     check_statuses,
     approval_statuses,
     approval_details,
+    reviewers=False,
+    show_labels=False,
 ):
     from .logger import logger
 
@@ -583,9 +608,11 @@ def render_csv(
         "changed_files",
         "commits",
         "review_comments",
-        "labels",
-        "requested_reviewers",
     ]
+    if show_labels:
+        fieldnames.append("labels")
+    if reviewers:
+        fieldnames.append("requested_reviewers")
     if age:
         fieldnames.append("age_days")
     if checks:
@@ -612,11 +639,13 @@ def render_csv(
             "changed_files": pr_detail.get("changed_files", ""),
             "commits": pr_detail.get("commits", ""),
             "review_comments": pr_detail.get("review_comments", ""),
-            "labels": "|".join(lb["name"] for lb in pr_detail.get("labels", [])),
-            "requested_reviewers": "|".join(
-                r["login"] for r in pr_detail.get("requested_reviewers", [])
-            ),
         }
+        if show_labels:
+            row["labels"] = "|".join(lbl["name"] for lbl in pr_detail.get("labels", []))
+        if reviewers:
+            logins = [r["login"] for r in pr_detail.get("requested_reviewers", [])]
+            teams = [f"@{t['slug']}" for t in pr_detail.get("requested_teams", [])]
+            row["requested_reviewers"] = "|".join(logins + teams)
         if age:
             row["age_days"] = _get_pr_age_days(pr_detail)
         if checks:
@@ -795,7 +824,10 @@ def render_table(
             row["Base Branch"] = _seasonal_colour_link(_bb_url, _bb_name)
         if reviewers:
             row["Reviewers"] = _seasonal_colour(
-                format_reviewers(pr_detail.get("requested_reviewers"))
+                format_reviewers(
+                    pr_detail.get("requested_reviewers"),
+                    pr_detail.get("requested_teams"),
+                )
             )
         if show_labels:
             row["Labels"] = _seasonal_colour(format_labels(pr_detail.get("labels")))

--- a/src/breakfast/renderers.py
+++ b/src/breakfast/renderers.py
@@ -41,6 +41,8 @@ _COLUMN_DISPLAY_NAMES: dict[str, str] = {
     "approvals": "Approved",
     "head-branch": "Head Branch",
     "base-branch": "Base Branch",
+    "reviewers": "Reviewers",
+    "labels": "Labels",
     "mergeable": "Mergeable?",
     "link": "Link",
 }
@@ -55,6 +57,8 @@ _DROPPABLE_COLUMNS = [
     "Age",
     "Checks",
     "Apr",
+    "Reviewers",
+    "Labels",
     "Head Branch",
     "Base Branch",
     "Mrg",
@@ -93,6 +97,30 @@ def is_legendary(pr_detail, now=None):
 
 def _strip_ansi(s):
     return _ANSI_RE.sub("", str(s))
+
+
+def format_reviewers(reviewers_list: list[dict] | None) -> str:
+    """Format requested reviewers with +N overflow rule."""
+    if not reviewers_list:
+        return "-"
+    logins = [r["login"] for r in reviewers_list if "login" in r]
+    if not logins:
+        return "-"
+    if len(logins) > 2:
+        return f"{logins[0]}, {logins[1]} +{len(logins) - 2}"
+    return ", ".join(logins)
+
+
+def format_labels(labels_list: list[dict] | None) -> str:
+    """Format label names with +N overflow rule."""
+    if not labels_list:
+        return "-"
+    names = [lbl["name"] for lbl in labels_list if "name" in lbl]
+    if not names:
+        return "-"
+    if len(names) > 2:
+        return f"{names[0]}, {names[1]} +{len(names) - 2}"
+    return ", ".join(names)
 
 
 def _visible_width(s):
@@ -237,6 +265,14 @@ def _auto_fit(pr_data, terminal_width, explicit_max_title_length):
 
     # 2. Truncate Author
     pr_data = _truncate_col(pr_data, "Author", terminal_width, min_len=8)
+    if fits():
+        return pr_data
+
+    # 2b. Truncate Reviewers / Labels
+    pr_data = _truncate_col(pr_data, "Reviewers", terminal_width, min_len=8)
+    if fits():
+        return pr_data
+    pr_data = _truncate_col(pr_data, "Labels", terminal_width, min_len=8)
     if fits():
         return pr_data
 
@@ -431,6 +467,8 @@ def render_markdown(
     head_branch,
     base_branch,
     status_style,
+    reviewers=False,
+    show_labels=False,
 ):
     from .logger import logger
 
@@ -488,6 +526,10 @@ def render_markdown(
             _bb_repo = pr_detail["base"]["repo"]["name"]
             _bb_url = f"https://github.com/{_bb_owner}/{_bb_repo}/tree/{_bb_name}"
             row["Base Branch"] = f"[{_bb_name}]({_bb_url})"
+        if reviewers:
+            row["Reviewers"] = format_reviewers(pr_detail.get("requested_reviewers"))
+        if show_labels:
+            row["Labels"] = format_labels(pr_detail.get("labels"))
         row["Mergeable?"] = _osc8_to_markdown(
             format_mergeable_status(
                 pr_detail.get("mergeable"),
@@ -664,6 +706,8 @@ def render_table(
     colour_index,
     max_title_length,
     column_specs,
+    reviewers=False,
+    show_labels=False,
     stdout_is_tty=None,
 ):
     from .logger import logger
@@ -749,6 +793,12 @@ def render_table(
             _bb_repo = pr_detail["base"]["repo"]["name"]
             _bb_url = f"https://github.com/{_bb_owner}/{_bb_repo}/tree/{_bb_name}"
             row["Base Branch"] = _seasonal_colour_link(_bb_url, _bb_name)
+        if reviewers:
+            row["Reviewers"] = _seasonal_colour(
+                format_reviewers(pr_detail.get("requested_reviewers"))
+            )
+        if show_labels:
+            row["Labels"] = _seasonal_colour(format_labels(pr_detail.get("labels")))
         row["Mergeable?"] = format_mergeable_status(
             pr_detail.get("mergeable"),
             pr_detail.get("mergeable_state"),

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -140,6 +140,69 @@ def test_cli_outputs_age_column_when_enabled(monkeypatch):
     assert "7" in result.stdout
 
 
+def test_cli_outputs_reviewers_and_labels_columns_when_enabled(monkeypatch):
+    monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
+    monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
+
+    def fake_get_prs(_org, _repo_filter, _state="open"):
+        return ["https://github.com/org/repo/pull/1"]
+
+    def fake_api_request(_path):
+        return {
+            "base": {"repo": {"name": "repo"}},
+            "mergeable": True,
+            "mergeable_state": "clean",
+            "additions": 5,
+            "deletions": 2,
+            "title": "Test PR",
+            "user": {"login": "alice"},
+            "state": "open",
+            "changed_files": 1,
+            "commits": 1,
+            "review_comments": 0,
+            "created_at": "2026-01-10T00:00:00Z",
+            "html_url": "https://github.com/org/repo/pull/1",
+            "number": 1,
+            "requested_reviewers": [{"login": "reviewer1"}, {"login": "reviewer2"}],
+            "labels": [{"name": "bug-label"}],
+        }
+
+    monkeypatch.setattr(cli, "get_github_prs", fake_get_prs)
+    monkeypatch.setattr(api, "make_github_api_request", fake_api_request)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli.breakfast,
+        ["-o", "org", "-r", "repo", "--reviewers", "--show-labels"],
+    )
+
+    assert result.exit_code == 0
+    assert "Reviewers" in result.stdout
+    assert "reviewer1, reviewer2" in result.stdout
+    assert "Labels" in result.stdout
+    assert "bug-label" in result.stdout
+
+    result_md = runner.invoke(
+        cli.breakfast,
+        [
+            "-o",
+            "org",
+            "-r",
+            "repo",
+            "--format",
+            "markdown",
+            "--reviewers",
+            "--show-labels",
+        ],
+    )
+    assert result_md.exit_code == 0
+    assert "Reviewers" in result_md.stdout
+    assert "reviewer1, reviewer2" in result_md.stdout
+    assert "Labels" in result_md.stdout
+    assert "bug-label" in result_md.stdout
+
+
 def _fake_pr_detail_with_branches():
     return {
         "base": {

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -165,6 +165,7 @@ def test_cli_outputs_reviewers_and_labels_columns_when_enabled(monkeypatch):
             "html_url": "https://github.com/org/repo/pull/1",
             "number": 1,
             "requested_reviewers": [{"login": "reviewer1"}, {"login": "reviewer2"}],
+            "requested_teams": [{"slug": "team-slug"}],
             "labels": [{"name": "bug-label"}],
         }
 
@@ -179,7 +180,7 @@ def test_cli_outputs_reviewers_and_labels_columns_when_enabled(monkeypatch):
 
     assert result.exit_code == 0
     assert "Reviewers" in result.stdout
-    assert "reviewer1, reviewer2" in result.stdout
+    assert "reviewer1, reviewer2 +1" in result.stdout
     assert "Labels" in result.stdout
     assert "bug-label" in result.stdout
 
@@ -198,9 +199,87 @@ def test_cli_outputs_reviewers_and_labels_columns_when_enabled(monkeypatch):
     )
     assert result_md.exit_code == 0
     assert "Reviewers" in result_md.stdout
-    assert "reviewer1, reviewer2" in result_md.stdout
+    assert "reviewer1, reviewer2 +1" in result_md.stdout
     assert "Labels" in result_md.stdout
     assert "bug-label" in result_md.stdout
+
+    # Test CSV output when enabled
+    result_csv = runner.invoke(
+        cli.breakfast,
+        [
+            "-o",
+            "org",
+            "-r",
+            "repo",
+            "--format",
+            "csv",
+            "--reviewers",
+            "--show-labels",
+        ],
+    )
+    assert result_csv.exit_code == 0
+    assert "labels" in result_csv.stdout
+    assert "requested_reviewers" in result_csv.stdout
+    assert "bug-label" in result_csv.stdout
+    assert "reviewer1|reviewer2|@team-slug" in result_csv.stdout
+
+    # Test CSV output when NOT enabled
+    result_csv_off = runner.invoke(
+        cli.breakfast,
+        [
+            "-o",
+            "org",
+            "-r",
+            "repo",
+            "--format",
+            "csv",
+        ],
+    )
+    assert result_csv_off.exit_code == 0
+    assert "labels" not in result_csv_off.stdout
+    assert "requested_reviewers" not in result_csv_off.stdout
+
+    # Test JSON output when enabled
+    result_json = runner.invoke(
+        cli.breakfast,
+        [
+            "-o",
+            "org",
+            "-r",
+            "repo",
+            "--format",
+            "json",
+            "--reviewers",
+            "--show-labels",
+        ],
+    )
+    assert result_json.exit_code == 0
+    json_start = result_json.stdout.index("[")
+    parsed_json = json.loads(result_json.stdout[json_start:])
+    assert parsed_json[0]["labels"] == ["bug-label"]
+    assert parsed_json[0]["requested_reviewers"] == [
+        "reviewer1",
+        "reviewer2",
+        "@team-slug",
+    ]
+
+    # Test JSON output when NOT enabled
+    result_json_off = runner.invoke(
+        cli.breakfast,
+        [
+            "-o",
+            "org",
+            "-r",
+            "repo",
+            "--format",
+            "json",
+        ],
+    )
+    assert result_json_off.exit_code == 0
+    json_start_off = result_json_off.stdout.index("[")
+    parsed_json_off = json.loads(result_json_off.stdout[json_start_off:])
+    assert "labels" not in parsed_json_off[0]
+    assert "requested_reviewers" not in parsed_json_off[0]
 
 
 def _fake_pr_detail_with_branches():
@@ -329,7 +408,10 @@ def test_cli_outputs_json(monkeypatch):
     monkeypatch.setattr(api, "make_github_api_request", fake_api_request)
 
     runner = CliRunner()
-    result = runner.invoke(cli.breakfast, ["-o", "org", "-r", "repo", "--json"])
+    result = runner.invoke(
+        cli.breakfast,
+        ["-o", "org", "-r", "repo", "--json", "--reviewers", "--show-labels"],
+    )
 
     assert result.exit_code == 0
     data = json.loads(result.stdout[result.stdout.index("[") :])
@@ -4350,3 +4432,57 @@ def test_cli_filter_mergeable_conflict(monkeypatch):
     assert result.exit_code == 0
     assert "PR 1 conflict" in result.stdout
     assert "PR 2 clean" not in result.stdout
+
+
+def test_cli_auto_appends_optional_columns_missing_from_custom_columns_config(
+    monkeypatch,
+):
+    monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
+    monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
+
+    def fake_get_prs(_org, _repo_filter, _state="open"):
+        return ["https://github.com/org/repo/pull/1"]
+
+    def fake_api_request(_path):
+        return {
+            "base": {"repo": {"name": "repo"}},
+            "mergeable": True,
+            "mergeable_state": "clean",
+            "additions": 5,
+            "deletions": 2,
+            "title": "Test PR",
+            "user": {"login": "alice"},
+            "state": "open",
+            "changed_files": 1,
+            "commits": 1,
+            "review_comments": 0,
+            "created_at": "2026-01-10T00:00:00Z",
+            "html_url": "https://github.com/org/repo/pull/1",
+            "number": 1,
+        }
+
+    monkeypatch.setattr(cli, "get_github_prs", fake_get_prs)
+    monkeypatch.setattr(api, "make_github_api_request", fake_api_request)
+
+    monkeypatch.setattr(
+        cli,
+        "load_config",
+        lambda *_: {
+            "columns": [
+                {"name": "repo", "header": None, "align": None},
+                {"name": "title", "header": None, "align": None},
+                {"name": "link", "header": None, "align": None},
+            ]
+        },
+    )
+
+    runner = CliRunner()
+
+    result_without = runner.invoke(cli.breakfast, ["-o", "org", "-r", "repo"])
+    assert result_without.exit_code == 0
+    assert "Age" not in result_without.stdout
+
+    result_with = runner.invoke(cli.breakfast, ["-o", "org", "-r", "repo", "--age"])
+    assert result_with.exit_code == 0
+    assert "Age" in result_with.stdout

--- a/tests/test_renderers.py
+++ b/tests/test_renderers.py
@@ -393,3 +393,58 @@ def test_droppable_columns_approved():
     for row in fitted:
         assert "Approved" not in row
         assert "Apr" not in row
+
+
+def test_format_reviewers_and_labels_overflow():
+    """Verify that reviewers and labels format correctly with +N overflow."""
+    assert renderers.format_reviewers([{"login": "alice"}]) == "alice"
+    assert (
+        renderers.format_reviewers([{"login": "alice"}, {"login": "bob"}])
+        == "alice, bob"
+    )
+    assert (
+        renderers.format_reviewers(
+            [{"login": "alice"}, {"login": "bob"}, {"login": "charlie"}]
+        )
+        == "alice, bob +1"
+    )
+    assert renderers.format_reviewers([]) == "-"
+    assert renderers.format_reviewers(None) == "-"
+
+    assert renderers.format_labels([{"name": "bug"}]) == "bug"
+    assert (
+        renderers.format_labels([{"name": "bug"}, {"name": "urgent"}]) == "bug, urgent"
+    )
+    assert (
+        renderers.format_labels(
+            [{"name": "bug"}, {"name": "urgent"}, {"name": "enhancement"}]
+        )
+        == "bug, urgent +1"
+    )
+    assert renderers.format_labels([]) == "-"
+
+
+def test_autofit_truncates_reviewers_and_labels():
+    """Verify that reviewers and labels columns are truncated and dropped by autofit."""
+    rows = [
+        {
+            "Repo": "short",
+            "PR Title": "title",
+            "Author": "alice",
+            "Reviewers": "alice, bob +5",
+            "Labels": "bug, urgent +3",
+        }
+    ]
+    truncated = renderers._auto_fit(
+        rows, terminal_width=65, explicit_max_title_length=None
+    )
+    assert len(truncated[0]["Reviewers"]) <= 12
+    assert len(truncated[0]["Labels"]) <= 12
+
+    # Verify dropping under extremely narrow terminal
+    fitted = renderers._auto_fit(
+        rows, terminal_width=20, explicit_max_title_length=None
+    )
+    for row in fitted:
+        assert "Reviewers" not in row
+        assert "Labels" not in row

--- a/tests/test_renderers.py
+++ b/tests/test_renderers.py
@@ -411,6 +411,18 @@ def test_format_reviewers_and_labels_overflow():
     assert renderers.format_reviewers([]) == "-"
     assert renderers.format_reviewers(None) == "-"
 
+    # Teams review requests tests
+    assert (
+        renderers.format_reviewers([{"login": "alice"}], [{"slug": "team-slug"}])
+        == "alice, @team-slug"
+    )
+    assert (
+        renderers.format_reviewers(
+            [{"login": "alice"}, {"login": "bob"}], [{"slug": "team-slug"}]
+        )
+        == "alice, bob +1"
+    )
+
     assert renderers.format_labels([{"name": "bug"}]) == "bug"
     assert (
         renderers.format_labels([{"name": "bug"}, {"name": "urgent"}]) == "bug, urgent"


### PR DESCRIPTION
## Summary

- **Add reviewers and labels columns**: Supports displaying pull request labels and requested reviewers in the terminal table and markdown output formats.
- **Key Changes**:
  - Registered optional `"reviewers"` and `"labels"` columns in the column specifications and formatting modules.
  - Implemented overflow rendering (`+N` logic for > 2 items) and auto-fitting truncation for the new columns in `src/breakfast/renderers.py`.
  - Added `--reviewers/--no-reviewers` and `--show-labels/--no-show-labels` click options, and mapping logic from default TOML configuration file keys in `src/breakfast/cli.py`.
  - Added commented configuration options to `_DEFAULT_CONFIG_CONTENT` in `src/breakfast/config.py`.
  - Updated user manuals `docs/manual/options.md` and `docs/manual/output-formats.md` to document the new options.
- **Addressing Review Comments**:
  - **CSV & JSON optional columns (#367)**: Integrated reviewers and labels into the JSON and CSV renderers as optional columns, so they are only included in the output when their respective CLI flags or configuration keys are set. For JSON, structured lists are used.
  - **De-duplicate formatting (#368)**: Consolidated list formatting and overflow logic under a shared `_format_overflow_list` helper in `src/breakfast/renderers.py`.
  - **Requested Teams Support (#369)**: Added support for requested teams in the Reviewers column, prefixing them with `@` (e.g. `@team-slug`) and combining them with individual user reviewers under the same `+N` overflow rule.
  - **CLI Overrides Custom Columns (#370)**: Updated `_apply_column_specs` to automatically append any optional columns enabled via CLI flags (e.g. `--age`, `--reviewers`, `--show-labels`, `--head-branch`, `--base-branch`) to the displayed columns if they are not already listed in the user's custom `columns` configuration.

## Test plan

- [x] `make format && make lint && make test` passes (verify all checks are clean).
- [x] **Unit tests added & updated**:
  - `test_cli_outputs_reviewers_and_labels_columns_when_enabled` — verifies CLI table, markdown, CSV, and JSON outputs match when options are set, including team reviewer requests.
  - `test_format_reviewers_and_labels_overflow` — verifies the list formatting, +N overflow logic, and requested teams formatting.
  - `test_autofit_truncates_reviewers_and_labels` — verifies that columns fit in narrow terminals and drop on extremely narrow views.
  - `test_cli_auto_appends_optional_columns_missing_from_custom_columns_config` — verifies that optional column flags (like `--age`) are auto-appended to the table when a custom columns config list exists but excludes them.
- [x] **Manual Verification / Smoke Test**:
  - Ran `uv run breakfast --version` successfully.
  - Ran `uv run breakfast --help` to confirm new options exist.

Closes #342
Closes #367
Closes #368
Closes #369
Closes #370

🥐 Prepared by [Gemini](https://deepmind.google/technologies/gemini/)
