### PR TITLE
#379: Add make install target to install executable to a standard Unix path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,11 @@
 .ONESHELL:
 SHELL = /bin/bash
 
-.PHONY: activate build version-bump release breakfast smoketest test lint docs-lint format man completions
+PREFIX ?= /usr/local
+BINDIR ?= $(PREFIX)/bin
+DESTDIR ?=
+
+.PHONY: activate build version-bump release breakfast smoketest test lint docs-lint format man completions install uninstall
 
 .venv:
 	uv venv .venv
@@ -14,6 +18,13 @@ build: .venv
 
 	uv sync --extra build
 	uv run shiv -c breakfast -o breakfast --python '/usr/bin/env python3' --preamble utils/preamble.py .
+
+install: build
+	install -d "$(DESTDIR)$(BINDIR)"
+	install -m 755 breakfast "$(DESTDIR)$(BINDIR)/breakfast"
+
+uninstall:
+	rm -f "$(DESTDIR)$(BINDIR)/breakfast"
 
 version-bump:
 	git mkver patch

--- a/docs/manual/installation.md
+++ b/docs/manual/installation.md
@@ -36,9 +36,9 @@ make build
 
 This produces a `./breakfast` standalone executable using [shiv](https://github.com/linkedin/shiv).
 
-### Install the binary
+### Install from source
 
-To install the built executable to a standard Unix path:
+To install the built executable after compiling from source:
 
 ```bash
 sudo make install
@@ -49,6 +49,9 @@ By default, this installs the executable to `/usr/local/bin`. You can customize 
 ```bash
 make install PREFIX=$HOME/.local
 ```
+
+> [!NOTE]
+> This compiles and installs the binary from your local source tree. If you want to download and install a pre-compiled binary instantly instead, use the primary [One-liner](#primary-method-one-liner) method.
 
 To uninstall:
 

--- a/docs/manual/installation.md
+++ b/docs/manual/installation.md
@@ -36,6 +36,32 @@ make build
 
 This produces a `./breakfast` standalone executable using [shiv](https://github.com/linkedin/shiv).
 
+### Install the binary
+
+To install the built executable to a standard Unix path:
+
+```bash
+sudo make install
+```
+
+By default, this installs the executable to `/usr/local/bin`. You can customize the installation prefix using the `PREFIX` variable:
+
+```bash
+make install PREFIX=$HOME/.local
+```
+
+To uninstall:
+
+```bash
+sudo make uninstall
+```
+
+If installed with a custom `PREFIX`:
+
+```bash
+make uninstall PREFIX=$HOME/.local
+```
+
 ## Set up your GitHub token
 
 breakfast requires a `GITHUB_TOKEN` environment variable:


### PR DESCRIPTION
## Summary

- **Add make install option**: Support installing the `breakfast` executable **from source** on a standard Unix path (designed for build-from-source/development workflows, rather than pulling pre-compiled binaries via the `install.sh` script).
- **Key Changes**:
  - Added `PREFIX`, `BINDIR`, and `DESTDIR` configuration variables to `Makefile`.
  - Added `install` and `uninstall` targets to the `Makefile`.
  - Added `install` and `uninstall` to `.PHONY`.
  - Documented `make install` and `make uninstall` usage in `docs/manual/installation.md` under advanced source installations.
- **Abstractions & Design Decisions**: Utilized standard `install(1)` utility for robust, permissions-preserving installations (mode `755`).

## Test plan

- [x] `make format && make lint && make test` passes.
- [x] **Manual Verification / Smoke Test**:
  - Built and installed the binary using a temporary prefix: `make build && make install PREFIX=/tmp/test_breakfast`.
  - Executed `/tmp/test_breakfast/bin/breakfast --version` to verify behavior.
  - Successfully uninstalled using `make uninstall PREFIX=/tmp/test_breakfast`.

Closes #379

🥐 Prepared by [Gemini](https://deepmind.google/technologies/gemini/)
