### PR TITLE
#394: Exclude drafts from open state filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ breakfast --completion bash
 - `--no-drafts`: Hide draft PRs.
 - `--drafts-only`: Show only draft PRs.
 - `--fetch-state`: Which PR states to fetch from GitHub: `open` (default), `closed`, `merged`, `all`.
-- `--filter-state`: Only show PRs with this state (`open`, `closed`, `draft`). Repeatable.
+- `--filter-state`: Only show PRs with this state (`open` excludes drafts; `closed` includes all closed PRs; `draft` selects drafts). Repeatable with OR logic.
 - `--filter-check`: Only show PRs with this CI result (`pass`, `fail`, `pending`, `none`). Repeatable. Implies `--checks`.
 - `--filter-approval`: Only show PRs with this review status (`approved`, `pending`, `changes`). Repeatable.
 - `--filter-mergeable`: Only show PRs with this mergeable status (`clean`, `conflict`, `unknown`). Repeatable — OR logic.

--- a/docs/manual/options.md
+++ b/docs/manual/options.md
@@ -149,12 +149,16 @@ Config key: `fetch-state = "open"`
 
 Only show PRs with a specific state. Accepted values: `open`, `closed`, `draft`. Repeat the flag to match multiple states.
 
-`draft` matches PRs where `draft=true`. It can be combined with other states:
+`open` matches PRs that are open and ready for review, excluding drafts. `closed`
+matches all closed PRs, including PRs closed while still drafts. `draft` matches
+PRs where `draft=true`. Values use OR logic, so combine `open` and `draft` when
+you want all open work:
 
 ```bash
-breakfast -o my-org -r my-app --filter-state open                        # open PRs only (includes drafts)
-breakfast -o my-org -r my-app --filter-state draft                       # only draft PRs
-breakfast -o my-org -r my-app --filter-state closed --filter-state draft # closed or draft
+breakfast -o my-org -r my-app --filter-state open                       # ready, open PRs only
+breakfast -o my-org -r my-app --filter-state draft                      # only draft PRs
+breakfast -o my-org -r my-app --filter-state open --filter-state draft  # ready and draft PRs
+breakfast -o my-org -r my-app --filter-state closed                     # all closed PRs
 ```
 
 ### `--filter-check`

--- a/src/breakfast/config.py
+++ b/src/breakfast/config.py
@@ -655,6 +655,33 @@ def filter_pr_details(
     filter_stale=None,
     filter_inactive=None,
 ):
+    """Apply configured filters to pull request details.
+
+    Args:
+        pr_details: Pull request detail mappings to filter.
+        ignore_authors: Author logins to exclude.
+        mine_only: Whether to include only PRs authored by the current user.
+        current_user_login: Authenticated GitHub login used by ``mine_only``.
+        no_drafts: Whether to exclude draft PRs.
+        drafts_only: Whether to include only draft PRs.
+        filter_state: Accepted PR state labels. ``open`` excludes drafts,
+            ``closed`` includes closed drafts, and ``draft`` is matched
+            independently using OR semantics.
+        filter_check: Accepted CI check states.
+        filter_approval: Accepted review approval states.
+        filter_mergeable: Accepted mergeability states.
+        check_statuses: CI check states keyed by PR ID.
+        approval_statuses: Approval states keyed by PR ID.
+        search_title: Case-insensitive title regular expression.
+        filter_reviewer: Requested reviewer logins to include.
+        filter_label: PR labels to include.
+        exclude_label: PR labels to exclude.
+        filter_stale: Minimum PR age in days.
+        filter_inactive: Minimum PR inactivity in days.
+
+    Returns:
+        list: Pull request details matching every configured filter.
+    """
     ignore_set = normalize_ignore_authors(ignore_authors)
     current_user_login_normalized = (
         current_user_login.lower()
@@ -684,7 +711,9 @@ def filter_pr_details(
             include_drafts = "draft" in filter_state_lower
             is_draft = pr_detail.get("draft", False)
             pr_state = pr_detail.get("state", "").lower()
-            state_match = bool(regular_states) and pr_state in regular_states
+            state_match = pr_state in regular_states and not (
+                pr_state == "open" and is_draft
+            )
             draft_match = include_drafts and is_draft
             if not (state_match or draft_match):
                 continue

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1413,6 +1413,42 @@ def _make_pr_fixture(title="Test PR", number=1):
     }
 
 
+@pytest.mark.parametrize(
+    ("filter_states", "ready_visible", "draft_visible"),
+    [
+        (["open"], True, False),
+        (["open", "draft"], True, True),
+    ],
+)
+def test_cli_filter_state_handles_drafts(
+    monkeypatch, filter_states, ready_visible, draft_visible
+):
+    monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
+    monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
+
+    urls = [
+        "https://github.com/org/repo/pull/1",
+        "https://github.com/org/repo/pull/2",
+    ]
+    ready_pr = {**_make_pr_fixture("Ready for review", 1), "draft": False}
+    draft_pr = {**_make_pr_fixture("Still a draft", 2), "draft": True}
+    pr_details = {
+        "/repos/org/repo/pulls/1": ready_pr,
+        "/repos/org/repo/pulls/2": draft_pr,
+    }
+
+    monkeypatch.setattr(cli, "get_github_prs", lambda *_args: urls)
+    monkeypatch.setattr(api, "make_github_api_request", pr_details.__getitem__)
+
+    state_args = [arg for state in filter_states for arg in ("--filter-state", state)]
+    result = CliRunner().invoke(cli.breakfast, ["-o", "org", "-r", "repo", *state_args])
+
+    assert result.exit_code == 0
+    assert ("Ready for review" in result.stdout) is ready_visible
+    assert ("Still a draft" in result.stdout) is draft_visible
+
+
 def test_cli_status_columns_use_ascii_to_keep_rows_aligned(monkeypatch):
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -142,19 +142,59 @@ def test_filter_pr_details_filter_state_draft():
     draft_pr = {**_make_pr(state="open", pr_id=1), "draft": True}
     open_pr = {**_make_pr(state="open", pr_id=2), "draft": False}
     closed_pr = {**_make_pr(state="closed", pr_id=3), "draft": False}
-    pr_details = [draft_pr, open_pr, closed_pr]
+    open_pr_without_draft = _make_pr(state="open", pr_id=4)
+    open_pr_with_null_draft = {**_make_pr(state="open", pr_id=5), "draft": None}
+    closed_draft_pr = {**_make_pr(state="closed", pr_id=6), "draft": True}
+    pr_details = [
+        draft_pr,
+        open_pr,
+        closed_pr,
+        open_pr_without_draft,
+        open_pr_with_null_draft,
+        closed_draft_pr,
+    ]
 
     # draft only
     result = config.filter_pr_details(pr_details, [], filter_state=("draft",))
-    assert [r["id"] for r in result] == [1]
+    assert [r["id"] for r in result] == [1, 6]
 
     # closed + draft
     result = config.filter_pr_details(pr_details, [], filter_state=("closed", "draft"))
-    assert sorted(r["id"] for r in result) == [1, 3]
+    assert [r["id"] for r in result] == [1, 3, 6]
 
-    # open alone still includes draft PRs (state=open)
+    # open excludes drafts and treats missing or null draft metadata as non-draft
     result = config.filter_pr_details(pr_details, [], filter_state=("open",))
-    assert sorted(r["id"] for r in result) == [1, 2]
+    assert [r["id"] for r in result] == [2, 4, 5]
+
+    # open + draft explicitly includes both categories
+    result = config.filter_pr_details(pr_details, [], filter_state=("open", "draft"))
+    assert [r["id"] for r in result] == [1, 2, 4, 5, 6]
+
+    # closed remains a lifecycle state and includes closed drafts
+    result = config.filter_pr_details(pr_details, [], filter_state=("closed",))
+    assert [r["id"] for r in result] == [3, 6]
+
+
+def test_filter_pr_details_filter_state_draft_flag_intersections():
+    draft_pr = {**_make_pr(state="open", pr_id=1), "draft": True}
+    open_pr = {**_make_pr(state="open", pr_id=2), "draft": False}
+    pr_details = [draft_pr, open_pr]
+
+    result = config.filter_pr_details(
+        pr_details,
+        [],
+        drafts_only=True,
+        filter_state=("open",),
+    )
+    assert result == []
+
+    result = config.filter_pr_details(
+        pr_details,
+        [],
+        no_drafts=True,
+        filter_state=("draft",),
+    )
+    assert result == []
 
 
 def test_filter_pr_details_filter_check():


### PR DESCRIPTION
## Issue

Closes #394

## Description

GitHub reports draft pull requests with the lifecycle state `open`, so Breakfast previously included drafts whenever `--filter-state open` was selected. This change makes the user-facing filter distinguish ready-for-review PRs from drafts while preserving explicit draft filtering.

## Changes

- Make `--filter-state open` match only open, non-draft pull requests.
- Keep `draft` as an independent filter category and preserve OR behavior when state filters are repeated.
- Preserve `closed` as a lifecycle state, including defensively handling closed objects whose draft flag remains true.
- Treat missing or null draft metadata as non-draft for compatibility with incomplete API or cached records.
- Add unit coverage for open, draft, closed, repeated-state, missing/null metadata, and contradictory draft-flag combinations.
- Add CLI-level coverage proving that `open` excludes drafts and `open + draft` includes both categories.
- Document the updated behavior in the README and manual options reference.

## Testing

- [x] `make test` passes — 511 tests.
- [x] `make lint` passes.
- [x] `make format` passes.
- [x] Targeted state-filter tests pass — 4 parameterized cases.
- [x] Real CLI verification with the cache disabled shows only the three ready PRs from a six-PR fixture repository.
- [x] Real CLI verification with cache refresh and cache-hit paths preserves the expected three-ready/three-draft split.

## Notes

The inherited local environment sets `NO_COLOR=1`; it was unset for the full test gate because the existing colour diagnostics tests intentionally assert ANSI output. Manual cache tests used isolated XDG directories and did not alter the user's normal Breakfast cache.

🤖 Prepared by Codex
