### PR TITLE
#377: Add permanent rainbow seasonal-calendar option

### DIFF
--- a/docs/manual/options.md
+++ b/docs/manual/options.md
@@ -1040,6 +1040,7 @@ Choose which cultural holiday calendar drives the seasonal colour effects in the
 | `"hindu"` | Diwali 🪔 (gold), Holi 🎨 (rainbow) |
 | `"islamic"` | Eid al-Fitr 🌙 (green), Eid al-Adha 🐑 (green) |
 | `"jewish"` | Hanukkah 🕎 (blue), Rosh Hashanah 🍎 (gold), Passover 🪬 (spring green), Sukkot 🌿 (orange) |
+| `"rainbow"` | Permanent Pride 🌈 cycle, every day of the year — no holiday detection |
 | `"sikh"` | Vaisakhi 🌾 (spring green), Bandi Chhor Divas 🪔 (gold) |
 | `"western"` | Gregorian calendar: Christmas 🎄, Easter 🐣, Pride Month 🌈, Halloween 🎃, Valentine's Day 💕, Lunar New Year 🧧 (default) |
 | `"off"` | Disable seasonal colours entirely |
@@ -1049,6 +1050,8 @@ seasonal-calendar = "east-asian"
 ```
 
 Note: `seasonal-colours = false` is a backward-compatible alias for `seasonal-calendar = "off"`.
+
+Note: every other calendar defers to purple in January; `"rainbow"` is the one exception and keeps cycling through the Pride colours all year, including January.
 
 ### `--colour-diagnostics` / `--color-diagnostics`
 

--- a/src/breakfast/config.py
+++ b/src/breakfast/config.py
@@ -178,6 +178,7 @@ _DEFAULT_CONFIG_CONTENT = """\
 #   hindu      — Diwali 🪔, Holi 🎨
 #   islamic    — Eid al-Fitr 🌙, Eid al-Adha 🐑
 #   jewish     — Hanukkah 🕎, Passover 🪬, Rosh Hashanah 🍎, Sukkot 🌿
+#   rainbow    — permanent Pride 🌈 cycle, every day of the year
 #   sikh       — Vaisakhi 🌾, Bandi Chhor Divas 🪔
 #   western    — Christmas 🎄, Easter 🐣, Pride Month 🌈, Halloween 🎃 (default)
 #   off        — disable seasonal colours entirely

--- a/src/breakfast/ui.py
+++ b/src/breakfast/ui.py
@@ -517,11 +517,21 @@ def _western_calendar(today: datetime.date) -> "str | list[str] | None":
     return None
 
 
+def _rainbow_calendar(today: datetime.date) -> "str | list[str] | None":
+    """Return the Pride rainbow cycle for every day of the year.
+
+    Unlike the other calendars, this is a permanent opt-in rather than a
+    date-driven holiday, so it is exempt from the January purple override.
+    """
+    return PRIDE_RAINBOW
+
+
 CALENDARS: dict[str, object] = {
     "east-asian": _east_asian_calendar,
     "hindu": _hindu_calendar,
     "islamic": _islamic_calendar,
     "jewish": _jewish_calendar,
+    "rainbow": _rainbow_calendar,
     "sikh": _sikh_calendar,
     "western": _western_calendar,
 }
@@ -547,7 +557,8 @@ def apply_seasonal_colour(text: str, pr_number: int, calendar: str = "western") 
 
     The *calendar* argument selects which cultural calendar's holidays drive
     the seasonal colours. Valid values: ``"western"`` (default), ``"jewish"``,
-    ``"islamic"``, ``"hindu"``, ``"sikh"``, or ``"off"`` to disable entirely.
+    ``"islamic"``, ``"hindu"``, ``"sikh"``, ``"rainbow"`` (permanent Pride
+    cycle, any date), or ``"off"`` to disable entirely.
 
     Lists (December candy-cane, June Pride, Holi rainbow) cycle by PR number.
     """
@@ -557,7 +568,7 @@ def apply_seasonal_colour(text: str, pr_number: int, calendar: str = "western") 
     if calendar_fn is None:
         return text
     today = datetime.date.today()
-    if today.month == 1:
+    if today.month == 1 and calendar != "rainbow":
         colour = SEASONAL_PALETTES["purple"]
         return f"{colour}{text}\033[0m"
     result = calendar_fn(today)
@@ -785,7 +796,9 @@ def render_colour_diagnostics() -> str:
 
     # Pride Month rainbow — one swatch per colour in the cycle.
     pride_swatches = "  ".join(f"{code}{BLOCK}\033[0m" for code in PRIDE_RAINBOW)
-    lines.append(f"  {_vpad('Pride Month 🌈 (June)', 34)}  {pride_swatches}")
+    lines.append(
+        f"  {_vpad('Pride 🌈 (June, or rainbow calendar)', 34)}  {pride_swatches}"
+    )
 
     # Holi rainbow — one swatch per colour in the cycle.
     holi_swatches = "  ".join(f"{code}{BLOCK}\033[0m" for code in HOLI_RAINBOW)

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -574,6 +574,31 @@ def test_global_january_purple_across_calendars():
         assert result.startswith(ui.SEASONAL_PALETTES["purple"]), f"cal={cal}"
 
 
+def test_rainbow_calendar_always_returns_pride_rainbow():
+    for month in range(1, 13):
+        result = ui._rainbow_calendar(_today(month))
+        assert result == ui.PRIDE_RAINBOW
+
+
+def test_apply_seasonal_colour_rainbow_cycles_by_pr_number():
+    with freeze_time("2025-09-03"):  # an otherwise unthemed month
+        results = [
+            ui.apply_seasonal_colour("x", i, calendar="rainbow")
+            for i in range(len(ui.PRIDE_RAINBOW))
+        ]
+    for i, expected in enumerate(ui.PRIDE_RAINBOW):
+        assert results[i].startswith(expected)
+
+
+def test_apply_seasonal_colour_rainbow_overrides_january_purple():
+    # Unlike every other calendar, rainbow mode is a permanent user choice
+    # and is exempt from the January purple override.
+    with freeze_time("2025-01-15"):
+        result = ui.apply_seasonal_colour("x", 0, calendar="rainbow")
+    assert result.startswith(ui.PRIDE_RAINBOW[0])
+    assert not result.startswith(ui.SEASONAL_PALETTES["purple"])
+
+
 def test_islamic_calendar_eid_al_adha():
     # Eid al-Adha 2024 starts June 16, 3-day window
     for d in range(16, 19):


### PR DESCRIPTION
## Summary

- **Permanent Pride rainbow mode**: `seasonal-calendar` currently only shows the Pride rainbow (🌈 cycling by PR row) automatically during June via `"western"`. This adds a `"rainbow"` calendar value that shows the same cycle every day of the year, for users who want it on permanently.
- **Key Changes**:
  - `src/breakfast/ui.py`: added `_rainbow_calendar()`, which always returns `PRIDE_RAINBOW` regardless of date, and registered it as `"rainbow"` in the `CALENDARS` dict alongside `east-asian` / `hindu` / `islamic` / `jewish` / `sikh` / `western`.
  - `src/breakfast/ui.py`: `apply_seasonal_colour()` now treats `"rainbow"` as the one exception to the hardcoded January-purple override (every other calendar defers to purple in January; rainbow keeps cycling since it's a deliberate permanent choice, not a floating holiday).
  - `src/breakfast/ui.py`: updated the `--colour-diagnostics` swatch label to note the Pride swatches are also used by the new `rainbow` calendar.
  - `src/breakfast/config.py`: documented `rainbow` in the `seasonal-calendar` config comment block.
  - No new CLI flag — reuses the existing `seasonal-calendar` config key, set via `seasonal-calendar = "rainbow"` in `config.toml`.
- **Abstractions & Design Decisions**: Slots into the existing pluggable-calendar architecture (`CALENDARS` dict of `date -> colour(s)` functions) rather than adding a separate flag/precedence system, since rainbow mode has no real use case layered on top of another calendar's holiday colours.

## Test plan

- [x] `make format && make lint && make test` passes (505 tests)
- [x] **New unit tests** in `tests/test_ui.py`:
  - `test_rainbow_calendar_always_returns_pride_rainbow` — verifies the calendar function returns `PRIDE_RAINBOW` for every month.
  - `test_apply_seasonal_colour_rainbow_cycles_by_pr_number` — verifies row colours cycle through the Pride palette by PR number in an otherwise unthemed month.
  - `test_apply_seasonal_colour_rainbow_overrides_january_purple` — verifies rainbow mode is the one calendar that stays active in January instead of deferring to purple.
- [x] **Manual Verification**:
  - Ran `apply_seasonal_colour(f"pr-{i}", i, calendar="rainbow")` for `i in range(6)` and confirmed the six ANSI codes match `PRIDE_RAINBOW` in order.

Closes #377

🤖 Generated with [Claude Code](https://claude.com/claude-code)