### PR TITLE
#375: Fix flaky colour-index test tied to wall-clock date

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ breakfast = "breakfast.cli:breakfast"
 test = [
   "pytest",
   "requests-mock",
+  "freezegun",
 ]
 lint = [
   "black",
@@ -37,6 +38,7 @@ build = [
 dev = [
   "black",
   "click-man",
+  "freezegun",
   "pytest",
   "requests-mock",
   "ruff",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,7 +3,7 @@ import io
 import json
 import re
 from concurrent.futures import ThreadPoolExecutor
-from datetime import datetime, timedelta, timezone
+from datetime import date, datetime, timedelta, timezone
 from unittest.mock import patch
 
 import pytest
@@ -4093,9 +4093,13 @@ def test_index_column_coloured_when_enabled_by_config(monkeypatch, tmp_path):
     _setup_colour_index_mocks(monkeypatch)
     cfg_file = tmp_path / "test.toml"
     cfg_file.write_text("colour-index = true\n")
-    result = CliRunner().invoke(
-        cli.breakfast, ["-o", "org", "-r", "repo", "--config", str(cfg_file)]
-    )
+    with patch("breakfast.ui.datetime") as mock_dt:
+        # June has an active seasonal palette (Pride), so the index is coloured
+        # regardless of which real-world date the suite runs on.
+        mock_dt.date.today.return_value = date(2026, 6, 1)
+        result = CliRunner().invoke(
+            cli.breakfast, ["-o", "org", "-r", "repo", "--config", str(cfg_file)]
+        )
     assert result.exit_code == 0
     # ANSI escape codes should wrap the index digit
     assert not re.search(r"\| 0 +\|", result.stdout)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,12 +3,13 @@ import io
 import json
 import re
 from concurrent.futures import ThreadPoolExecutor
-from datetime import date, datetime, timedelta, timezone
+from datetime import datetime, timedelta, timezone
 from unittest.mock import patch
 
 import pytest
 import requests
 from click.testing import CliRunner
+from freezegun import freeze_time
 
 from breakfast import api, cache, cli, renderers
 
@@ -4093,10 +4094,9 @@ def test_index_column_coloured_when_enabled_by_config(monkeypatch, tmp_path):
     _setup_colour_index_mocks(monkeypatch)
     cfg_file = tmp_path / "test.toml"
     cfg_file.write_text("colour-index = true\n")
-    with patch("breakfast.ui.datetime") as mock_dt:
-        # June has an active seasonal palette (Pride), so the index is coloured
-        # regardless of which real-world date the suite runs on.
-        mock_dt.date.today.return_value = date(2026, 6, 1)
+    # June has an active seasonal palette (Pride), so the index is coloured
+    # regardless of which real-world date the suite runs on.
+    with freeze_time("2026-06-01"):
         result = CliRunner().invoke(
             cli.breakfast, ["-o", "org", "-r", "repo", "--config", str(cfg_file)]
         )

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -1,8 +1,8 @@
 import datetime
-from unittest.mock import patch
 
 import click
 import pytest
+from freezegun import freeze_time
 
 from breakfast import ui
 
@@ -169,8 +169,7 @@ def test_western_calendar_non_special_months_return_none(month):
 
 
 def test_apply_seasonal_colour_uses_single_colour():
-    with patch("breakfast.ui.datetime") as mock_dt:
-        mock_dt.date.today.return_value = _today(1)  # January → purple
+    with freeze_time("2026-01-01"):  # January → purple
         for pr_num in range(8):
             result = ui.apply_seasonal_colour("alice", pr_num)
             assert result.startswith(ui.SEASONAL_PALETTES["purple"])
@@ -179,16 +178,14 @@ def test_apply_seasonal_colour_uses_single_colour():
 
 
 def test_apply_seasonal_colour_non_special_month_returns_plain():
-    with patch("breakfast.ui.datetime") as mock_dt:
-        mock_dt.date.today.return_value = _today(7)  # July → no seasonal theme
+    with freeze_time("2026-07-01"):  # July → no seasonal theme
         for pr_num in range(4):
             result = ui.apply_seasonal_colour("alice", pr_num)
             assert result == "alice"
 
 
 def test_apply_seasonal_colour_christmas_alternates():
-    with patch("breakfast.ui.datetime") as mock_dt:
-        mock_dt.date.today.return_value = _today(12)  # December
+    with freeze_time("2026-12-01"):  # December
         even_result = ui.apply_seasonal_colour("Test PR", 2)
         odd_result = ui.apply_seasonal_colour("Test PR", 3)
     # Even PR numbers → red, odd → green
@@ -197,8 +194,7 @@ def test_apply_seasonal_colour_christmas_alternates():
 
 
 def test_apply_seasonal_colour_wraps_and_resets():
-    with patch("breakfast.ui.datetime") as mock_dt:
-        mock_dt.date.today.return_value = _today(10)  # October → orange
+    with freeze_time("2026-10-01"):  # October → orange
         result = ui.apply_seasonal_colour("hello", 0)
     assert "\033[0m" in result
     assert "hello" in result
@@ -210,8 +206,7 @@ def test_apply_seasonal_colour_wraps_and_resets():
 
 
 def test_apply_seasonal_colour_valentines_day():
-    with patch("breakfast.ui.datetime") as mock_dt:
-        mock_dt.date.today.return_value = _today(2, day=14)  # Feb 14
+    with freeze_time("2026-02-14"):  # Feb 14
         result = ui.apply_seasonal_colour("alice", 0)
     assert result.startswith(ui.SEASONAL_PALETTES["pink"])
     assert result.endswith("\033[0m")
@@ -219,8 +214,7 @@ def test_apply_seasonal_colour_valentines_day():
 
 
 def test_apply_seasonal_colour_not_valentines_day():
-    with patch("breakfast.ui.datetime") as mock_dt:
-        mock_dt.date.today.return_value = _today(2, day=15)  # Feb 15 — plain
+    with freeze_time("2026-02-15"):  # Feb 15 — plain
         result = ui.apply_seasonal_colour("alice", 0)
     assert result == "alice"
 
@@ -241,8 +235,7 @@ def test_lny_date_known_years():
 
 def test_apply_seasonal_colour_lny_february():
     # 2026 LNY is 17 February — should show gold.
-    with patch("breakfast.ui.datetime") as mock_dt:
-        mock_dt.date.today.return_value = datetime.date(2026, 2, 17)
+    with freeze_time("2026-02-17"):
         result = ui.apply_seasonal_colour("alice", 0)
     assert result.startswith(ui.SEASONAL_PALETTES["lny"])
     assert result.endswith("\033[0m")
@@ -250,8 +243,7 @@ def test_apply_seasonal_colour_lny_february():
 
 def test_apply_seasonal_colour_lny_january_stays_purple():
     # 2025 LNY is 29 January — January purple (birthday) must NOT be overridden.
-    with patch("breakfast.ui.datetime") as mock_dt:
-        mock_dt.date.today.return_value = datetime.date(2025, 1, 29)
+    with freeze_time("2025-01-29"):
         result = ui.apply_seasonal_colour("alice", 0)
     assert result.startswith(ui.SEASONAL_PALETTES["purple"])
     assert not result.startswith(ui.SEASONAL_PALETTES["lny"])
@@ -263,8 +255,7 @@ def test_apply_seasonal_colour_lny_january_stays_purple():
 
 
 def test_apply_seasonal_colour_pride_cycles_rainbow():
-    with patch("breakfast.ui.datetime") as mock_dt:
-        mock_dt.date.today.return_value = _today(6)  # June → Pride
+    with freeze_time("2026-06-01"):  # June → Pride
         for i, expected_colour in enumerate(ui.PRIDE_RAINBOW):
             result = ui.apply_seasonal_colour("alice", i)
             assert result.startswith(expected_colour)
@@ -272,8 +263,7 @@ def test_apply_seasonal_colour_pride_cycles_rainbow():
 
 
 def test_apply_seasonal_colour_pride_wraps():
-    with patch("breakfast.ui.datetime") as mock_dt:
-        mock_dt.date.today.return_value = _today(6)
+    with freeze_time("2026-06-01"):
         n = len(ui.PRIDE_RAINBOW)
         assert ui.apply_seasonal_colour("x", 0) == ui.apply_seasonal_colour("x", n)
 
@@ -435,22 +425,19 @@ def test_render_pr_summary_small_draft_minority_keeps_solid_block():
 
 
 def test_apply_seasonal_colour_off_returns_plain():
-    with patch("breakfast.ui.datetime") as mock_dt:
-        mock_dt.date.today.return_value = _today(1)  # January — normally purple
+    with freeze_time("2026-01-01"):  # January — normally purple
         result = ui.apply_seasonal_colour("alice", 0, calendar="off")
     assert result == "alice"
 
 
 def test_apply_seasonal_colour_unknown_calendar_returns_plain():
-    with patch("breakfast.ui.datetime") as mock_dt:
-        mock_dt.date.today.return_value = _today(1)
+    with freeze_time("2026-01-01"):
         result = ui.apply_seasonal_colour("alice", 0, calendar="nonexistent")
     assert result == "alice"
 
 
 def test_apply_seasonal_colour_western_default():
-    with patch("breakfast.ui.datetime") as mock_dt:
-        mock_dt.date.today.return_value = _today(1)  # January → purple
+    with freeze_time("2026-01-01"):  # January → purple
         result = ui.apply_seasonal_colour("alice", 0)  # default calendar
     assert result.startswith(ui.SEASONAL_PALETTES["purple"])
 
@@ -539,16 +526,14 @@ def test_sikh_calendar_non_holiday_returns_none():
 
 
 def test_apply_seasonal_colour_jewish_calendar():
-    with patch("breakfast.ui.datetime") as mock_dt:
-        mock_dt.date.today.return_value = datetime.date(2025, 12, 14)  # Hanukkah
+    with freeze_time("2025-12-14"):  # Hanukkah
         result = ui.apply_seasonal_colour("alice", 0, calendar="jewish")
     assert result.startswith(ui.SEASONAL_PALETTES["blue"])
     assert result.endswith("\033[0m")
 
 
 def test_apply_seasonal_colour_holi_cycles_by_pr_number():
-    with patch("breakfast.ui.datetime") as mock_dt:
-        mock_dt.date.today.return_value = datetime.date(2025, 3, 14)  # Holi
+    with freeze_time("2025-03-14"):  # Holi
         results = [ui.apply_seasonal_colour("x", i, calendar="hindu") for i in range(6)]
     for i, expected in enumerate(ui.HOLI_RAINBOW):
         assert results[i].startswith(expected)
@@ -567,8 +552,7 @@ def test_in_holiday_window_unknown_year():
 
 def test_western_calendar_january_stays_purple_on_lny_2025():
     # 2025 LNY is Jan 29 — must return purple, not LNY gold.
-    with patch("breakfast.ui.datetime") as mock_dt:
-        mock_dt.date.today.return_value = datetime.date(2025, 1, 29)
+    with freeze_time("2025-01-29"):
         result = ui.apply_seasonal_colour("alice", 0, calendar="western")
     assert result.startswith(ui.SEASONAL_PALETTES["purple"])
 
@@ -576,8 +560,7 @@ def test_western_calendar_january_stays_purple_on_lny_2025():
 def test_render_pr_summary_seasonal_calendar():
     # When a non-"off" calendar is passed, seasonal colours are applied.
     groups = [("alice", _ALICE_URL, 3, 0, 10, 0)]
-    with patch("breakfast.ui.datetime") as mock_dt:
-        mock_dt.date.today.return_value = _today(1)  # January → purple
+    with freeze_time("2026-01-01"):  # January → purple
         result = ui.render_pr_summary(groups, "Title", "Author", True, "western")
     assert "\033[" in result
 
@@ -586,8 +569,7 @@ def test_global_january_purple_across_calendars():
     # Eid al-Fitr (2031-01-24), Eid al-Adha (2038-01-16), or LNY (2025-01-29)
     # falling in January must always return purple regardless of calendar.
     for cal in ["jewish", "islamic", "hindu", "sikh", "east-asian", "western"]:
-        with patch("breakfast.ui.datetime") as mock_dt:
-            mock_dt.date.today.return_value = datetime.date(2025, 1, 29)
+        with freeze_time("2025-01-29"):
             result = ui.apply_seasonal_colour("x", 0, calendar=cal)
         assert result.startswith(ui.SEASONAL_PALETTES["purple"]), f"cal={cal}"
 

--- a/uv.lock
+++ b/uv.lock
@@ -57,6 +57,7 @@ build = [
 dev = [
     { name = "black" },
     { name = "click-man" },
+    { name = "freezegun" },
     { name = "pytest" },
     { name = "requests-mock" },
     { name = "ruff" },
@@ -67,6 +68,7 @@ lint = [
     { name = "ruff" },
 ]
 test = [
+    { name = "freezegun" },
     { name = "pytest" },
     { name = "requests-mock" },
 ]
@@ -78,6 +80,8 @@ requires-dist = [
     { name = "click" },
     { name = "click-man", marker = "extra == 'build'" },
     { name = "click-man", marker = "extra == 'dev'" },
+    { name = "freezegun", marker = "extra == 'dev'" },
+    { name = "freezegun", marker = "extra == 'test'" },
     { name = "pytest", marker = "extra == 'dev'" },
     { name = "pytest", marker = "extra == 'test'" },
     { name = "requests" },
@@ -208,6 +212,18 @@ wheels = [
 ]
 
 [[package]]
+name = "freezegun"
+version = "1.5.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "python-dateutil" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/95/dd/23e2f4e357f8fd3bdff613c1fe4466d21bfb00a6177f238079b17f7b1c84/freezegun-1.5.5.tar.gz", hash = "sha256:ac7742a6cc6c25a2c35e9292dfd554b897b517d2dec26891a2e8debf205cb94a", size = 35914, upload-time = "2025-08-09T10:39:08.338Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5e/2e/b41d8a1a917d6581fc27a35d05561037b048e47df50f27f8ac9c7e27a710/freezegun-1.5.5-py3-none-any.whl", hash = "sha256:cd557f4a75cf074e84bc374249b9dd491eaeacd61376b9eb3c423282211619d2", size = 19266, upload-time = "2025-08-09T10:39:06.636Z" },
+]
+
+[[package]]
 name = "idna"
 version = "3.11"
 source = { registry = "https://pypi.org/simple" }
@@ -302,6 +318,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901, upload-time = "2025-12-06T21:30:51.014Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801, upload-time = "2025-12-06T21:30:49.154Z" },
+]
+
+[[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
 ]
 
 [[package]]
@@ -412,6 +440,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/06/85/004e7123b4821c64be6d9bfed27f63147b4dde929a1cd848f137befeada4/shiv-1.0.8.tar.gz", hash = "sha256:2a68d69e98ce81cb5b8fdafbfc1e27efa93e6d89ca14bfae33482e4176f561d6", size = 32806, upload-time = "2024-11-01T19:47:46.189Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e7/ec/afbb46f7c1ab071a50d92424daf149420ca1f0e02dc51239485747151d6c/shiv-1.0.8-py2.py3-none-any.whl", hash = "sha256:a60e4b05a2d2f8b820d567b1d89ee59af731759771c32c282d03c4ceae6aba24", size = 20516, upload-time = "2024-11-01T19:47:45.061Z" },
+]
+
+[[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Issue

Closes #375

## Description

CI on `main` was failing (run [#925](https://github.com/mrsixw/breakfast/actions/runs/28547733507)) because `tests/test_cli.py::test_index_column_coloured_when_enabled_by_config` implicitly depended on the real-world calendar date.

The `colour-index` feature (`renderers.py:844`) colours the row-index column by reusing the seasonal-theme helper `_seasonal_colour()`, which only emits ANSI codes when `apply_seasonal_colour()` (`ui.py`) decides the current month has an active palette (January, the computed Easter month, June Pride, October, December). The test never mocked the current date, so it happened to pass throughout June (Pride month) but started failing on July 1st, since July has no seasonal palette and the index column is left unstyled.

While fixing this, we also replaced all manual `datetime` mocking in the affected test files with the `freezegun` library, since it's more robust than hand-rolled `unittest.mock.patch("breakfast.ui.datetime")` boilerplate — it patches the stdlib `datetime` module directly so tests don't need to know or target `ui.py`'s internal import path.

## Changes

- Added `freezegun` to the `test` and `dev` optional dependency groups in `pyproject.toml`.
- `tests/test_cli.py::test_index_column_coloured_when_enabled_by_config` now uses `@freeze_time`/`with freeze_time(...)` pinned to June, so the assertion no longer depends on when the suite is run.
- Converted every manual `patch("breakfast.ui.datetime")` / `mock_dt.date.today.return_value = ...` block in `tests/test_ui.py` and `tests/test_cli.py` (18 call sites) to use `freeze_time` instead.

## Testing

- [x] `make test` passes (502 passed)
- [x] `make lint` passes
- [x] `make format` run
- [x] Ran the affected tests directly to confirm deterministic pass/fail independent of wall-clock date

## Notes

This only fixes the test's flakiness. The underlying `colour-index` feature still only visibly colours the index column during "special" seasonal months by design (it reuses the seasonal palette machinery) — that behaviour is unchanged and considered out of scope here, per discussion with the maintainer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
