### PR TITLE
#339: Warn on unknown keys in the TOML config file

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -1,0 +1,2 @@
+[default.extend-words]
+cheks = "cheks"

--- a/docs/manual/troubleshooting.md
+++ b/docs/manual/troubleshooting.md
@@ -125,3 +125,17 @@ When `--filter-mergeable` is used, breakfast maps `mergeable: null` to `unknown`
 - Running breakfast again a few seconds later will show the correct `clean` or `conflict` status.
 
 If you consistently see `unknown` for a PR that has been idle for a while, it may indicate a GitHub API issue. Try refreshing with `--refresh` to bypass the local cache and fetch fresh data.
+
+## "Warning: Unknown config key '...' in config"
+
+If you see a yellow warning on startup:
+
+```text
+⚠️  Unknown config key 'cheks' in config.toml — did you mean 'checks'?
+```
+
+This indicates that your `breakfast.toml` (or `config.toml`) contains a key that breakfast does not recognize. This is usually due to a typo or a deprecated/removed option.
+
+- Double-check the option name against the default config template (which you can generate using `breakfast --init-config`).
+- If you made a typo, correct the key name in your configuration file.
+- If you have an outdated config file, you can run `breakfast --update-config` to append any missing options from the newest default template.

--- a/src/breakfast/config.py
+++ b/src/breakfast/config.py
@@ -1,3 +1,5 @@
+import difflib
+import os
 import re
 import tomllib
 from datetime import datetime
@@ -323,6 +325,13 @@ def _extract_option_blocks(content: str) -> list[tuple[str, str]]:
     return results
 
 
+_EXPLICIT_EXTRAS = {"organization", "drafts-only", "offline"}
+_KNOWN_KEYS_FROM_TEMPLATE = {
+    k for k, _ in _extract_option_blocks(_DEFAULT_CONFIG_CONTENT)
+}
+KNOWN_KEYS = frozenset(_KNOWN_KEYS_FROM_TEMPLATE | _EXPLICIT_EXTRAS)
+
+
 def _key_present_in_file(key: str, content: str) -> bool:
     """Return True if *key* appears in *content* as an active or commented option."""
     pattern = rf"^#?\s*{re.escape(key)}\s*="
@@ -436,26 +445,60 @@ def load_config(config_path=None):
     for path in reversed(paths):
         if path.exists():
             with open(path, "rb") as f:
+                # Resolve color suppression before TOML parse error might occur
+                ctx = click.get_current_context(silent=True)
+                no_color_cli = ctx.params.get("no_colour", False) if ctx else False
+                no_color_env = os.getenv("NO_COLOR") is not None
                 try:
                     data = tomllib.load(f)
                 except tomllib.TOMLDecodeError as e:
                     logger.warning("config_parse_error path=%s error=%r", path, str(e))
                     msg = f"Warning: Failed to parse config {path}: {e}"
-                    click.echo(click.style(msg, fg="yellow"), err=True)
+                    if not (no_color_cli or no_color_env):
+                        click.echo(click.style(msg, fg="yellow"), err=True)
+                    else:
+                        click.echo(msg, err=True)
                     continue
+
+            # Determine final color usage state including config setting
+            no_color_config = data.get("no-colour", False) or data.get(
+                "no-color", False
+            )
+            use_color = not (no_color_cli or no_color_env or no_color_config)
+
+            # Check for unknown config keys and warn
+            for key in sorted(data.keys()):
+                if key not in KNOWN_KEYS:
+                    closest_matches = difflib.get_close_matches(
+                        key.lower(), KNOWN_KEYS, n=1
+                    )
+                    if closest_matches:
+                        closest = closest_matches[0]
+                        warning_msg = (
+                            f"⚠️  Unknown config key '{key}' in {path.name}"
+                            f" — did you mean '{closest}'?"
+                        )
+                    else:
+                        warning_msg = f"⚠️  Unknown config key '{key}' in {path.name}"
+
+                    if use_color:
+                        click.echo(click.style(warning_msg, fg="yellow"), err=True)
+                    else:
+                        click.echo(warning_msg, err=True)
+
             # seasonal-colours = false → seasonal-calendar = "off" (backward compat)
             if not data.get("seasonal-colours", True):
                 data.setdefault("seasonal-calendar", "off")
             # organization → owner (deprecated key, backward compat)
             if "organization" in data:
-                click.echo(
-                    click.style(
-                        "⚠️  Config key 'organization' is deprecated and will be"
-                        " removed in a future release. Rename it to 'owner'.",
-                        fg="yellow",
-                    ),
-                    err=True,
+                dep_msg = (
+                    "⚠️  Config key 'organization' is deprecated and will be"
+                    " removed in a future release. Rename it to 'owner'."
                 )
+                if use_color:
+                    click.echo(click.style(dep_msg, fg="yellow"), err=True)
+                else:
+                    click.echo(dep_msg, err=True)
                 data.setdefault("owner", data.pop("organization"))
             for key in _LIST_KEYS:
                 if key in data and not isinstance(data[key], list):
@@ -465,14 +508,14 @@ def load_config(config_path=None):
                         key,
                         data[key],
                     )
-                    click.echo(
-                        click.style(
-                            f"Warning: config key '{key}' should be a list "
-                            f'(e.g. ["{data[key]}"]), wrapping scalar automatically.',
-                            fg="yellow",
-                        ),
-                        err=True,
+                    list_warn_msg = (
+                        f"Warning: config key '{key}' should be a list "
+                        f'(e.g. ["{data[key]}"]), wrapping scalar automatically.'
                     )
+                    if use_color:
+                        click.echo(click.style(list_warn_msg, fg="yellow"), err=True)
+                    else:
+                        click.echo(list_warn_msg, err=True)
                     data[key] = [data[key]]
             for key, value in data.items():
                 if isinstance(value, list) and isinstance(merged.get(key), list):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4005,6 +4005,11 @@ def _setup_colour_index_mocks(monkeypatch):
     )
     monkeypatch.setattr(api, "make_github_api_request", lambda _path: _COLOUR_INDEX_PR)
     monkeypatch.setattr(cli, "_stdout_is_tty", lambda: True)
+    monkeypatch.setattr(
+        renderers,
+        "apply_seasonal_colour",
+        lambda text, pr_num, calendar: f"\033[35m{text}\033[0m",
+    )
 
 
 def test_index_column_plain_by_default(monkeypatch):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -827,3 +827,77 @@ def test_load_config_owner_takes_precedence_over_organization(monkeypatch, tmp_p
     result = config.load_config()
 
     assert result.get("owner") == "new-owner"
+
+
+def test_load_config_unknown_keys_warning(monkeypatch, tmp_path):
+    """Test that unknown keys warn, with close match suggestion if it exists."""
+    warnings = []
+    # Mock click.echo to collect printed warnings
+    monkeypatch.setattr(
+        config.click, "echo", lambda msg, **kw: warnings.append(str(msg))
+    )
+
+    # 1. Config with a typo that has a close match
+    cfg_file1 = tmp_path / "config.toml"
+    cfg_file1.write_text("cheks = true\n")
+    monkeypatch.setattr(config, "get_config_paths", lambda: [cfg_file1])
+
+    config.load_config()
+    assert len(warnings) == 1
+    assert "Unknown config key 'cheks' in config.toml" in warnings[0]
+    assert "did you mean 'checks'?" in warnings[0]
+
+    # 2. Config with an unknown key that does NOT have a close match
+    warnings.clear()
+    cfg_file2 = tmp_path / "breakfast.toml"
+    cfg_file2.write_text('totallyinvalidkeyname = "hello"\n')
+    monkeypatch.setattr(config, "get_config_paths", lambda: [cfg_file2])
+
+    config.load_config()
+    assert len(warnings) == 1
+    assert "Unknown config key 'totallyinvalidkeyname' in breakfast.toml" in warnings[0]
+    assert "did you mean" not in warnings[0]
+
+
+def test_load_config_valid_extra_keys_do_not_warn(monkeypatch, tmp_path):
+    """Test that keys valid in cli.py but absent from default template do not warn."""
+    warnings = []
+    monkeypatch.setattr(
+        config.click, "echo", lambda msg, **kw: warnings.append(str(msg))
+    )
+
+    cfg_file = tmp_path / "config.toml"
+    cfg_file.write_text('organization = "my-org"\ndrafts-only = true\noffline = true\n')
+    monkeypatch.setattr(config, "get_config_paths", lambda: [cfg_file])
+
+    config.load_config()
+    # Should only produce the 'organization' deprecation warning,
+    # NO unknown key warnings
+    assert not any("Unknown config key" in w for w in warnings)
+
+
+def test_load_config_all_known_keys_no_warnings(monkeypatch, tmp_path):
+    """Test that a config containing all known keys produces zero warnings."""
+    warnings = []
+    monkeypatch.setattr(
+        config.click, "echo", lambda msg, **kw: warnings.append(str(msg))
+    )
+
+    # Generate a config containing every key in KNOWN_KEYS
+    lines = []
+    for k in config.KNOWN_KEYS:
+        # Avoid using list types improperly for scalar checks (e.g. ignore-author)
+        if k in config._LIST_KEYS:
+            lines.append(f'{k} = ["val"]')
+        elif k == "columns":
+            lines.append(f"{k} = []")
+        else:
+            lines.append(f'{k} = "val"')
+
+    cfg_file = tmp_path / "config.toml"
+    cfg_file.write_text("\n".join(lines) + "\n")
+    monkeypatch.setattr(config, "get_config_paths", lambda: [cfg_file])
+
+    config.load_config()
+    # Check that no unknown key warnings were emitted
+    assert not any("Unknown config key" in w for w in warnings)


### PR DESCRIPTION
## Summary

- **Warn on unknown keys in the TOML config file**: Unrecognized or mistyped keys in any loaded TOML configuration file are no longer silently ignored, preventing silent failures of config options.
- **Key Changes**:
  - Derived the `KNOWN_KEYS` set dynamically by extracting keys from the default template configuration (`_DEFAULT_CONFIG_CONTENT` in `src/breakfast/config.py`) via the existing `_extract_option_blocks` helper.
  - Added valid configuration keys (`organization`, `drafts-only`, `offline`) that are absent from the default template comments but handled in `cli.py` to `_EXPLICIT_EXTRAS`.
  - Updated `load_config` to compare parsed TOML keys against `KNOWN_KEYS` for each file loaded.
  - Implemented typo suggestion lookup using `difflib.get_close_matches` matched case-insensitively.
  - Checked `--no-colour`/`--no-color` option and `NO_COLOR` environment variable dynamically during configuration parsing via `click.get_current_context` to safely disable yellow warning highlighting when requested.
  - Added `.typos.toml` to ignore the intentional config typo test case word `cheks`.
  - Fixed pre-existing time-dependent seasonal color index test failure in `tests/test_cli.py`.
- **Abstractions & Design Decisions**:
  - Leveraged case-insensitive close matches for spelling suggestions.
  - Kept warning delivery safe for stdout/stderr redirection by directing warnings to stderr.

## Test plan

- [x] `make format && make lint && make test` passes cleanly.
- [x] **New unit tests added in `tests/test_config.py`**:
  - `test_load_config_unknown_keys_warning` — verifies warnings on stderr with/without suggestions.
  - `test_load_config_valid_extra_keys_do_not_warn` — verifies that permitted extras do not warn.
  - `test_load_config_all_known_keys_no_warnings` — verifies that a config containing all known keys emits zero unknown-key warnings.
- [x] **Manual Verification**:
  - Verified warning output locally on a custom TOML config file with typos.
  - Checked that `--no-colour` removes ANSI colors while preserving warnings.

Closes #339

🥐 Prepared by [Gemini](https://deepmind.google/technologies/gemini/)