### PR TITLE
#335: Fix title truncation for CJK and emoji wide characters

### DIFF
--- a/src/breakfast/renderers.py
+++ b/src/breakfast/renderers.py
@@ -102,6 +102,21 @@ def _visible_width(s):
     return w if w >= 0 else len(plain)
 
 
+def _slice_by_width(s: str, max_width: int) -> str:
+    """Return the longest prefix of *s* whose display width is <= *max_width*.
+
+    Uses per-character wcwidth so CJK (width-2) and emoji are handled correctly.
+    """
+    out, used = [], 0
+    for ch in s:
+        w = max(wcwidth.wcwidth(ch), 0)
+        if used + w > max_width:
+            break
+        out.append(ch)
+        used += w
+    return "".join(out)
+
+
 def _osc8_to_markdown(s):
     """Convert OSC 8 hyperlinks and ANSI codes in *s* to Markdown link syntax."""
     result = _OSC8_ANY_RE.sub(
@@ -124,7 +139,7 @@ def _truncate_formatted_text(value, limit):
     if _visible_width(plain) <= limit:
         return value
 
-    truncated = plain[: limit - 1] + "…"
+    truncated = _slice_by_width(plain, limit - 1) + "…"
     osc_match = _OSC8_FULL_RE.match(str(value))
     if osc_match:
         return (

--- a/tests/test_renderers.py
+++ b/tests/test_renderers.py
@@ -135,6 +135,50 @@ def test_visible_width():
     assert renderers._visible_width("hello") == 5
 
 
+def test_slice_by_width_ascii():
+    assert renderers._slice_by_width("hello", 3) == "hel"
+    assert renderers._slice_by_width("hello", 10) == "hello"
+    assert renderers._slice_by_width("hello", 0) == ""
+
+
+def test_slice_by_width_cjk():
+    # Each CJK character is width 2
+    s = "日本語テスト"  # 6 chars × 2 = width 12
+    assert renderers._visible_width(renderers._slice_by_width(s, 5)) <= 5
+    assert renderers._visible_width(renderers._slice_by_width(s, 6)) <= 6
+    assert renderers._visible_width(renderers._slice_by_width(s, 12)) == 12
+
+
+def test_slice_by_width_mixed():
+    s = "AB日C"  # A=1, B=1, 日=2, C=1 → total width 5
+    # max_width=3: A(1)+B(1)=2, 日(2) would make 4>3 → only "AB"
+    assert renderers._slice_by_width(s, 3) == "AB"
+    assert renderers._visible_width(renderers._slice_by_width(s, 3)) <= 3
+    # max_width=4: A(1)+B(1)+日(2)=4 exactly → "AB日"
+    assert renderers._slice_by_width(s, 4) == "AB日"
+
+
+def test_truncate_formatted_text_ascii():
+    result = renderers._truncate_formatted_text("Hello world", 7)
+    assert renderers._visible_width(result) <= 7
+    assert result.endswith("…")
+
+
+def test_truncate_formatted_text_cjk():
+    # 5 CJK chars = display width 10; truncate to limit 7 must stay ≤ 7 columns
+    cjk = "日本語テス"
+    result = renderers._truncate_formatted_text(cjk, 7)
+    assert renderers._visible_width(result) <= 7
+    assert result.endswith("…")
+
+
+def test_truncate_formatted_text_mixed():
+    mixed = "AB日本語CD"  # A=1,B=1,日=2,本=2,語=2,C=1,D=1 → total 10
+    result = renderers._truncate_formatted_text(mixed, 6)
+    assert renderers._visible_width(result) <= 6
+    assert result.endswith("…")
+
+
 def test_osc8_to_markdown():
     link = "\x1b]8;;http://example.com\x1b\\linktext\x1b]8;;\x1b\\"
     assert renderers._osc8_to_markdown(link) == "[linktext](http://example.com)"

--- a/tests/test_renderers.py
+++ b/tests/test_renderers.py
@@ -136,9 +136,9 @@ def test_visible_width():
 
 
 def test_slice_by_width_ascii():
-    assert renderers._slice_by_width("hello", 3) == "hel"
-    assert renderers._slice_by_width("hello", 10) == "hello"
-    assert renderers._slice_by_width("hello", 0) == ""
+    assert renderers._slice_by_width("abcde", 3) == "abc"
+    assert renderers._slice_by_width("abcde", 10) == "abcde"
+    assert renderers._slice_by_width("abcde", 0) == ""
 
 
 def test_slice_by_width_cjk():


### PR DESCRIPTION
## Issue

Closes #335

## Description

`_truncate_formatted_text` in `renderers.py` was slicing the plain-text string by code-point index (`plain[: limit - 1]`). CJK characters and most emoji have a display width of 2, so a title with wide characters could render nearly twice as wide as the column limit, breaking table alignment.

## Changes

- `src/breakfast/renderers.py`: add `_slice_by_width(s, max_width)` helper that walks characters via `wcwidth.wcwidth` and stops before the display width would exceed the limit. Replace the bare code-point slice in `_truncate_formatted_text` with this helper.

## Testing

- [x] `make test` passes (510 tests, 0 failures)
- [x] `make lint` passes
- New tests in `tests/test_renderers.py` covering `_slice_by_width` (ASCII, pure CJK, mixed) and `_truncate_formatted_text` (ASCII, CJK, mixed) — all assert `_visible_width(result) <= limit`.
- Existing OSC 8 hyperlink truncation test still passes (formatting preserved).

## Notes

Stacked on top of PR for #334. No docs or CI changes required — this is a pure rendering fix.

---
_Generated by [Claude Code](https://claude.ai/code/session_01T16243q1gHuNuvQocy5UvL)_