### PR TITLE
#392: Fall back to cache when GitHub API limits are exhausted

### DIFF
--- a/docs/manual/options.md
+++ b/docs/manual/options.md
@@ -904,7 +904,7 @@ workers = 16
 
 ## Caching options
 
-The disk cache is **off by default**. Enable it with `--cache` or `cache = true` in config. Once enabled, results are stored in `~/.cache/breakfast/` (or `$XDG_CACHE_HOME/breakfast/`) and reused until the TTL expires.
+The disk cache is **off by default**. Enable it with `--cache` or `cache = true` in config. Once enabled, results are stored in `~/.cache/breakfast/` (or `$XDG_CACHE_HOME/breakfast/`) and reused until the TTL expires. Complete cache hits are resolved before GitHub identity or diagnostics requests, so `--mine-only` and `--needs-my-review` can also avoid the API after the token's login has been cached by a successful run.
 
 ### `--cache` / `--no-cache`
 
@@ -940,6 +940,8 @@ cache-ttl = "5m"
 
 Fetch fresh data and write it to the cache, ignoring whatever is already cached. Requires `--cache` (or `cache = true` in config) — exits with an error if the cache is not enabled. Subsequent runs within the TTL will be served from the freshly updated cache.
 
+If GitHub exhausts a REST or GraphQL rate limit during the refresh, breakfast displays the latest coherent full cache instead and prints a warning that the requested refresh could not be completed. The degraded run exits successfully because cached output was produced, but the cache timestamp is not updated.
+
 ```bash
 breakfast -o my-org -r my-app --cache --refresh
 ```
@@ -947,6 +949,8 @@ breakfast -o my-org -r my-app --cache --refresh
 ### `--refresh-prs`
 
 Re-fetch PR details (comments, CI status, merge state) using the cached repo list, then write the fresh results back to the cache. Requires `--cache` (or `cache = true` in config) — exits with an error if the cache is not enabled. Faster than `--refresh` when you know the set of open PRs hasn't changed.
+
+Like `--refresh`, a rate-limited `--refresh-prs` run falls back to the latest full cache with a clear warning and does not overwrite it with partial results.
 
 ```bash
 breakfast -o my-org -r my-app --cache --refresh-prs
@@ -956,14 +960,14 @@ breakfast -o my-org -r my-app --cache --refresh-prs
 
 Force offline mode using the most recent cached data (even if it has expired beyond the configured TTL).
 
-If internet connectivity is absent or weak, breakfast will also automatically fall back to the most recent disk cache (even if older than the TTL) and display a clear offline banner.
+If internet connectivity is absent or weak, or GitHub exhausts a REST or GraphQL rate limit, breakfast will automatically fall back to the most recent full disk cache (even if older than the TTL) and display a clear `stderr` banner. A rate-limit banner names the exhausted API, reports the cache age, and includes the reset time when GitHub provides one.
 
 When offline mode is active (either forced via `--offline` or via automatic fallback):
 
 - It reads from the cache regardless of the TTL expiration.
 - It bypasses all update checks, check status fetches, and approval fetches.
-- It does not write any refreshed data back to the cache, preventing corrupted timestamps.
-- If `--mine-only` or `--needs-my-review` is used, breakfast reads your GitHub login from a small `user.json` file in the cache directory (written automatically on the first successful online run). If no cached login exists yet, a warning is printed to `stderr` and the filter is skipped — run once online to prime the cache.
+- Successful online identity lookups are cached by a SHA-256-derived, token-specific key; the token itself is never written to disk.
+- `--mine-only` and `--needs-my-review` use that cached login. If no login has been cached for the active token, a warning is printed to `stderr` stating that the identity-dependent filter was not applied and all cached PRs are shown.
 
 If `--offline` is enabled but no cached data is found on disk, the application exits with an error.
 
@@ -985,6 +989,8 @@ offline = true
 | `--cache --refresh` | yes | skip, write fresh | skip, write fresh |
 | `--no-cache` | no (override) | skip | skip |
 | `--offline` | yes | read (ignore TTL) | read (ignore TTL, no write) |
+
+When a live cache-enabled run is rate limited, the full PR detail cache is read with TTL expiry ignored. If no matching full cache is available, breakfast exits non-zero, leaves `stdout` empty, and reports both the missing cache and reset time on `stderr`.
 
 ## Update notifications
 
@@ -1105,7 +1111,7 @@ Each row shows filled blocks rendered in the actual colour alongside the ANSI co
 
 ### `--api-stats`
 
-Print API diagnostics to stderr after the normal output. Useful for understanding slow runs or diagnosing rate-limit issues.
+Print API diagnostics to stderr after the normal output. Useful for understanding slow runs or diagnosing rate-limit issues. Call counts represent attempted HTTP requests, including retries and rate-limited responses. The summary uses metadata captured from those responses and never makes its own diagnostics request.
 
 ```bash
 breakfast -o my-org -r my-app --api-stats
@@ -1121,8 +1127,22 @@ Output is written to **stderr** so it does not interfere with `--json` piping. E
   REST rate limit:  4913 requests remaining
   REST rate resets: 10:30:00 UTC
   GQL rate limit:   4998 points remaining
-  GQL rate resets:  2026-04-11T10:30:00Z
+  GQL rate resets:  10:30:00 UTC
+  Data source:      live GitHub API
 ```
+
+When a limit causes cached fallback, the exhausted resource and cache source are explicit:
+
+```text
+🐛 Debug summary
+  API calls:        1 (1 REST + 0 GraphQL)
+  REST rate limit:   exhausted (0 requests remaining)
+  REST rate resets:  11:19:37 UTC
+  GQL rate limit:    not reported this run
+  Data source:      local cache (12 minutes ago)
+```
+
+`not reported this run` means that resource returned no rate-limit headers; it does not mean the resource is exhausted.
 
 Can also be enabled persistently via config:
 

--- a/docs/manual/troubleshooting.md
+++ b/docs/manual/troubleshooting.md
@@ -37,13 +37,25 @@ curl -H "Authorization: Bearer ${GH_TOKEN:-$GITHUB_TOKEN}" https://api.github.co
 - If using `--mine-only`, ensure the token belongs to the user whose PRs you want to see
 - If using `--ignore-author`, check you haven't accidentally filtered out the authors you want
 
-## API errors (502, 503, 504), timeouts, and network loss
+## API errors, rate limits, timeouts, and network loss
 
 breakfast automatically retries REST and GraphQL API requests on transient server errors and network timeouts with exponential backoff (up to 3 retries).
 
 To prevent the CLI from hanging indefinitely on stalled or flaky connections (e.g. captive portals or misconfigured VPNs), an explicit timeout is set on all API requests: a connection timeout of 5 seconds and a read timeout of 30 seconds.
 
-If you lose internet connectivity, a request times out, or GitHub is experiencing outages, breakfast will automatically fall back to the most recent cached results on disk, even if expired, and print an offline mode banner.
+If you lose internet connectivity, a request times out, GitHub is experiencing outages, or a REST/GraphQL rate limit is exhausted, a cache-enabled run automatically falls back to the most recent full cached results on disk, even if expired. Partial live results are discarded and never overwrite that coherent snapshot.
+
+Rate-limit fallback prints a `stderr` message such as:
+
+```text
+🥞 GitHub REST API rate limit exceeded; displaying local cached data from 12 minutes ago. Live GitHub data should be available after 2026-07-13 11:19:37 UTC.
+```
+
+The run exits successfully when cached output is available. If no matching full cache exists, it exits non-zero with empty `stdout` and states that no local cached data is available. Explicit `--refresh` and `--refresh-prs` requests also fall back, but their warning clearly says the requested refresh could not be completed and the old cache is not rewritten.
+
+With `--api-stats`, exhausted limits are shown as `exhausted (0 requests remaining)` or `exhausted (0 points remaining)`, alongside the captured reset time and `Data source: local cache (...)`. The debug summary does not make another GitHub request.
+
+`--mine-only` and `--needs-my-review` use a token-specific cached login during fallback. If the active token has not completed an online identity lookup before, breakfast warns that the filter could not be applied and displays all locally cached PRs.
 
 If you know you are offline or have weak connectivity, you can force breakfast to use the local cache immediately without making any network requests by passing `--offline`.
 

--- a/docs/manual/usage.md
+++ b/docs/manual/usage.md
@@ -199,25 +199,29 @@ breakfast -o my-org -r platform --legendary-only
 
 ### Speed up repeated runs with caching
 
-PR results are cached to disk for 5 minutes by default. The second run is near-instant:
+PR results can be cached to disk. The second cache-enabled run is near-instant:
 
 ```bash
-breakfast -o my-org -r platform          # fetches from API, writes cache
-breakfast -o my-org -r platform          # served from cache (~instant)
+breakfast -o my-org -r platform --cache      # fetches from API, writes cache
+breakfast -o my-org -r platform --cache      # served from cache (~instant)
 breakfast -o my-org -r platform --no-cache   # always fetches fresh
 ```
 
 Adjust the TTL with `--cache-ttl`:
 
 ```bash
-breakfast -o my-org -r platform --cache-ttl 10m   # cache for 10 minutes
+breakfast -o my-org -r platform --cache --cache-ttl 10m
 ```
+
+If GitHub exhausts a REST or GraphQL rate limit, a cache-enabled run automatically displays the latest coherent full cache, even if its TTL has expired. The warning on `stderr` names the exhausted resource, cache age, and reset time. `--api-stats` also marks the resource as exhausted and identifies the local cache as the data source without making another API request.
 
 ## How it works
 
-1. **Check cache** - Looks for a recent on-disk cache for the `(owner, repo-filter)` pair; if found and within the TTL, skips steps 2–3 entirely
-2. **Fetch repositories** - Uses the GitHub GraphQL API to paginate through all repositories for the owner (organization or personal account)
-3. **Filter repos** - Keeps only repos whose name contains the `--repo-filter` substring
-4. **Fetch PR details** - Uses the GitHub REST API to fetch full details for each open PR (parallelized for speed); writes results to disk cache
-5. **Filter PRs** - Applies author filters (`--ignore-author`, `--mine-only`), title search (`--search`), and other filters
-6. **Display** - Renders results as a terminal table or JSON
+1. **Check cache** - Looks for a recent full on-disk cache for the `(owner, repo-filter)` pair before making avoidable GitHub requests
+2. **Resolve identity** - Uses the token-specific cached login for identity-dependent filters, or fetches and caches it when needed
+3. **Fetch repositories** - Uses the GitHub GraphQL API to paginate through all repositories for the owner (organization or personal account)
+4. **Filter repos** - Keeps only repos matching the active repository filters
+5. **Fetch PR details** - Uses the GitHub REST API to fetch full details for each open PR (parallelized for speed); writes complete results to disk cache
+6. **Fall back safely** - If a rate limit or connection failure interrupts acquisition, discards partial results and reads the latest coherent full cache
+7. **Filter PRs** - Applies author filters (`--ignore-author`, `--mine-only`), title search (`--search`), and other filters
+8. **Display** - Renders results as a terminal table or JSON

--- a/src/breakfast/api.py
+++ b/src/breakfast/api.py
@@ -4,6 +4,7 @@ import os
 import random
 import threading
 import time
+from concurrent.futures import CancelledError
 from functools import lru_cache
 from urllib.parse import quote, urlparse
 
@@ -101,14 +102,30 @@ class GitHubGraphQLResourceLimitError(GitHubGraphQLError):
 
 
 class GitHubRateLimitError(Exception):
-    """Raised when the GitHub REST API rate limit is exhausted.
+    """Raised when a GitHub API rate limit is exhausted.
 
     Attributes:
+        resource: API resource that was rate limited (``rest`` or ``graphql``).
+        remaining: Reported remaining requests or points, if available.
+        reset_timestamp: Unix reset timestamp, if available.
         reset_time: UTC datetime when the rate limit resets, or None if unknown.
+        retry_after: Retry delay reported by GitHub, if available.
     """
 
-    def __init__(self, reset_time=None):
+    def __init__(
+        self,
+        reset_time=None,
+        *,
+        resource="rest",
+        remaining=None,
+        reset_timestamp=None,
+        retry_after=None,
+    ):
+        self.resource = resource.lower()
+        self.remaining = remaining
+        self.reset_timestamp = reset_timestamp
         self.reset_time = reset_time
+        self.retry_after = retry_after
         if reset_time:
             super().__init__(
                 f"GitHub API rate limit exceeded. Try again after {reset_time} UTC."
@@ -149,18 +166,167 @@ class GitHubAuthenticationError(requests.exceptions.HTTPError):
 
 
 _api_stats_lock = threading.Lock()
-_api_stats = {
+_API_STATS_DEFAULTS = {
     "rest_calls": 0,
     "graphql_calls": 0,
     "rest_rate_limit_remaining": None,
     "rest_rate_limit_reset": None,
+    "rest_rate_limit_exhausted": False,
+    "graphql_rate_limit_remaining": None,
+    "graphql_rate_limit_reset": None,
+    "graphql_rate_limit_exhausted": False,
 }
+_api_stats = dict(_API_STATS_DEFAULTS)
+_api_request_stop_event = None
+_api_request_stop_lock = threading.Lock()
 
 
 def get_api_stats():
     """Return a snapshot of the current API call statistics."""
     with _api_stats_lock:
         return dict(_api_stats)
+
+
+def reset_api_stats():
+    """Reset API diagnostics for a new CLI invocation."""
+    with _api_stats_lock:
+        _api_stats.clear()
+        _api_stats.update(_API_STATS_DEFAULTS)
+
+
+def set_api_request_stop_event(stop_event):
+    """Register a shared event used to stop a concurrent API request pool."""
+    global _api_request_stop_event
+    with _api_request_stop_lock:
+        _api_request_stop_event = stop_event
+
+
+def clear_api_request_stop_event(stop_event):
+    """Unregister *stop_event* without clearing a newer pool's event."""
+    global _api_request_stop_event
+    with _api_request_stop_lock:
+        if _api_request_stop_event is stop_event:
+            _api_request_stop_event = None
+
+
+def _signal_api_request_stop():
+    """Stop queued and subsequent requests after rate-limit detection."""
+    with _api_request_stop_lock:
+        stop_event = _api_request_stop_event
+    if stop_event is not None:
+        stop_event.set()
+
+
+def _raise_if_api_requests_stopped():
+    """Abort before an HTTP send when another worker exhausted the limit."""
+    with _api_request_stop_lock:
+        stop_event = _api_request_stop_event
+    if stop_event is not None and stop_event.is_set():
+        raise CancelledError("API request cancelled after rate-limit exhaustion")
+
+
+def _record_api_attempt(resource):
+    """Count one attempted HTTP request for API diagnostics."""
+    with _api_stats_lock:
+        _api_stats[f"{resource}_calls"] += 1
+
+
+def _parse_int_header(headers, name):
+    """Return integer header *name*, or ``None`` when absent or invalid."""
+    value = headers.get(name)
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _record_rate_limit_headers(resource, headers, *, exhausted=False):
+    """Record rate-limit response headers for REST or GraphQL diagnostics."""
+    remaining = _parse_int_header(headers, "X-RateLimit-Remaining")
+    reset_timestamp = _parse_int_header(headers, "X-RateLimit-Reset")
+    with _api_stats_lock:
+        if remaining is not None:
+            _api_stats[f"{resource}_rate_limit_remaining"] = remaining
+        if reset_timestamp is not None:
+            _api_stats[f"{resource}_rate_limit_reset"] = reset_timestamp
+        if exhausted or remaining == 0:
+            _api_stats[f"{resource}_rate_limit_exhausted"] = True
+
+
+def _payload_is_rate_limited(payload):
+    """Return whether a GitHub REST or GraphQL error payload signals throttling."""
+    if not isinstance(payload, dict):
+        return False
+
+    messages = [str(payload.get("message", ""))]
+    errors = payload.get("errors", [])
+    if isinstance(errors, list):
+        for error in errors:
+            if isinstance(error, dict):
+                if str(error.get("type", "")).upper() == "RATE_LIMITED":
+                    return True
+                messages.append(str(error.get("message", "")))
+            else:
+                messages.append(str(error))
+
+    text = " ".join(messages).lower()
+    return (
+        "rate limit exceeded" in text
+        or "exceeded a secondary rate limit" in text
+        or "secondary rate limit exceeded" in text
+    )
+
+
+def _response_json_or_none(response):
+    """Return an error response's JSON body when it can be decoded."""
+    try:
+        return response.json()
+    except (AttributeError, ValueError, requests.exceptions.JSONDecodeError):
+        return None
+
+
+def _rate_limit_error_from_response(response, resource, payload=None):
+    """Build a typed rate-limit error when *response* indicates exhaustion."""
+    headers = getattr(response, "headers", {})
+    status_code = getattr(response, "status_code", None)
+    remaining = _parse_int_header(headers, "X-RateLimit-Remaining")
+    retry_after = headers.get("Retry-After")
+    payload_rate_limited = _payload_is_rate_limited(payload)
+    rate_limited = status_code == 429 or (
+        status_code == 403
+        and (remaining == 0 or retry_after is not None or payload_rate_limited)
+    )
+    if resource == "graphql" and payload_rate_limited:
+        rate_limited = True
+    if not rate_limited:
+        return None
+
+    reset_timestamp = _parse_int_header(headers, "X-RateLimit-Reset")
+    reset_time = None
+    if reset_timestamp is not None:
+        reset_time = datetime.datetime.fromtimestamp(
+            reset_timestamp, tz=datetime.timezone.utc
+        ).strftime("%Y-%m-%d %H:%M:%S")
+    elif retry_after is not None:
+        try:
+            retry_seconds = int(retry_after)
+        except (TypeError, ValueError):
+            retry_seconds = None
+        if retry_seconds is not None:
+            reset_time = (
+                datetime.datetime.now(datetime.timezone.utc)
+                + datetime.timedelta(seconds=retry_seconds)
+            ).strftime("%Y-%m-%d %H:%M:%S")
+
+    return GitHubRateLimitError(
+        reset_time,
+        resource=resource,
+        remaining=remaining,
+        reset_timestamp=reset_timestamp,
+        retry_after=retry_after,
+    )
 
 
 def get_graphql_rate_limit():
@@ -189,12 +355,17 @@ def make_github_api_request(query_string):
         "Accept": "application/vnd.github.v3+json",
     }
     for attempt in range(_MAX_RETRIES + 1):
+        _raise_if_api_requests_stopped()
         if attempt:
             time.sleep(2 ** (attempt - 1) + random.uniform(0, 0.5))
         try:
+            _raise_if_api_requests_stopped()
             t0 = time.monotonic()
+            _record_api_attempt("rest")
             req = requests.get(url, headers=headers, timeout=_REQUEST_TIMEOUT)
             elapsed_ms = int((time.monotonic() - t0) * 1000)
+            response_headers = getattr(req, "headers", {})
+            _record_rate_limit_headers("rest", response_headers)
             if req.status_code in _RETRY_STATUSES and attempt < _MAX_RETRIES:
                 logger.debug(
                     "api_call type=rest url=%s status=%d"
@@ -214,22 +385,21 @@ def make_github_api_request(query_string):
                     token_var,
                 )
                 raise GitHubAuthenticationError(token_var=token_var, response=req)
-            if (
-                req.status_code == 403
-                and req.headers.get("X-RateLimit-Remaining") == "0"
-            ):
-                reset_ts = req.headers.get("X-RateLimit-Reset")
-                reset_time = None
-                if reset_ts:
-                    reset_time = datetime.datetime.fromtimestamp(
-                        int(reset_ts), tz=datetime.timezone.utc
-                    ).strftime("%Y-%m-%d %H:%M:%S")
+            error_payload = (
+                _response_json_or_none(req) if req.status_code in {403, 429} else None
+            )
+            rate_limit_error = _rate_limit_error_from_response(
+                req, "rest", error_payload
+            )
+            if rate_limit_error is not None:
+                _record_rate_limit_headers("rest", response_headers, exhausted=True)
+                _signal_api_request_stop()
                 logger.warning(
                     "api_call type=rest url=%s rate_limit_exceeded reset=%s",
                     url,
-                    reset_time,
+                    rate_limit_error.reset_time,
                 )
-                raise GitHubRateLimitError(reset_time)
+                raise rate_limit_error
             req.raise_for_status()
             logger.debug(
                 "api_call type=rest url=%s status=%d elapsed_ms=%d",
@@ -238,15 +408,6 @@ def make_github_api_request(query_string):
                 elapsed_ms,
             )
             result = req.json()
-            with _api_stats_lock:
-                _api_stats["rest_calls"] += 1
-                resp_headers = getattr(req, "headers", {})
-                remaining = resp_headers.get("X-RateLimit-Remaining")
-                reset_ts = resp_headers.get("X-RateLimit-Reset")
-                if remaining is not None:
-                    _api_stats["rest_rate_limit_remaining"] = int(remaining)
-                if reset_ts is not None:
-                    _api_stats["rest_rate_limit_reset"] = int(reset_ts)
             return result
         except (
             requests.exceptions.ChunkedEncodingError,
@@ -304,10 +465,13 @@ def make_github_graphql_request(query, variables=None):
     }
     payload = {"query": query, "variables": variables or {}}
     for attempt in range(_MAX_RETRIES + 1):
+        _raise_if_api_requests_stopped()
         if attempt:
             time.sleep(2 ** (attempt - 1) + random.uniform(0, 0.5))
         try:
+            _raise_if_api_requests_stopped()
             t0 = time.monotonic()
+            _record_api_attempt("graphql")
             response = requests.post(
                 GITHUB_GRAPHQL_URL,
                 json=payload,
@@ -315,6 +479,8 @@ def make_github_graphql_request(query, variables=None):
                 timeout=_REQUEST_TIMEOUT,
             )
             elapsed_ms = int((time.monotonic() - t0) * 1000)
+            response_headers = getattr(response, "headers", {})
+            _record_rate_limit_headers("graphql", response_headers)
             if response.status_code in _RETRY_STATUSES and attempt < _MAX_RETRIES:
                 logger.debug(
                     "api_call type=graphql status=%d elapsed_ms=%d attempt=%d retrying",
@@ -331,8 +497,35 @@ def make_github_graphql_request(query, variables=None):
                     token_var,
                 )
                 raise GitHubAuthenticationError(token_var=token_var, response=response)
+            error_payload = (
+                _response_json_or_none(response)
+                if response.status_code in {403, 429}
+                else None
+            )
+            rate_limit_error = _rate_limit_error_from_response(
+                response, "graphql", error_payload
+            )
+            if rate_limit_error is not None:
+                _record_rate_limit_headers("graphql", response_headers, exhausted=True)
+                _signal_api_request_stop()
+                logger.warning(
+                    "api_call type=graphql rate_limit_exceeded reset=%s",
+                    rate_limit_error.reset_time,
+                )
+                raise rate_limit_error
             response.raise_for_status()
             resp_json = response.json()
+            rate_limit_error = _rate_limit_error_from_response(
+                response, "graphql", resp_json
+            )
+            if rate_limit_error is not None:
+                _record_rate_limit_headers("graphql", response_headers, exhausted=True)
+                _signal_api_request_stop()
+                logger.warning(
+                    "api_call type=graphql rate_limit_exceeded reset=%s",
+                    rate_limit_error.reset_time,
+                )
+                raise rate_limit_error
             if "errors" in resp_json:
                 errors = resp_json["errors"]
                 summary = _summarize_graphql_errors(errors)
@@ -357,8 +550,6 @@ def make_github_graphql_request(query, variables=None):
                 response.status_code,
                 elapsed_ms,
             )
-            with _api_stats_lock:
-                _api_stats["graphql_calls"] += 1
             return resp_json
         except (
             requests.exceptions.ChunkedEncodingError,

--- a/src/breakfast/cache.py
+++ b/src/breakfast/cache.py
@@ -76,6 +76,61 @@ def graphql_cache_path(org: str, repo_filter: str) -> Path:
     return _CACHE_DIR / f"graphql_{key}.json"
 
 
+def identity_cache_path(token: str) -> Path:
+    """Return the versioned identity cache path for a GitHub token."""
+    key = hashlib.sha256(token.encode()).hexdigest()[:16]
+    return _CACHE_DIR / f"identity_v1_{key}.json"
+
+
+def read_cached_user_login(token: str | None) -> str | None:
+    """Return the cached login associated with *token*, if available."""
+    if not token:
+        return None
+    path = identity_cache_path(token)
+    try:
+        if not path.exists():
+            logger.debug(
+                "cache_miss layer=identity path=%s reason=file_not_found", path
+            )
+            return None
+        data = json.loads(path.read_text())
+        login = data["login"]
+        if not isinstance(login, str) or not login.strip():
+            raise ValueError("cached login is empty or invalid")
+        logger.debug("cache_hit layer=identity path=%s login=%s", path, login)
+        return login
+    except (OSError, json.JSONDecodeError, KeyError, ValueError, TypeError) as exc:
+        logger.warning(
+            "cache_read_error layer=identity path=%s error=%r", path, str(exc)
+        )
+        click.echo(
+            click.style(f"Warning: failed to read identity cache: {exc}", fg="yellow"),
+            err=True,
+        )
+        return None
+
+
+def write_cached_user_login(token: str | None, login: str) -> None:
+    """Persist *login* for *token* without storing the credential itself."""
+    if not token:
+        return
+    try:
+        _CACHE_DIR.mkdir(parents=True, exist_ok=True)
+        path = identity_cache_path(token)
+        _atomic_write_text(path, json.dumps({"login": login}))
+        logger.debug("cache_write layer=identity path=%s login=%s", path, login)
+    except OSError as exc:
+        logger.warning(
+            "cache_write_error layer=identity path=%s error=%r",
+            identity_cache_path(token),
+            str(exc),
+        )
+        click.echo(
+            click.style(f"Warning: failed to write identity cache: {exc}", fg="yellow"),
+            err=True,
+        )
+
+
 def read_graphql_cache(org: str, repo_filter: str, ttl: int) -> list | None:
     """Return cached PR URL list if present and within TTL, else None."""
     path = graphql_cache_path(org, repo_filter)
@@ -316,30 +371,6 @@ def write_repo_pr_cache(
             click.style(f"Warning: failed to write repo PR cache: {exc}", fg="yellow"),
             err=True,
         )
-
-
-def read_cached_user_login() -> str | None:
-    """Return the GitHub login persisted from a previous online run, or None."""
-    path = _CACHE_DIR / "user.json"
-    try:
-        if not path.exists():
-            return None
-        data = json.loads(path.read_text())
-        return data.get("login") or None
-    except (OSError, json.JSONDecodeError, KeyError) as exc:
-        logger.warning("cache_read_error layer=user_login error=%r", str(exc))
-        return None
-
-
-def write_cached_user_login(login: str) -> None:
-    """Persist *login* to the cache directory for offline use."""
-    try:
-        _CACHE_DIR.mkdir(parents=True, exist_ok=True)
-        path = _CACHE_DIR / "user.json"
-        _atomic_write_text(path, json.dumps({"login": login}))
-        logger.debug("cache_write layer=user_login login=%s", login)
-    except OSError as exc:
-        logger.warning("cache_write_error layer=user_login error=%r", str(exc))
 
 
 def write_pr_cache(

--- a/src/breakfast/cli.py
+++ b/src/breakfast/cli.py
@@ -3,8 +3,9 @@ import random
 import re
 import shutil
 import sys
+import threading
 import time
-from concurrent.futures import ThreadPoolExecutor, as_completed
+from concurrent.futures import CancelledError, ThreadPoolExecutor, as_completed
 from datetime import datetime, timezone
 from enum import StrEnum, auto
 from urllib.parse import urlparse
@@ -21,13 +22,15 @@ from .api import (
     OwnerNotFoundError,
     _fetch_pr_detail,
     _match_exclude_repos,
+    clear_api_request_stop_event,
     get_api_stats,
     get_approval_summary,
     get_authenticated_user_login,
     get_check_status,
     get_github_prs,
-    get_graphql_rate_limit,
     get_pr_age_days,
+    reset_api_stats,
+    set_api_request_stop_event,
 )
 from .cache import (
     parse_ttl,
@@ -123,6 +126,85 @@ def format_cache_age(age_seconds: float) -> str:
         return f"{int(age_seconds // 86400)} days ago"
 
 
+def _cache_age_seconds(cache_result: dict) -> float:
+    """Return the non-negative age of a full-cache result in seconds."""
+    fetched_at = datetime.fromisoformat(cache_result["fetched_at"])
+    return max(0, (datetime.now(timezone.utc) - fetched_at).total_seconds())
+
+
+def _rate_limit_api_name(exc: GitHubRateLimitError) -> str:
+    """Return a user-facing API name for a typed rate-limit error."""
+    return "GitHub GraphQL API" if exc.resource == "graphql" else "GitHub REST API"
+
+
+def _emit_rate_limit_cache_banner(
+    exc: GitHubRateLimitError,
+    cache_age_seconds: float,
+    *,
+    refresh_requested: bool,
+    colour: bool,
+) -> None:
+    """Explain that rate limiting forced a local-cache fallback."""
+    refresh_text = "Refresh could not be completed; " if refresh_requested else ""
+    message = (
+        f"🥞 {_rate_limit_api_name(exc)} rate limit exceeded; "
+        f"{refresh_text}displaying local cached data from "
+        f"{format_cache_age(cache_age_seconds)}."
+    )
+    if exc.reset_time:
+        message += f" Live GitHub data should be available after {exc.reset_time} UTC."
+    click.echo(
+        click.style(message, fg="yellow", bold=True),
+        err=True,
+        color=colour,
+    )
+
+
+def _read_degraded_cache(
+    org_cache_key: str,
+    repo_cache_key: str,
+    cache_ttl_seconds: int,
+    *,
+    cache_enabled: bool,
+) -> dict | None:
+    """Return the latest full cache for degraded mode, including expired data."""
+    if not cache_enabled:
+        return None
+    return read_pr_cache(
+        org_cache_key,
+        repo_cache_key,
+        cache_ttl_seconds,
+        ignore_ttl=True,
+    )
+
+
+def _cached_status_maps(
+    pr_details: list,
+    cached_check_statuses: dict | None,
+    cached_approval_statuses: dict | None,
+    cached_approval_details: dict | None,
+    *,
+    checks: bool,
+    approvals: bool,
+) -> tuple[dict, dict, dict]:
+    """Build complete status maps from a coherent full-cache snapshot."""
+    check_statuses = dict(cached_check_statuses or {})
+    approval_statuses = dict(cached_approval_statuses or {})
+    approval_details = dict(cached_approval_details or {})
+
+    for pr_detail in pr_details:
+        pr_id = pr_detail["id"]
+        if checks:
+            check_statuses.setdefault(pr_id, "none")
+        if approvals:
+            approval_statuses.setdefault(pr_id, "pending")
+            approval_details.setdefault(
+                pr_id,
+                {"status": "pending", "current": 0, "required": None},
+            )
+    return check_statuses, approval_statuses, approval_details
+
+
 def _stdout_is_tty():
     return sys.stdout.isatty()
 
@@ -182,10 +264,19 @@ def _require_positive_int(value, key, colour):
     return parsed
 
 
-def _handle_rate_limit(exc, json_output=False):
+def _handle_rate_limit(exc, json_output=False, *, cache_unavailable=False):
     """Print a friendly rate-limit message and exit non-zero."""
+    if cache_unavailable:
+        message = (
+            f"🥞 {_rate_limit_api_name(exc)} rate limit exceeded and no local "
+            "cached data is available."
+        )
+        if exc.reset_time:
+            message += f" Try again after {exc.reset_time} UTC."
+    else:
+        message = f"🥞 {exc}"
     click.echo(
-        click.style(f"🥞 {exc}", fg="red", bold=True),
+        click.style(message, fg="red", bold=True),
         err=True,
     )
     sys.exit(1)
@@ -201,9 +292,15 @@ def _handle_auth_error(exc, colour=None, json_output=False):
     sys.exit(1)
 
 
-def _print_debug_summary(t0, pr_count, api_stats, graphql_rate_limit):
-    from datetime import datetime, timezone
-
+def _print_debug_summary(
+    t0,
+    pr_count,
+    api_stats,
+    *,
+    data_source,
+    cache_age_seconds=None,
+):
+    """Print request counts, captured rate limits, and the rendered data source."""
     elapsed = time.monotonic() - t0
     total_calls = api_stats["rest_calls"] + api_stats["graphql_calls"]
     lines = [
@@ -213,20 +310,34 @@ def _print_debug_summary(t0, pr_count, api_stats, graphql_rate_limit):
         f"  API calls:        {total_calls}"
         f" ({api_stats['rest_calls']} REST + {api_stats['graphql_calls']} GraphQL)",
     ]
-    remaining = api_stats.get("rest_rate_limit_remaining")
-    reset_ts = api_stats.get("rest_rate_limit_reset")
-    if remaining is not None:
-        lines.append(f"  REST rate limit:  {remaining} requests remaining")
-    if reset_ts is not None:
-        reset_dt = datetime.fromtimestamp(reset_ts, tz=timezone.utc)
-        lines.append(f"  REST rate resets: {reset_dt.strftime('%H:%M:%S UTC')}")
-    if graphql_rate_limit:
-        gql_remaining = graphql_rate_limit.get("remaining")
-        gql_reset = graphql_rate_limit.get("resetAt")
-        if gql_remaining is not None:
-            lines.append(f"  GQL rate limit:   {gql_remaining} points remaining")
-        if gql_reset:
-            lines.append(f"  GQL rate resets:  {gql_reset}")
+
+    for resource, label, unit in (
+        ("rest", "REST", "requests"),
+        ("graphql", "GQL", "points"),
+    ):
+        remaining = api_stats.get(f"{resource}_rate_limit_remaining")
+        exhausted = api_stats.get(f"{resource}_rate_limit_exhausted", False)
+        if exhausted:
+            detail = (
+                f" ({remaining} {unit} remaining)"
+                if remaining is not None
+                else " (remaining unavailable)"
+            )
+            lines.append(f"  {label} rate limit:   exhausted{detail}")
+        elif remaining is not None:
+            lines.append(f"  {label} rate limit:   {remaining} {unit} remaining")
+        else:
+            lines.append(f"  {label} rate limit:   not reported this run")
+
+        reset_ts = api_stats.get(f"{resource}_rate_limit_reset")
+        if reset_ts is not None:
+            reset_dt = datetime.fromtimestamp(reset_ts, tz=timezone.utc)
+            lines.append(f"  {label} rate resets:  {reset_dt.strftime('%H:%M:%S UTC')}")
+
+    source_text = data_source
+    if data_source == "local cache" and cache_age_seconds is not None:
+        source_text += f" ({format_cache_age(cache_age_seconds)})"
+    lines.append(f"  Data source:      {source_text}")
     click.echo("\n".join(lines), err=True)
 
 
@@ -238,6 +349,8 @@ def _finish_run(
     show_update_summary,
     api_stats,
     colour,
+    data_source,
+    cache_age_seconds,
     pizza=False,
     cake=False,
 ):
@@ -282,7 +395,11 @@ def _finish_run(
         )
     if api_stats:
         _print_debug_summary(
-            t0_total, pr_count, get_api_stats(), get_graphql_rate_limit()
+            t0_total,
+            pr_count,
+            get_api_stats(),
+            data_source=data_source,
+            cache_age_seconds=cache_age_seconds,
         )
 
 
@@ -988,6 +1105,7 @@ def breakfast(
     cake,
 ):
     t0_total = time.monotonic()
+    reset_api_stats()
     configure_logging()
 
     # This callback body *is* the program — without this guard, `breakfast
@@ -1364,20 +1482,7 @@ def breakfast(
         message = "GH_TOKEN or GITHUB_TOKEN not set in environment - exiting..."
         click.echo(click.style(message, fg="red", bold=True), err=True, color=colour)
         sys.exit(1)
-    current_user_login = None
-    if mine_only or needs_my_review:
-        if not offline:
-            try:
-                current_user_login = get_authenticated_user_login()
-                write_cached_user_login(current_user_login)
-            except GitHubAuthenticationError as exc:
-                _handle_auth_error(exc, colour=colour, json_output=json_output)
-            except GitHubRateLimitError as exc:
-                _handle_rate_limit(exc, json_output)
-            except (requests.exceptions.ConnectionError, requests.exceptions.Timeout):
-                pass
-        else:
-            current_user_login = read_cached_user_login()
+
     t_acquire = time.monotonic()
 
     # Cache key encodes each org with its effective scoped filter for determinism
@@ -1392,10 +1497,16 @@ def breakfast(
     cached_approval_details = None
     needs_cache_write = False
     offline_mode = False
+    data_source = "live GitHub API"
+    cache_age_seconds = None
+    cache_result = None
 
     if offline:
-        cache_result = read_pr_cache(
-            org_cache_key, repo_cache_key, cache_ttl_seconds, ignore_ttl=True
+        cache_result = _read_degraded_cache(
+            org_cache_key,
+            repo_cache_key,
+            cache_ttl_seconds,
+            cache_enabled=True,
         )
         if cache_result is not None:
             pr_details = cache_result["prs"]
@@ -1404,10 +1515,8 @@ def breakfast(
             cached_approval_details = cache_result.get("approval_details")
             offline_mode = True
             no_update_check = True
-            fetched_at = datetime.fromisoformat(cache_result["fetched_at"])
-            cache_age_seconds = (
-                datetime.now(timezone.utc) - fetched_at
-            ).total_seconds()
+            data_source = "local cache"
+            cache_age_seconds = _cache_age_seconds(cache_result)
             formatted_age = format_cache_age(cache_age_seconds)
             click.echo(
                 click.style(
@@ -1437,6 +1546,64 @@ def breakfast(
             cached_check_statuses = cache_result["check_statuses"]
             cached_approval_statuses = cache_result["approval_statuses"]
             cached_approval_details = cache_result.get("approval_details")
+            data_source = "local cache"
+            cache_age_seconds = _cache_age_seconds(cache_result)
+
+    current_user_login = None
+    if mine_only or needs_my_review:
+        if cache_enabled:
+            current_user_login = read_cached_user_login(SECRET_GITHUB_TOKEN)
+        if current_user_login is None and not offline:
+            try:
+                current_user_login = get_authenticated_user_login()
+                if cache_enabled:
+                    write_cached_user_login(SECRET_GITHUB_TOKEN, current_user_login)
+            except GitHubAuthenticationError as exc:
+                _handle_auth_error(exc, colour=colour, json_output=json_output)
+            except GitHubRateLimitError as exc:
+                fallback_result = cache_result or _read_degraded_cache(
+                    org_cache_key,
+                    repo_cache_key,
+                    cache_ttl_seconds,
+                    cache_enabled=cache_enabled,
+                )
+                if fallback_result is None:
+                    _handle_rate_limit(exc, json_output, cache_unavailable=True)
+                cache_result = fallback_result
+                pr_details = fallback_result["prs"]
+                cached_check_statuses = fallback_result["check_statuses"]
+                cached_approval_statuses = fallback_result["approval_statuses"]
+                cached_approval_details = fallback_result.get("approval_details")
+                offline_mode = True
+                no_update_check = True
+                needs_cache_write = False
+                data_source = "local cache"
+                cache_age_seconds = _cache_age_seconds(fallback_result)
+                _emit_rate_limit_cache_banner(
+                    exc,
+                    cache_age_seconds,
+                    refresh_requested=refresh or refresh_prs,
+                    colour=colour,
+                )
+            except (
+                requests.exceptions.ConnectionError,
+                requests.exceptions.Timeout,
+            ):
+                if cache_result is not None:
+                    offline_mode = True
+                    no_update_check = True
+                    data_source = "local cache"
+                    cache_age_seconds = _cache_age_seconds(cache_result)
+                    click.echo(
+                        click.style(
+                            "🔌 Offline Mode: Displaying cached data from "
+                            f"{format_cache_age(cache_age_seconds)}.",
+                            fg="yellow",
+                            bold=True,
+                        ),
+                        err=True,
+                        color=colour,
+                    )
 
     # Resolve implied flags before fetch so bundle knows what to fetch per PR.
     if filter_check:
@@ -1545,7 +1712,11 @@ def breakfast(
 
             if urls_to_fetch:
                 max_workers = min(workers, len(urls_to_fetch))
-                with ThreadPoolExecutor(max_workers=max_workers) as executor:
+                stop_event = threading.Event()
+                set_api_request_stop_event(stop_event)
+                executor = ThreadPoolExecutor(max_workers=max_workers)
+                rate_limit_error = None
+                try:
                     future_to_url = {
                         executor.submit(_fetch_pr_bundle, url, checks, approvals): url
                         for url in urls_to_fetch
@@ -1594,13 +1765,24 @@ def breakfast(
                                 exc, colour=colour, json_output=json_output
                             )
                         except GitHubRateLimitError as exc:
-                            click.echo("", err=True)
-                            _handle_rate_limit(exc, json_output)
+                            rate_limit_error = exc
+                            stop_event.set()
+                            for pending in future_to_url:
+                                pending.cancel()
+                            break
+                        except CancelledError:
+                            continue
                         except requests.exceptions.RequestException as exc:
                             logger.warning(
                                 "pr_detail_fetch_failed url=%s error=%r", url, str(exc)
                             )
                             failed_urls.append(url)
+                finally:
+                    executor.shutdown(wait=True, cancel_futures=stop_event.is_set())
+                    clear_api_request_stop_event(stop_event)
+                if rate_limit_error is not None:
+                    click.echo("", err=True)
+                    raise rate_limit_error
 
             # Write per-repo cache for repos fetched in this run
             if cache_enabled and newly_fetched_by_repo:
@@ -1667,28 +1849,60 @@ def breakfast(
             msg = f"🥞 GitHub couldn't complete the GraphQL request: {exc.summary}"
             click.echo(click.style(msg, fg="red", bold=True), err=True, color=colour)
             sys.exit(1)
+        except GitHubRateLimitError as exc:
+            cache_result = _read_degraded_cache(
+                org_cache_key,
+                repo_cache_key,
+                cache_ttl_seconds,
+                cache_enabled=cache_enabled,
+            )
+            if cache_result is None:
+                _handle_rate_limit(exc, json_output, cache_unavailable=True)
+            pr_details = cache_result["prs"]
+            cached_check_statuses = cache_result["check_statuses"]
+            cached_approval_statuses = cache_result["approval_statuses"]
+            cached_approval_details = cache_result.get("approval_details")
+            check_statuses = {}
+            approval_statuses = {}
+            approval_details = {}
+            statuses_from_bundle = False
+            needs_cache_write = False
+            offline_mode = True
+            no_update_check = True
+            data_source = "local cache"
+            cache_age_seconds = _cache_age_seconds(cache_result)
+            click.echo("", err=True)
+            _emit_rate_limit_cache_banner(
+                exc,
+                cache_age_seconds,
+                refresh_requested=refresh or refresh_prs,
+                colour=colour,
+            )
         except (
             requests.exceptions.ConnectionError,
             requests.exceptions.Timeout,
         ) as exc:
             # Fall back to expired cache
-            cache_result = read_pr_cache(
+            cache_result = _read_degraded_cache(
                 org_cache_key,
                 repo_cache_key,
                 cache_ttl_seconds,
-                ignore_ttl=True,
+                cache_enabled=True,
             )
             if cache_result is not None:
                 pr_details = cache_result["prs"]
                 cached_check_statuses = cache_result["check_statuses"]
                 cached_approval_statuses = cache_result["approval_statuses"]
                 cached_approval_details = cache_result.get("approval_details")
+                check_statuses = {}
+                approval_statuses = {}
+                approval_details = {}
+                statuses_from_bundle = False
                 offline_mode = True
                 no_update_check = True
-                fetched_at = datetime.fromisoformat(cache_result["fetched_at"])
-                cache_age_seconds = (
-                    datetime.now(timezone.utc) - fetched_at
-                ).total_seconds()
+                needs_cache_write = False
+                data_source = "local cache"
+                cache_age_seconds = _cache_age_seconds(cache_result)
                 formatted_age = format_cache_age(cache_age_seconds)
                 # Ensure we end the progress line if we started it
                 click.echo("", err=True)
@@ -1722,102 +1936,170 @@ def breakfast(
             repo_display = ", ".join(repo_filters) if repo_filters else "all repos"
             click.echo(f"Processing {repo_display} PRs...⚡...Done", err=True)
 
-    # Fetch check statuses for cache-hit paths where statuses are absent.
-    # In the live-fetch path statuses are already populated by _fetch_pr_bundle.
-    if checks and pr_details and not statuses_from_bundle:
-        if cached_check_statuses is not None:
-            check_statuses = cached_check_statuses
-            # Ensure all PRs are in check_statuses
-            for pr_detail in pr_details:
-                if pr_detail["id"] not in check_statuses:
-                    check_statuses[pr_detail["id"]] = "none"
-        elif offline_mode:
-            # Skip fetching if offline
-            for pr_detail in pr_details:
-                check_statuses[pr_detail["id"]] = "none"
-        else:
-            max_workers = min(workers, len(pr_details))
-            with ThreadPoolExecutor(max_workers=max_workers) as executor:
-                check_futures = []
-                for pr_detail in pr_details:
-                    owner = pr_detail["base"]["repo"]["owner"]["login"]
-                    repo_name = pr_detail["base"]["repo"]["name"]
-                    sha = pr_detail["head"]["sha"]
-                    future = executor.submit(get_check_status, owner, repo_name, sha)
-                    check_futures.append((pr_detail["id"], future))
-            for pr_id, future in check_futures:
+    try:
+        # Fetch check statuses for cache-hit paths where statuses are absent.
+        if checks and pr_details and not statuses_from_bundle:
+            if cached_check_statuses is not None or offline_mode:
+                check_statuses, _, _ = _cached_status_maps(
+                    pr_details,
+                    cached_check_statuses,
+                    None,
+                    None,
+                    checks=True,
+                    approvals=False,
+                )
+            else:
+                max_workers = min(workers, len(pr_details))
+                stop_event = threading.Event()
+                set_api_request_stop_event(stop_event)
+                executor = ThreadPoolExecutor(max_workers=max_workers)
+                rate_limit_error = None
                 try:
-                    check_statuses[pr_id] = future.result()
-                except (
-                    KeyError,
-                    ValueError,
-                    AttributeError,
-                    requests.exceptions.RequestException,
-                ) as exc:
-                    logger.warning(
-                        "check_status_fetch_failed pr_id=%s error=%r",
-                        pr_id,
-                        str(exc),
-                    )
-                    check_statuses[pr_id] = "none"
-            needs_cache_write = True
+                    future_to_pr_id = {}
+                    for pr_detail in pr_details:
+                        owner = pr_detail["base"]["repo"]["owner"]["login"]
+                        repo_name = pr_detail["base"]["repo"]["name"]
+                        sha = pr_detail["head"]["sha"]
+                        future = executor.submit(
+                            get_check_status, owner, repo_name, sha
+                        )
+                        future_to_pr_id[future] = pr_detail["id"]
 
-    # Fetch approval statuses for cache-hit paths where statuses are absent.
-    # In the live-fetch path statuses are already populated by _fetch_pr_bundle.
-    if approvals and pr_details and not statuses_from_bundle:
-        if cached_approval_statuses is not None and cached_approval_details is not None:
-            approval_statuses = cached_approval_statuses
-            approval_details = cached_approval_details
-            # Ensure all PRs are in approval_statuses and approval_details
-            for pr_detail in pr_details:
-                if pr_detail["id"] not in approval_statuses:
-                    approval_statuses[pr_detail["id"]] = "pending"
-                if pr_detail["id"] not in approval_details:
-                    approval_details[pr_detail["id"]] = {
-                        "status": "pending",
-                        "current": 0,
-                        "required": None,
-                    }
-        elif offline_mode:
-            # Skip fetching if offline
-            for pr_detail in pr_details:
-                approval_statuses[pr_detail["id"]] = "pending"
-                approval_details[pr_detail["id"]] = {
-                    "status": "pending",
-                    "current": 0,
-                    "required": None,
-                }
-        else:
-            max_workers = min(workers, len(pr_details))
-            with ThreadPoolExecutor(max_workers=max_workers) as executor:
-                approval_futures = []
-                for pr_detail in pr_details:
-                    owner = pr_detail["base"]["repo"]["owner"]["login"]
-                    repo_name = pr_detail["base"]["repo"]["name"]
-                    pr_number = pr_detail["number"]
-                    base_branch = pr_detail.get("base", {}).get("ref")
-                    future = executor.submit(
-                        get_approval_summary, owner, repo_name, pr_number, base_branch
-                    )
-                    approval_futures.append((pr_detail["id"], future))
-            for pr_id, future in approval_futures:
+                    for future in as_completed(future_to_pr_id):
+                        pr_id = future_to_pr_id[future]
+                        try:
+                            check_statuses[pr_id] = future.result()
+                        except GitHubRateLimitError as exc:
+                            rate_limit_error = exc
+                            stop_event.set()
+                            for pending in future_to_pr_id:
+                                pending.cancel()
+                            break
+                        except CancelledError:
+                            continue
+                        except (
+                            KeyError,
+                            ValueError,
+                            AttributeError,
+                            requests.exceptions.RequestException,
+                        ) as exc:
+                            logger.warning(
+                                "check_status_fetch_failed pr_id=%s error=%r",
+                                pr_id,
+                                str(exc),
+                            )
+                            check_statuses[pr_id] = "none"
+                finally:
+                    executor.shutdown(wait=True, cancel_futures=stop_event.is_set())
+                    clear_api_request_stop_event(stop_event)
+                if rate_limit_error is not None:
+                    raise rate_limit_error
+                needs_cache_write = True
+
+        # Fetch approval statuses for cache-hit paths where statuses are absent.
+        if approvals and pr_details and not statuses_from_bundle:
+            if (
+                cached_approval_statuses is not None
+                and cached_approval_details is not None
+            ) or offline_mode:
+                _, approval_statuses, approval_details = _cached_status_maps(
+                    pr_details,
+                    None,
+                    cached_approval_statuses,
+                    cached_approval_details,
+                    checks=False,
+                    approvals=True,
+                )
+            else:
+                max_workers = min(workers, len(pr_details))
+                stop_event = threading.Event()
+                set_api_request_stop_event(stop_event)
+                executor = ThreadPoolExecutor(max_workers=max_workers)
+                rate_limit_error = None
                 try:
-                    approval_detail = future.result()
-                    approval_statuses[pr_id] = approval_detail["status"]
-                    approval_details[pr_id] = approval_detail
-                except (ValueError, requests.exceptions.RequestException) as exc:
-                    logger.warning(
-                        "approval_status_fetch_failed pr_id=%s error=%r",
-                        pr_id,
-                        str(exc),
-                    )
-                    approval_statuses[pr_id] = "pending"
-                    approval_details[pr_id] = {
-                        "status": "pending",
-                        "current": 0,
-                        "required": None,
-                    }
-            needs_cache_write = True
+                    future_to_pr_id = {}
+                    for pr_detail in pr_details:
+                        owner = pr_detail["base"]["repo"]["owner"]["login"]
+                        repo_name = pr_detail["base"]["repo"]["name"]
+                        pr_number = pr_detail["number"]
+                        base_branch = pr_detail.get("base", {}).get("ref")
+                        future = executor.submit(
+                            get_approval_summary,
+                            owner,
+                            repo_name,
+                            pr_number,
+                            base_branch,
+                        )
+                        future_to_pr_id[future] = pr_detail["id"]
+
+                    for future in as_completed(future_to_pr_id):
+                        pr_id = future_to_pr_id[future]
+                        try:
+                            approval_detail = future.result()
+                            approval_statuses[pr_id] = approval_detail["status"]
+                            approval_details[pr_id] = approval_detail
+                        except GitHubRateLimitError as exc:
+                            rate_limit_error = exc
+                            stop_event.set()
+                            for pending in future_to_pr_id:
+                                pending.cancel()
+                            break
+                        except CancelledError:
+                            continue
+                        except (
+                            ValueError,
+                            requests.exceptions.RequestException,
+                        ) as exc:
+                            logger.warning(
+                                "approval_status_fetch_failed pr_id=%s error=%r",
+                                pr_id,
+                                str(exc),
+                            )
+                            approval_statuses[pr_id] = "pending"
+                            approval_details[pr_id] = {
+                                "status": "pending",
+                                "current": 0,
+                                "required": None,
+                            }
+                finally:
+                    executor.shutdown(wait=True, cancel_futures=stop_event.is_set())
+                    clear_api_request_stop_event(stop_event)
+                if rate_limit_error is not None:
+                    raise rate_limit_error
+                needs_cache_write = True
+    except GitHubRateLimitError as exc:
+        cache_result = _read_degraded_cache(
+            org_cache_key,
+            repo_cache_key,
+            cache_ttl_seconds,
+            cache_enabled=cache_enabled,
+        )
+        if cache_result is None:
+            _handle_rate_limit(exc, json_output, cache_unavailable=True)
+        pr_details = cache_result["prs"]
+        cached_check_statuses = cache_result["check_statuses"]
+        cached_approval_statuses = cache_result["approval_statuses"]
+        cached_approval_details = cache_result.get("approval_details")
+        check_statuses, approval_statuses, approval_details = _cached_status_maps(
+            pr_details,
+            cached_check_statuses,
+            cached_approval_statuses,
+            cached_approval_details,
+            checks=checks,
+            approvals=approvals,
+        )
+        statuses_from_bundle = False
+        needs_cache_write = False
+        offline_mode = True
+        no_update_check = True
+        data_source = "local cache"
+        cache_age_seconds = _cache_age_seconds(cache_result)
+        _emit_rate_limit_cache_banner(
+            exc,
+            cache_age_seconds,
+            refresh_requested=refresh or refresh_prs,
+            colour=colour,
+        )
 
     logger.info(
         "data_acquired pr_count=%d elapsed_ms=%d",
@@ -1838,11 +2120,18 @@ def breakfast(
             click.echo("🔄 Cache refreshed.", err=True)
 
     if (mine_only or needs_my_review) and offline_mode and current_user_login is None:
+        identity_filters = " and ".join(
+            flag
+            for enabled, flag in (
+                (mine_only, "--mine-only"),
+                (needs_my_review, "--needs-my-review"),
+            )
+            if enabled
+        )
         click.echo(
             click.style(
-                "⚠️  Offline mode: no cached login found — "
-                "--mine-only / --needs-my-review skipped. "
-                "Run online once to cache your login.",
+                f"⚠️  {identity_filters} could not be applied because the current "
+                "user login is not cached; displaying all locally cached PRs.",
                 fg="yellow",
             ),
             err=True,
@@ -1929,6 +2218,8 @@ def breakfast(
             show_update_summary=show_update_summary,
             api_stats=api_stats,
             colour=colour,
+            data_source=data_source,
+            cache_age_seconds=cache_age_seconds,
             pizza=pizza,
             cake=cake,
         )
@@ -2009,6 +2300,8 @@ def breakfast(
         show_update_summary=show_update_summary,
         api_stats=api_stats,
         colour=colour,
+        data_source=data_source,
+        cache_age_seconds=cache_age_seconds,
         pizza=pizza,
         cake=cake,
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,7 @@ from breakfast import api, cache
 def isolate_cache(tmp_path, monkeypatch):
     """Redirect the PR cache to a per-test temp dir so tests don't share cache state."""
     monkeypatch.setattr(cache, "_CACHE_DIR", tmp_path / "breakfast_cache")
+    api.reset_api_stats()
     api.get_required_approving_review_count.cache_clear()
 
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,3 +1,6 @@
+import threading
+from concurrent.futures import CancelledError
+
 import pytest
 import requests
 
@@ -30,6 +33,7 @@ def test_make_github_api_request_retries_on_connection_error(monkeypatch):
 
     assert result == {"ok": True}
     assert len(attempts) == 3
+    assert api.get_api_stats()["rest_calls"] == 3
 
 
 def test_make_github_api_request_raises_after_max_retries_connection_error(monkeypatch):
@@ -1240,36 +1244,41 @@ def test_match_repo_filter_glob_no_partial_match():
 # ---------------------------------------------------------------------------
 
 
-def _make_rate_limit_response(reset_ts="1712000000"):
-    """Return a fake requests.Response that looks like a GitHub rate-limit 403."""
-
-    class FakeResponse:
-        status_code = 403
-        headers = {
-            "X-RateLimit-Remaining": "0",
-            "X-RateLimit-Reset": reset_ts,
-        }
-
-        def raise_for_status(self):
-            raise requests.exceptions.HTTPError(response=self)
-
-    return FakeResponse()
-
-
-def test_make_github_api_request_raises_rate_limit_error(monkeypatch):
+def test_make_github_api_request_raises_rate_limit_error(monkeypatch, requests_mock):
     monkeypatch.setattr(api, "SECRET_GITHUB_TOKEN", "token-123")
-    monkeypatch.setattr(
-        api.requests, "get", lambda *_a, **_kw: _make_rate_limit_response()
+    requests_mock.get(
+        f"{api.GITHUB_API_URL}/user",
+        status_code=403,
+        headers={
+            "X-RateLimit-Remaining": "0",
+            "X-RateLimit-Reset": "1712000000",
+        },
+        json={"message": "API rate limit exceeded"},
     )
 
-    with pytest.raises(api.GitHubRateLimitError):
+    with pytest.raises(api.GitHubRateLimitError) as exc_info:
         api.make_github_api_request("/user")
 
+    assert exc_info.value.resource == "rest"
+    assert exc_info.value.remaining == 0
+    stats = api.get_api_stats()
+    assert stats["rest_calls"] == 1
+    assert stats["rest_rate_limit_remaining"] == 0
+    assert stats["rest_rate_limit_exhausted"] is True
 
-def test_make_github_api_request_rate_limit_error_contains_reset_time(monkeypatch):
+
+def test_make_github_api_request_rate_limit_error_contains_reset_time(
+    monkeypatch, requests_mock
+):
     monkeypatch.setattr(api, "SECRET_GITHUB_TOKEN", "token-123")
-    monkeypatch.setattr(
-        api.requests, "get", lambda *_a, **_kw: _make_rate_limit_response("1712000000")
+    requests_mock.get(
+        f"{api.GITHUB_API_URL}/user",
+        status_code=403,
+        headers={
+            "X-RateLimit-Remaining": "0",
+            "X-RateLimit-Reset": "1712000000",
+        },
+        json={"message": "API rate limit exceeded"},
     )
 
     with pytest.raises(api.GitHubRateLimitError) as exc_info:
@@ -1280,19 +1289,15 @@ def test_make_github_api_request_rate_limit_error_contains_reset_time(monkeypatc
 
 
 def test_make_github_api_request_403_without_rate_limit_header_raises_http_error(
-    monkeypatch,
+    monkeypatch, requests_mock
 ):
     """A plain 403 (auth failure) should raise HTTPError, not GitHubRateLimitError."""
-
-    class FakeForbidden:
-        status_code = 403
-        headers = {}  # no X-RateLimit-Remaining header
-
-        def raise_for_status(self):
-            raise requests.exceptions.HTTPError(response=self)
-
     monkeypatch.setattr(api, "SECRET_GITHUB_TOKEN", "token-123")
-    monkeypatch.setattr(api.requests, "get", lambda *_a, **_kw: FakeForbidden())
+    requests_mock.get(
+        f"{api.GITHUB_API_URL}/user",
+        status_code=403,
+        json={"message": "Resource not accessible by token"},
+    )
 
     with pytest.raises(requests.exceptions.HTTPError):
         api.make_github_api_request("/user")
@@ -1386,6 +1391,127 @@ def test_github_auth_error_message_identifies_token_variable():
 
     err2 = api.GitHubAuthenticationError(token_var="GITHUB_TOKEN")
     assert "GITHUB_TOKEN was rejected" in str(err2)
+
+
+def test_make_github_api_request_accepts_last_successful_request(
+    monkeypatch, requests_mock
+):
+    """A successful response that consumes the last request remains usable."""
+    monkeypatch.setattr(api, "SECRET_GITHUB_TOKEN", "token-123")
+    requests_mock.get(
+        f"{api.GITHUB_API_URL}/user",
+        status_code=200,
+        headers={"X-RateLimit-Remaining": "0"},
+        json={"login": "alice"},
+    )
+
+    result = api.make_github_api_request("/user")
+
+    assert result == {"login": "alice"}
+    stats = api.get_api_stats()
+    assert stats["rest_calls"] == 1
+    assert stats["rest_rate_limit_remaining"] == 0
+    assert stats["rest_rate_limit_exhausted"] is True
+
+
+def test_make_github_api_request_detects_secondary_rate_limit(
+    monkeypatch, requests_mock
+):
+    """A Retry-After 429 is typed as secondary rate-limit exhaustion."""
+    monkeypatch.setattr(api, "SECRET_GITHUB_TOKEN", "token-123")
+    requests_mock.get(
+        f"{api.GITHUB_API_URL}/user",
+        status_code=429,
+        headers={"Retry-After": "60"},
+        json={"message": "You have exceeded a secondary rate limit."},
+    )
+
+    with pytest.raises(api.GitHubRateLimitError) as exc_info:
+        api.make_github_api_request("/user")
+
+    assert exc_info.value.retry_after == "60"
+    assert exc_info.value.reset_time is not None
+    assert api.get_api_stats()["rest_rate_limit_exhausted"] is True
+
+
+def test_make_github_graphql_request_detects_rate_limit_error(
+    monkeypatch, requests_mock
+):
+    """GraphQL RATE_LIMITED responses preserve reset metadata and stats."""
+    monkeypatch.setattr(api, "SECRET_GITHUB_TOKEN", "token-123")
+    requests_mock.post(
+        api.GITHUB_GRAPHQL_URL,
+        status_code=200,
+        headers={
+            "X-RateLimit-Remaining": "0",
+            "X-RateLimit-Reset": "1712000000",
+        },
+        json={
+            "data": None,
+            "errors": [{"type": "RATE_LIMITED", "message": "rate limit"}],
+        },
+    )
+
+    with pytest.raises(api.GitHubRateLimitError) as exc_info:
+        api.make_github_graphql_request("{ viewer { login } }")
+
+    assert exc_info.value.resource == "graphql"
+    assert exc_info.value.remaining == 0
+    stats = api.get_api_stats()
+    assert stats["graphql_calls"] == 1
+    assert stats["graphql_rate_limit_remaining"] == 0
+    assert stats["graphql_rate_limit_exhausted"] is True
+
+
+def test_make_github_graphql_request_plain_403_is_not_rate_limit(
+    monkeypatch, requests_mock
+):
+    """GraphQL authorization failures remain ordinary HTTP errors."""
+    monkeypatch.setattr(api, "SECRET_GITHUB_TOKEN", "token-123")
+    requests_mock.post(
+        api.GITHUB_GRAPHQL_URL,
+        status_code=403,
+        json={"message": "Resource not accessible by token"},
+    )
+
+    with pytest.raises(requests.exceptions.HTTPError):
+        api.make_github_graphql_request("{ viewer { login } }")
+
+
+def test_make_github_graphql_request_accepts_last_successful_request(
+    monkeypatch, requests_mock
+):
+    """GraphQL data remains valid when the response leaves zero points."""
+    monkeypatch.setattr(api, "SECRET_GITHUB_TOKEN", "token-123")
+    requests_mock.post(
+        api.GITHUB_GRAPHQL_URL,
+        status_code=200,
+        headers={"X-RateLimit-Remaining": "0"},
+        json={"data": {"viewer": {"login": "alice"}}},
+    )
+
+    result = api.make_github_graphql_request("{ viewer { login } }")
+
+    assert result == {"data": {"viewer": {"login": "alice"}}}
+    stats = api.get_api_stats()
+    assert stats["graphql_calls"] == 1
+    assert stats["graphql_rate_limit_remaining"] == 0
+    assert stats["graphql_rate_limit_exhausted"] is True
+
+
+def test_request_stop_event_prevents_another_http_attempt(requests_mock):
+    """A stopped concurrent pool aborts before issuing another request."""
+    stop_event = threading.Event()
+    stop_event.set()
+    api.set_api_request_stop_event(stop_event)
+    matcher = requests_mock.get(f"{api.GITHUB_API_URL}/user", json={"login": "alice"})
+
+    try:
+        with pytest.raises(CancelledError):
+            api.make_github_api_request("/user")
+    finally:
+        api.clear_api_request_stop_event(stop_event)
+    assert matcher.call_count == 0
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -99,6 +99,54 @@ def test_make_cache_key_differs_by_input():
 
 
 # ---------------------------------------------------------------------------
+# cached identity
+# ---------------------------------------------------------------------------
+
+
+def test_cached_user_login_roundtrip(monkeypatch, tmp_path):
+    monkeypatch.setattr(cache, "_CACHE_DIR", tmp_path)
+
+    cache.write_cached_user_login("token-one", "alice")
+
+    assert cache.read_cached_user_login("token-one") == "alice"
+    payload = json.loads(cache.identity_cache_path("token-one").read_text())
+    assert payload == {"login": "alice"}
+    assert "token-one" not in cache.identity_cache_path("token-one").name
+
+
+def test_cached_user_login_is_scoped_by_token(monkeypatch, tmp_path):
+    monkeypatch.setattr(cache, "_CACHE_DIR", tmp_path)
+
+    cache.write_cached_user_login("token-one", "alice")
+    cache.write_cached_user_login("token-two", "bob")
+
+    assert cache.read_cached_user_login("token-one") == "alice"
+    assert cache.read_cached_user_login("token-two") == "bob"
+    assert cache.identity_cache_path("token-one") != cache.identity_cache_path(
+        "token-two"
+    )
+
+
+def test_read_cached_user_login_corrupt_warns_to_stderr(monkeypatch, tmp_path):
+    monkeypatch.setattr(cache, "_CACHE_DIR", tmp_path)
+    path = cache.identity_cache_path("token-one")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("}{ bad json")
+    echo_calls = []
+    monkeypatch.setattr(
+        cache.click,
+        "echo",
+        lambda message, **kwargs: echo_calls.append((message, kwargs)),
+    )
+    monkeypatch.setattr(cache.click, "style", lambda message, **_kwargs: message)
+
+    assert cache.read_cached_user_login("token-one") is None
+    assert len(echo_calls) == 1
+    assert "identity cache" in echo_calls[0][0]
+    assert echo_calls[0][1]["err"] is True
+
+
+# ---------------------------------------------------------------------------
 # read_pr_cache / write_pr_cache
 # ---------------------------------------------------------------------------
 
@@ -451,32 +499,3 @@ def test_read_pr_cache_expired_but_ignored(monkeypatch, tmp_path):
     assert result is not None
     assert result["prs"] == pr_details
     assert result["fetched_at"] == old_time
-
-
-# ---------------------------------------------------------------------------
-# user login cache (#334)
-# ---------------------------------------------------------------------------
-
-
-def test_write_and_read_cached_user_login(monkeypatch, tmp_path):
-    monkeypatch.setattr(cache, "_CACHE_DIR", tmp_path)
-    cache.write_cached_user_login("alice")
-    assert cache.read_cached_user_login() == "alice"
-
-
-def test_read_cached_user_login_returns_none_when_missing(monkeypatch, tmp_path):
-    monkeypatch.setattr(cache, "_CACHE_DIR", tmp_path)
-    assert cache.read_cached_user_login() is None
-
-
-def test_read_cached_user_login_returns_none_on_corrupt_file(monkeypatch, tmp_path):
-    monkeypatch.setattr(cache, "_CACHE_DIR", tmp_path)
-    (tmp_path / "user.json").write_text("not json{{")
-    assert cache.read_cached_user_login() is None
-
-
-def test_write_cached_user_login_overwrites(monkeypatch, tmp_path):
-    monkeypatch.setattr(cache, "_CACHE_DIR", tmp_path)
-    cache.write_cached_user_login("alice")
-    cache.write_cached_user_login("bob")
-    assert cache.read_cached_user_login() == "bob"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -16,14 +16,21 @@ from breakfast import api, cache, cli, renderers, ui
 
 @pytest.fixture(autouse=True)
 def stub_review_decision(monkeypatch):
-    monkeypatch.setattr(
-        api,
-        "make_github_graphql_request",
-        lambda query, variables: {
+    real_graphql_request = api.make_github_graphql_request
+
+    def graphql_request(query, variables=None):
+        if "reviewDecision" not in query:
+            return real_graphql_request(query, variables)
+        return {
             "data": {
                 "repository": {"pullRequest": {"reviewDecision": "REVIEW_REQUIRED"}}
             }
-        },
+        }
+
+    monkeypatch.setattr(
+        api,
+        "make_github_graphql_request",
+        graphql_request,
     )
 
 
@@ -543,16 +550,18 @@ def test_cli_mine_only_filters_to_authenticated_user(monkeypatch):
     assert "Bob PR" not in result.stdout
 
 
-def test_cli_mine_only_exits_cleanly_on_rate_limit(monkeypatch):
-    from breakfast.api import GitHubRateLimitError
-
+def test_cli_mine_only_exits_cleanly_on_rate_limit(monkeypatch, requests_mock):
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
     monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
-    monkeypatch.setattr(
-        cli,
-        "get_authenticated_user_login",
-        lambda: (_ for _ in ()).throw(GitHubRateLimitError("2026-04-10 16:04:48")),
+    requests_mock.get(
+        f"{api.GITHUB_API_URL}/user",
+        status_code=403,
+        headers={
+            "X-RateLimit-Remaining": "0",
+            "X-RateLimit-Reset": "1783941577",
+        },
+        json={"message": "API rate limit exceeded"},
     )
 
     runner = CliRunner()
@@ -560,7 +569,7 @@ def test_cli_mine_only_exits_cleanly_on_rate_limit(monkeypatch):
 
     assert result.exit_code == 1
     assert "rate limit" in result.stderr.lower()
-    assert "2026-04-10 16:04:48" in result.stderr
+    assert "2026-07-13 11:19:37" in result.stderr
 
 
 def test_cli_mine_only_exits_cleanly_on_auth_error(monkeypatch):
@@ -1872,6 +1881,25 @@ def _make_pr_detail(number=1, repo="repo"):
     }
 
 
+def _graphql_pr_urls_response(*urls):
+    """Return a repository-owner GraphQL response containing *urls*."""
+    return {
+        "data": {
+            "repositoryOwner": {
+                "repositories": {
+                    "nodes": [
+                        {
+                            "name": "repo",
+                            "pullRequests": {"nodes": [{"url": url} for url in urls]},
+                        }
+                    ],
+                    "pageInfo": {"endCursor": None, "hasNextPage": False},
+                }
+            }
+        }
+    }
+
+
 def test_cache_hit_skips_get_github_prs(monkeypatch, tmp_path):
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
@@ -1892,6 +1920,287 @@ def test_cache_hit_skips_get_github_prs(monkeypatch, tmp_path):
     assert result.exit_code == 0
     assert len(api_called) == 0, "get_github_prs should not be called on a cache hit"
     assert "PR number 1" in result.stdout
+
+
+def test_cache_hit_with_cached_login_makes_no_api_calls(
+    monkeypatch, tmp_path, requests_mock
+):
+    """A complete cache hit applies --mine-only without resolving /user."""
+    monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
+    monkeypatch.setattr(cache, "_CACHE_DIR", tmp_path)
+
+    alice_pr = _make_pr_detail(1)
+    bob_pr = _make_pr_detail(2)
+    bob_pr["user"]["login"] = "bob"
+    bob_pr["title"] = "Bob PR"
+    cache.write_pr_cache("org", "repo", [alice_pr, bob_pr])
+    cache.write_cached_user_login("token-123", "alice")
+
+    result = CliRunner().invoke(
+        cli.breakfast,
+        ["-o", "org", "-r", "repo", "--cache", "--mine-only", "--api-stats"],
+    )
+
+    assert result.exit_code == 0
+    assert "PR number 1" in result.stdout
+    assert "Bob PR" not in result.stdout
+    assert "API calls:        0 (0 REST + 0 GraphQL)" in result.stderr
+    assert "REST rate limit:   not reported this run" in result.stderr
+    assert "GQL rate limit:   not reported this run" in result.stderr
+    assert "Data source:      local cache" in result.stderr
+    assert requests_mock.call_count == 0
+
+
+def test_mine_only_rate_limit_falls_back_to_expired_cache(
+    monkeypatch, tmp_path, requests_mock
+):
+    """Rate limiting during identity lookup serves the latest full cache."""
+    monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
+    monkeypatch.setattr(cache, "_CACHE_DIR", tmp_path)
+    cache.write_pr_cache("org", "repo", [_make_pr_detail(1)])
+    path = cache.cache_path("org", "repo")
+    payload = json.loads(path.read_text())
+    payload["fetched_at"] = (
+        datetime.now(timezone.utc) - timedelta(hours=2)
+    ).isoformat()
+    path.write_text(json.dumps(payload))
+    requests_mock.get(
+        f"{api.GITHUB_API_URL}/user",
+        status_code=403,
+        headers={
+            "X-RateLimit-Remaining": "0",
+            "X-RateLimit-Reset": "1783941577",
+        },
+        json={"message": "API rate limit exceeded"},
+    )
+
+    result = CliRunner().invoke(
+        cli.breakfast,
+        [
+            "-o",
+            "org",
+            "-r",
+            "repo",
+            "--cache",
+            "--mine-only",
+            "--json",
+            "--api-stats",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert json.loads(result.stdout)[0]["pr_number"] == 1
+    assert "GitHub REST API rate limit exceeded" in result.stderr
+    assert "displaying local cached data from 2 hours ago" in result.stderr
+    assert "2026-07-13 11:19:37 UTC" in result.stderr
+    assert "--mine-only could not be applied" in result.stderr
+    assert "REST rate limit:   exhausted (0 requests remaining)" in result.stderr
+    assert "REST rate resets:  11:19:37 UTC" in result.stderr
+    assert "Data source:      local cache (2 hours ago)" in result.stderr
+    assert requests_mock.call_count == 1
+
+
+def test_mine_only_rate_limit_without_cache_exits_cleanly(
+    monkeypatch, tmp_path, requests_mock
+):
+    """Rate limiting with no full cache leaves stdout empty and exits non-zero."""
+    monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
+    monkeypatch.setattr(cache, "_CACHE_DIR", tmp_path)
+    requests_mock.get(
+        f"{api.GITHUB_API_URL}/user",
+        status_code=403,
+        headers={
+            "X-RateLimit-Remaining": "0",
+            "X-RateLimit-Reset": "1783941577",
+        },
+        json={"message": "API rate limit exceeded"},
+    )
+
+    result = CliRunner().invoke(
+        cli.breakfast,
+        ["-o", "org", "-r", "repo", "--cache", "--mine-only", "--json"],
+    )
+
+    assert result.exit_code == 1
+    assert result.stdout == ""
+    assert "no local cached data is available" in result.stderr
+    assert "2026-07-13 11:19:37 UTC" in result.stderr
+
+
+def test_no_cache_override_does_not_use_existing_cache(
+    monkeypatch, tmp_path, requests_mock
+):
+    """Explicit --no-cache keeps rate-limit failure from reading stale data."""
+    monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
+    monkeypatch.setattr(cache, "_CACHE_DIR", tmp_path)
+    cache.write_pr_cache("org", "repo", [_make_pr_detail(1)])
+    cache.write_cached_user_login("token-123", "alice")
+    requests_mock.get(
+        f"{api.GITHUB_API_URL}/user",
+        status_code=403,
+        headers={
+            "X-RateLimit-Remaining": "0",
+            "X-RateLimit-Reset": "1783941577",
+        },
+        json={"message": "API rate limit exceeded"},
+    )
+
+    result = CliRunner().invoke(
+        cli.breakfast,
+        ["-o", "org", "-r", "repo", "--no-cache", "--mine-only", "--json"],
+    )
+
+    assert result.exit_code == 1
+    assert result.stdout == ""
+    assert "no local cached data is available" in result.stderr
+    assert requests_mock.call_count == 1
+
+
+@pytest.mark.parametrize("refresh_flag", ["--refresh", "--refresh-prs"])
+def test_rate_limit_refresh_falls_back_with_distinct_banner(
+    monkeypatch, tmp_path, requests_mock, refresh_flag
+):
+    """Refresh flags degrade to expired cache while clearly reporting failure."""
+    monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
+    monkeypatch.setattr(cache, "_CACHE_DIR", tmp_path)
+    cache.write_pr_cache("org", "repo", [_make_pr_detail(1)])
+    requests_mock.post(
+        api.GITHUB_GRAPHQL_URL,
+        status_code=200,
+        headers={
+            "X-RateLimit-Remaining": "0",
+            "X-RateLimit-Reset": "1783941577",
+        },
+        json={
+            "data": None,
+            "errors": [{"type": "RATE_LIMITED", "message": "rate limit"}],
+        },
+    )
+
+    result = CliRunner().invoke(
+        cli.breakfast,
+        ["-o", "org", "-r", "repo", "--cache", refresh_flag, "--api-stats"],
+    )
+
+    assert result.exit_code == 0
+    assert "PR number 1" in result.stdout
+    assert "GitHub GraphQL API rate limit exceeded" in result.stderr
+    assert "Refresh could not be completed" in result.stderr
+    assert "Cache refreshed" not in result.stderr
+    assert "GQL rate limit:   exhausted (0 points remaining)" in result.stderr
+    assert requests_mock.call_count == 1
+
+
+def test_rate_limit_does_not_overwrite_cache_with_partial_results(
+    monkeypatch, tmp_path, requests_mock
+):
+    """A worker rate limit discards live partial results and preserves the snapshot."""
+    monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
+    monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
+    monkeypatch.setattr(cache, "_CACHE_DIR", tmp_path)
+    cache.write_pr_cache("org", "repo", [_make_pr_detail(1)])
+    original_payload = cache.cache_path("org", "repo").read_text()
+    requests_mock.post(
+        api.GITHUB_GRAPHQL_URL,
+        json=_graphql_pr_urls_response(
+            "https://github.com/org/repo/pull/10",
+            "https://github.com/org/repo/pull/11",
+        ),
+    )
+    requests_mock.get(
+        f"{api.GITHUB_API_URL}/repos/org/repo/pulls/10",
+        json=_make_pr_detail(10),
+    )
+    requests_mock.get(
+        f"{api.GITHUB_API_URL}/repos/org/repo/pulls/11",
+        status_code=403,
+        headers={
+            "X-RateLimit-Remaining": "0",
+            "X-RateLimit-Reset": "1783941577",
+        },
+        json={"message": "API rate limit exceeded"},
+    )
+
+    result = CliRunner().invoke(
+        cli.breakfast,
+        [
+            "-o",
+            "org",
+            "-r",
+            "repo",
+            "--cache",
+            "--refresh",
+            "--workers",
+            "1",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert "PR number 1" in result.stdout
+    assert "PR number 10" not in result.stdout
+    assert cache.cache_path("org", "repo").read_text() == original_payload
+
+
+def test_check_enrichment_rate_limit_restores_cached_statuses(
+    monkeypatch, tmp_path, requests_mock
+):
+    """Rate limiting during cache enrichment returns coherent cached defaults."""
+    monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
+    monkeypatch.setattr(cache, "_CACHE_DIR", tmp_path)
+    cache.write_pr_cache("org", "repo", [_make_pr_detail(1)])
+    requests_mock.get(
+        f"{api.GITHUB_API_URL}/repos/org/repo/commits/abc123/check-runs",
+        status_code=403,
+        headers={
+            "X-RateLimit-Remaining": "0",
+            "X-RateLimit-Reset": "1783941577",
+        },
+        json={"message": "API rate limit exceeded"},
+    )
+
+    result = CliRunner().invoke(
+        cli.breakfast,
+        ["-o", "org", "-r", "repo", "--cache", "--checks"],
+    )
+
+    assert result.exit_code == 0
+    assert "PR number 1" in result.stdout
+    assert "GitHub REST API rate limit exceeded" in result.stderr
+
+
+def test_approval_enrichment_rate_limit_restores_cached_statuses(
+    monkeypatch, tmp_path, requests_mock
+):
+    """Approval enrichment exhaustion restores coherent cached defaults."""
+    monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
+    monkeypatch.setattr(cache, "_CACHE_DIR", tmp_path)
+    cache.write_pr_cache("org", "repo", [_make_pr_detail(1)])
+    requests_mock.get(
+        f"{api.GITHUB_API_URL}/repos/org/repo/pulls/1/reviews",
+        status_code=403,
+        headers={
+            "X-RateLimit-Remaining": "0",
+            "X-RateLimit-Reset": "1783941577",
+        },
+        json={"message": "API rate limit exceeded"},
+    )
+
+    result = CliRunner().invoke(
+        cli.breakfast,
+        ["-o", "org", "-r", "repo", "--cache", "--approvals"],
+    )
+
+    assert result.exit_code == 0
+    assert "PR number 1" in result.stdout
+    assert "GitHub REST API rate limit exceeded" in result.stderr
 
 
 def test_no_cache_flag_always_fetches(monkeypatch, tmp_path):
@@ -2669,14 +2978,10 @@ def test_debug_flag_prints_summary_to_stderr(monkeypatch):
             "graphql_calls": 2,
             "rest_rate_limit_remaining": 4990,
             "rest_rate_limit_reset": 1700000000,
-        },
-    )
-    monkeypatch.setattr(
-        cli,
-        "get_graphql_rate_limit",
-        lambda: {
-            "remaining": 4998,
-            "resetAt": "2026-04-11T10:30:00Z",
+            "rest_rate_limit_exhausted": False,
+            "graphql_rate_limit_remaining": 4998,
+            "graphql_rate_limit_reset": 1700000000,
+            "graphql_rate_limit_exhausted": False,
         },
     )
 
@@ -2712,6 +3017,7 @@ def test_debug_flag_prints_summary_to_stderr(monkeypatch):
     assert "12 (10 REST + 2 GraphQL)" in result.stderr
     assert "4990 requests remaining" in result.stderr
     assert "4998 points remaining" in result.stderr
+    assert "Data source:      live GitHub API" in result.stderr
     # Normal table output is still present on stdout
     assert "PR-1" in result.stdout
 
@@ -4597,74 +4903,11 @@ def test_cli_offline_mode_mine_only_no_cached_login_warns(monkeypatch, tmp_path)
 
     assert result.exit_code == 0
     assert "PR number 1" in result.stdout
-    assert "no cached login found" in result.stderr
-    assert "--mine-only / --needs-my-review skipped" in result.stderr
-
-
-def test_cli_mine_only_online_persists_login(monkeypatch, tmp_path):
-    monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
-    monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
-    monkeypatch.setattr(cache, "_CACHE_DIR", tmp_path)
-    monkeypatch.setattr(cli, "write_cached_user_login", cache.write_cached_user_login)
-    monkeypatch.setattr(cli, "get_authenticated_user_login", lambda: "alice")
-
-    def fake_get_prs(_org, _repo_filter, _state="open"):
-        return ["https://github.com/org/repo/pull/1"]
-
-    def fake_api_request(path):
-        return {
-            "base": {"repo": {"name": "repo", "owner": {"login": "org"}}},
-            "head": {"sha": "abc123"},
-            "mergeable": True,
-            "mergeable_state": "clean",
-            "additions": 1,
-            "deletions": 0,
-            "title": "Alice PR",
-            "user": {"login": "alice"},
-            "state": "open",
-            "changed_files": 1,
-            "commits": 1,
-            "review_comments": 0,
-            "created_at": "2026-01-10T00:00:00Z",
-            "html_url": "https://github.com/org/repo/pull/1",
-            "number": 1,
-            "id": 1001,
-            "labels": [],
-            "requested_reviewers": [],
-            "draft": False,
-        }
-
-    monkeypatch.setattr(cli, "get_github_prs", fake_get_prs)
-    monkeypatch.setattr(api, "make_github_api_request", fake_api_request)
-
-    runner = CliRunner()
-    result = runner.invoke(cli.breakfast, ["-o", "org", "-r", "repo", "--mine-only"])
-
-    assert result.exit_code == 0
-    assert cache.read_cached_user_login() == "alice"
-
-
-def test_cli_offline_mine_only_with_cached_login_filters(monkeypatch, tmp_path):
-    monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
-    monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
-    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
-    monkeypatch.setattr(cache, "_CACHE_DIR", tmp_path)
-    monkeypatch.setattr(cli, "read_pr_cache", cache.read_pr_cache)
-    monkeypatch.setattr(cli, "write_pr_cache", cache.write_pr_cache)
-    monkeypatch.setattr(cli, "read_cached_user_login", cache.read_cached_user_login)
-
-    cache.write_cached_user_login("alice")
-
-    alice_pr = _make_pr_detail(1)  # default author is alice
-    bob_pr = {**_make_pr_detail(2), "user": {"login": "bob"}}
-    cache.write_pr_cache("org", "repo", [alice_pr, bob_pr])
-
-    runner = CliRunner()
-    result = runner.invoke(
-        cli.breakfast,
-        ["-o", "org", "-r", "repo", "--offline", "--mine-only"],
+    expected_msg = (
+        "--mine-only could not be applied because the current user login is not "
+        "cached; displaying all locally cached PRs."
     )
+    assert expected_msg in result.stderr
 
     assert result.exit_code == 0
     assert "PR number 1" in result.stdout


### PR DESCRIPTION
## Issue

Closes #392

## Description

Rate-limited runs now fall back to the latest coherent full PR cache instead of exiting when caching is enabled. Complete cache hits happen before avoidable GitHub requests, and token-specific cached identity data keeps `--mine-only` and `--needs-my-review` correct without another `/user` call.

REST and GraphQL primary/secondary exhaustion are normalized into one typed error carrying resource, remaining, reset, and retry metadata. Concurrent workers stop before further HTTP attempts, partial live collections are discarded, and debug statistics describe the exhausted limit and local-cache source without making a diagnostic request.

## Changes

- Read the full cache and token-specific identity cache before avoidable API work.
- Fall back to expired full-cache snapshots for rate limits during identity lookup, GraphQL acquisition, REST PR workers, checks, and approvals.
- Cancel queued work, stop subsequent HTTP attempts, and prevent partial cache writes after exhaustion.
- Preserve `--no-cache` semantics and give `--refresh` / `--refresh-prs` a distinct incomplete-refresh warning.
- Count attempted REST/GraphQL requests and report exhausted limits, reset times, and cache provenance in `--api-stats`.
- Add `requests-mock` coverage for REST/GraphQL exhaustion, normal authorization failures, last-successful zero-remaining responses, cancellation, fallback, stdout/stderr discipline, and cache integrity.
- Document cache-first identity, degraded fallback, refresh behavior, and debug output.

## Testing

- [x] `make test` — 526 passed
- [x] `make lint`
- [x] `make format`
- [x] `make build`
- [x] Packaged CLI live/cache/no-cache smoke tests using an isolated XDG cache
- [x] Packaged `--mine-only --cache --api-stats` repeat run: 0 API attempts, local-cache data source
- [x] Simulated exhausted REST and GraphQL paths with `requests-mock`

## Notes

- A cached fallback exits successfully only when a matching coherent full cache exists; otherwise the command exits non-zero with empty data output and an actionable reset-time message.
- `--api-stats` counters now represent attempted HTTP requests, including retries and rate-limited responses.
- Cross-family independent review used Claude Opus. It identified and prompted a regression fix so a successful response that consumes the last remaining request/point is still accepted while stats mark the resource exhausted.

🤖 Prepared by Codex
