### PR TITLE
#397: Handle GraphQL resource-limit failures gracefully

### DIFF
--- a/docs/manual/troubleshooting.md
+++ b/docs/manual/troubleshooting.md
@@ -33,6 +33,30 @@ If errors persist and no cached data exists:
 - Verify your token hasn't been revoked
 - Check your [API rate limit](https://docs.github.com/en/rest/rate-limit): `curl -H "Authorization: token $GITHUB_TOKEN" https://api.github.com/rate_limit`
 
+## GitHub GraphQL resource limits
+
+GitHub may reject a query that asks it to process too many repositories and
+pull requests at once. breakfast automatically uses bounded repository pages
+and retries the same page with progressively fewer repositories when GitHub
+reports `RESOURCE_LIMITS_EXCEEDED`.
+
+If even a single-repository page cannot be served, breakfast exits cleanly
+without a Python traceback and prints:
+
+```text
+🥞 GitHub couldn't return the PR list because the GraphQL query exceeded resource limits. Try again or narrow the requested repositories.
+```
+
+Retry the command later or use owner-scoped repository filters to reduce the
+query, for example:
+
+```bash
+breakfast -o my-org:api -o my-org:web
+```
+
+The error is written to stderr, so redirected JSON, CSV, Markdown, and template
+output on stdout is not contaminated by diagnostics.
+
 ## Slow performance
 
 PR details are fetched in parallel (up to 8 concurrent requests), and results are cached to disk for 5 minutes by default. If output is slow on the first run:

--- a/src/breakfast/api.py
+++ b/src/breakfast/api.py
@@ -17,6 +17,65 @@ GITHUB_API_URL = "https://api.github.com"
 GITHUB_GRAPHQL_URL = "https://api.github.com/graphql"
 SECRET_GITHUB_TOKEN = os.getenv("GITHUB_TOKEN", None)
 
+_MAX_GRAPHQL_ERROR_TYPES = 3
+_MAX_GRAPHQL_ERROR_MESSAGE_LENGTH = 120
+_MAX_STORED_GRAPHQL_ERRORS = 10
+
+
+def _summarize_graphql_errors(errors):
+    """Return a bounded summary of GraphQL errors grouped by type.
+
+    Args:
+        errors: GraphQL error objects returned by GitHub.
+
+    Returns:
+        str: Error counts and one representative message per error type.
+    """
+    counts = {}
+    first_messages = {}
+    for error in errors:
+        if isinstance(error, dict):
+            error_type = str(error.get("type") or "UNKNOWN")
+            message = str(error.get("message") or "No message provided")
+        else:
+            error_type = "UNKNOWN"
+            message = str(error)
+        counts[error_type] = counts.get(error_type, 0) + 1
+        first_messages.setdefault(error_type, " ".join(message.split()))
+
+    summaries = []
+    error_types = sorted(counts, key=lambda item: (-counts[item], item))
+    for error_type in error_types[:_MAX_GRAPHQL_ERROR_TYPES]:
+        message = first_messages[error_type]
+        if len(message) > _MAX_GRAPHQL_ERROR_MESSAGE_LENGTH:
+            message = f"{message[: _MAX_GRAPHQL_ERROR_MESSAGE_LENGTH - 3]}..."
+        summaries.append(f"{error_type}={counts[error_type]}: {message}")
+
+    omitted_types = len(counts) - len(summaries)
+    if omitted_types > 0:
+        summaries.append(f"{omitted_types} additional error type(s)")
+    return "; ".join(summaries) or "no error details"
+
+
+class GitHubGraphQLError(ValueError):
+    """Raised when GitHub returns fatal GraphQL errors.
+
+    Attributes:
+        error_count: Total number of errors in the response.
+        errors: Bounded tuple of representative original error objects.
+        summary: Bounded error summary grouped by type.
+    """
+
+    def __init__(self, errors):
+        self.error_count = len(errors)
+        self.errors = tuple(errors[:_MAX_STORED_GRAPHQL_ERRORS])
+        self.summary = _summarize_graphql_errors(errors)
+        super().__init__(f"GraphQL request failed: {self.summary}")
+
+
+class GitHubGraphQLResourceLimitError(GitHubGraphQLError):
+    """Raised when any GitHub GraphQL error reports exhausted resources."""
+
 
 class GitHubRateLimitError(Exception):
     """Raised when the GitHub REST API rate limit is exhausted.
@@ -49,6 +108,7 @@ class OwnerNotFoundError(Exception):
 _MAX_RETRIES = 3
 _RETRY_STATUSES = {502, 503, 504}
 _REQUEST_TIMEOUT = (5, 30)
+_GRAPHQL_REPOSITORY_PAGE_SIZE = 25
 
 _api_stats_lock = threading.Lock()
 _api_stats = {
@@ -219,13 +279,24 @@ def make_github_graphql_request(query, variables=None):
             response.raise_for_status()
             resp_json = response.json()
             if "errors" in resp_json:
+                errors = resp_json["errors"]
+                summary = _summarize_graphql_errors(errors)
                 logger.warning(
-                    "api_call type=graphql status=%d elapsed_ms=%d errors=%r",
+                    "api_call type=graphql status=%d elapsed_ms=%d"
+                    " error_count=%d errors=%s",
                     response.status_code,
                     elapsed_ms,
-                    resp_json["errors"],
+                    len(errors),
+                    summary,
                 )
-                raise ValueError(f"GraphQL request failed: {resp_json['errors']}")
+                error_types = {
+                    error.get("type") if isinstance(error, dict) else None
+                    for error in errors
+                }
+                error_class = GitHubGraphQLError
+                if error_types == {"RESOURCE_LIMITS_EXCEEDED"}:
+                    error_class = GitHubGraphQLResourceLimitError
+                raise error_class(errors)
             logger.debug(
                 "api_call type=graphql status=%d elapsed_ms=%d",
                 response.status_code,
@@ -291,13 +362,67 @@ _FETCH_STATE_MAP = {
 }
 
 
+def _request_github_repository_page(query, owner, cursor, page_size):
+    """Request one repository page, reducing its size on resource failures.
+
+    Args:
+        query: GraphQL repository and pull-request query.
+        owner: GitHub organization or user login.
+        cursor: Repository pagination cursor, or ``None`` for the first page.
+        page_size: Number of repositories to request in the first attempt.
+
+    Returns:
+        tuple: Successful GraphQL response and the page size that succeeded.
+
+    Raises:
+        GitHubGraphQLError: If GitHub returns any non-resource GraphQL error.
+        GitHubGraphQLResourceLimitError: If a single-repository page still
+            exceeds GitHub's resource limits.
+        requests.exceptions.RequestException: If the request fails after its
+            configured network retries.
+    """
+    current_page_size = page_size
+    while True:
+        variables = {
+            "owner": owner,
+            "cursor": cursor,
+            "repositoryPageSize": current_page_size,
+        }
+        try:
+            return make_github_graphql_request(query, variables), current_page_size
+        except GitHubGraphQLResourceLimitError as exc:
+            if current_page_size == 1:
+                raise
+            next_page_size = max(1, current_page_size // 2)
+            logger.warning(
+                "graphql_resource_limit owner=%s cursor=%r error_count=%d"
+                " repository_page_size=%d retry_page_size=%d",
+                owner,
+                cursor,
+                exc.error_count,
+                current_page_size,
+                next_page_size,
+            )
+            current_page_size = next_page_size
+
+
 def get_github_prs(owner, repo_filters, fetch_state="open"):
+    """Return pull-request URLs for an owner using bounded repository pages.
+
+    Args:
+        owner: GitHub organization or user login.
+        repo_filters: Repository name filters, or an empty value for all repos.
+        fetch_state: Pull-request state selector.
+
+    Returns:
+        list[str]: Matching pull-request URLs.
+    """
     states_list = _FETCH_STATE_MAP.get(fetch_state.lower(), ["OPEN"])
     states_gql = ", ".join(states_list)
     base_query = f"""
-    query($owner: String!, $cursor: String){{
+    query($owner: String!, $cursor: String, $repositoryPageSize: Int!){{
       repositoryOwner(login: $owner){{
-        repositories(after: $cursor, first:100){{
+        repositories(after: $cursor, first: $repositoryPageSize){{
           nodes{{
             name
             pullRequests(first:100,states: [{states_gql}]){{
@@ -314,20 +439,22 @@ def get_github_prs(owner, repo_filters, fetch_state="open"):
       }}
     }}
         """
-    variables = {"owner": owner}
-
+    cursor = None
+    page_size = _GRAPHQL_REPOSITORY_PAGE_SIZE
     gql_responses = []
 
     click.echo(f"Fetching {owner} PRs...", nl=False, err=True)
     while True:
-        response = make_github_graphql_request(base_query, variables)
+        response, page_size = _request_github_repository_page(
+            base_query, owner, cursor, page_size
+        )
         if response["data"]["repositoryOwner"] is None:
             raise OwnerNotFoundError(owner)
         gql_responses.append(response)
         page_info = response["data"]["repositoryOwner"]["repositories"]["pageInfo"]
         if not page_info["hasNextPage"]:
             break
-        variables["cursor"] = page_info["endCursor"]
+        cursor = page_info["endCursor"]
         click.echo(random.choices(BREAKFAST_ITEMS)[0], nl=False, err=True)
     click.echo("...Done", err=True)
 

--- a/src/breakfast/cli.py
+++ b/src/breakfast/cli.py
@@ -11,6 +11,8 @@ import requests
 
 from .api import (
     SECRET_GITHUB_TOKEN,
+    GitHubGraphQLError,
+    GitHubGraphQLResourceLimitError,
     GitHubRateLimitError,
     OwnerNotFoundError,
     _fetch_pr_detail,
@@ -1432,6 +1434,31 @@ def breakfast(
             if cache_enabled:
                 needs_cache_write = True
 
+        except GitHubGraphQLResourceLimitError as exc:
+            logger.warning(
+                "graphql_resource_limit_unrecoverable error_count=%d errors=%s",
+                exc.error_count,
+                exc.summary,
+            )
+            # End the active fetch progress line before showing the error.
+            click.echo("", err=True)
+            msg = (
+                "🥞 GitHub couldn't return the PR list because the GraphQL query "
+                "exceeded resource limits. Try again or narrow the requested "
+                "repositories."
+            )
+            click.echo(click.style(msg, fg="red", bold=True), err=True, color=colour)
+            sys.exit(1)
+        except GitHubGraphQLError as exc:
+            logger.warning(
+                "graphql_request_failed error_count=%d errors=%s",
+                exc.error_count,
+                exc.summary,
+            )
+            click.echo("", err=True)
+            msg = f"🥞 GitHub couldn't complete the GraphQL request: {exc.summary}"
+            click.echo(click.style(msg, fg="red", bold=True), err=True, color=colour)
+            sys.exit(1)
         except (
             requests.exceptions.ConnectionError,
             requests.exceptions.Timeout,

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -198,6 +198,134 @@ def test_get_github_prs_filters_and_paginates(monkeypatch):
     ]
 
 
+def test_get_github_prs_starts_with_bounded_repository_page(monkeypatch):
+    variables_seen = []
+
+    def fake_graphql_request(_query, variables):
+        variables_seen.append(dict(variables))
+        return _single_page_graphql([])
+
+    monkeypatch.setattr(api, "make_github_graphql_request", fake_graphql_request)
+
+    api.get_github_prs("org", None)
+
+    assert variables_seen == [
+        {"owner": "org", "cursor": None, "repositoryPageSize": 25}
+    ]
+
+
+def test_get_github_prs_reduces_page_size_after_resource_limit(monkeypatch):
+    variables_seen = []
+
+    def fake_graphql_request(_query, variables):
+        variables_seen.append(dict(variables))
+        if len(variables_seen) == 1:
+            raise api.GitHubGraphQLResourceLimitError(
+                [
+                    {
+                        "type": "RESOURCE_LIMITS_EXCEEDED",
+                        "message": "Resource limits for this query exceeded.",
+                    }
+                ]
+            )
+        return _single_page_graphql([])
+
+    monkeypatch.setattr(api, "make_github_graphql_request", fake_graphql_request)
+
+    api.get_github_prs("org", None)
+
+    assert [variables["repositoryPageSize"] for variables in variables_seen] == [
+        25,
+        12,
+    ]
+
+
+def test_get_github_prs_retains_reduced_size_without_corrupting_cursor(monkeypatch):
+    variables_seen = []
+
+    def fake_graphql_request(_query, variables):
+        variables_seen.append(dict(variables))
+        if len(variables_seen) == 1:
+            raise api.GitHubGraphQLResourceLimitError(
+                [
+                    {
+                        "type": "RESOURCE_LIMITS_EXCEEDED",
+                        "message": "Resource limits for this query exceeded.",
+                    }
+                ]
+            )
+        if len(variables_seen) == 2:
+            return {
+                "data": {
+                    "repositoryOwner": {
+                        "repositories": {
+                            "nodes": [],
+                            "pageInfo": {
+                                "endCursor": "cursor-1",
+                                "hasNextPage": True,
+                            },
+                        }
+                    }
+                }
+            }
+        return _single_page_graphql([])
+
+    monkeypatch.setattr(api, "make_github_graphql_request", fake_graphql_request)
+    monkeypatch.setattr(api, "BREAKFAST_ITEMS", ["*"])
+
+    api.get_github_prs("org", None)
+
+    assert [
+        (variables["cursor"], variables["repositoryPageSize"])
+        for variables in variables_seen
+    ] == [(None, 25), (None, 12), ("cursor-1", 12)]
+
+
+def test_get_github_prs_propagates_resource_limit_at_page_size_one(monkeypatch):
+    page_sizes = []
+
+    def fake_graphql_request(_query, variables):
+        page_sizes.append(variables["repositoryPageSize"])
+        raise api.GitHubGraphQLResourceLimitError(
+            [
+                {
+                    "type": "RESOURCE_LIMITS_EXCEEDED",
+                    "message": "Resource limits for this query exceeded.",
+                }
+            ]
+        )
+
+    monkeypatch.setattr(api, "make_github_graphql_request", fake_graphql_request)
+
+    with pytest.raises(api.GitHubGraphQLResourceLimitError):
+        api.get_github_prs("org", None)
+
+    assert page_sizes == [25, 12, 6, 3, 1]
+
+
+def test_get_github_prs_does_not_retry_mixed_graphql_errors(monkeypatch):
+    page_sizes = []
+
+    def fake_graphql_request(_query, variables):
+        page_sizes.append(variables["repositoryPageSize"])
+        raise api.GitHubGraphQLError(
+            [
+                {"type": "FORBIDDEN", "message": "Access denied."},
+                {
+                    "type": "RESOURCE_LIMITS_EXCEEDED",
+                    "message": "Resource limits for this query exceeded.",
+                },
+            ]
+        )
+
+    monkeypatch.setattr(api, "make_github_graphql_request", fake_graphql_request)
+
+    with pytest.raises(api.GitHubGraphQLError):
+        api.get_github_prs("org", None)
+
+    assert page_sizes == [25]
+
+
 def _single_page_response(repos):
     return {
         "data": {
@@ -852,6 +980,59 @@ def test_make_github_graphql_request_retries_on_chunked_encoding_error(monkeypat
 
     assert result == {"data": {"ok": True}}
     assert len(attempts) == 3
+
+
+def test_make_github_graphql_request_bounds_repeated_resource_errors(
+    monkeypatch, requests_mock, caplog
+):
+    errors = [
+        {
+            "type": "RESOURCE_LIMITS_EXCEEDED",
+            "path": ["repositoryOwner", "repositories", "nodes", index, "url"],
+            "message": "Resource limits for this query exceeded.",
+        }
+        for index in range(500)
+    ]
+    requests_mock.post(
+        api.GITHUB_GRAPHQL_URL,
+        json={"data": {"repositoryOwner": {"repositories": None}}, "errors": errors},
+    )
+    monkeypatch.setattr(api, "SECRET_GITHUB_TOKEN", "token-123")
+    caplog.set_level("WARNING")
+
+    with pytest.raises(api.GitHubGraphQLResourceLimitError) as exc_info:
+        api.make_github_graphql_request("{ viewer { login } }")
+
+    exc = exc_info.value
+    assert exc.error_count == 500
+    assert len(exc.errors) == 10
+    assert "RESOURCE_LIMITS_EXCEEDED=500" in str(exc)
+    assert "repositories', 'nodes'" not in str(exc)
+    assert len(str(exc)) < 250
+    assert "error_count=500" in caplog.text
+    assert caplog.text.count("RESOURCE_LIMITS_EXCEEDED") == 1
+    assert len(caplog.text) < 500
+
+
+def test_make_github_graphql_request_does_not_mask_mixed_errors(
+    monkeypatch, requests_mock
+):
+    errors = [
+        {"type": "FORBIDDEN", "message": "Access denied."},
+        {
+            "type": "RESOURCE_LIMITS_EXCEEDED",
+            "message": "Resource limits for this query exceeded.",
+        },
+    ]
+    requests_mock.post(api.GITHUB_GRAPHQL_URL, json={"data": {}, "errors": errors})
+    monkeypatch.setattr(api, "SECRET_GITHUB_TOKEN", "token-123")
+
+    with pytest.raises(api.GitHubGraphQLError) as exc_info:
+        api.make_github_graphql_request("{ viewer { login } }")
+
+    assert type(exc_info.value) is api.GitHubGraphQLError
+    assert "FORBIDDEN=1" in exc_info.value.summary
+    assert "RESOURCE_LIMITS_EXCEEDED=1" in exc_info.value.summary
 
 
 def test_make_github_api_request_retries_on_chunked_encoding_error(monkeypatch):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3751,6 +3751,81 @@ def test_owner_not_found_exits_cleanly(monkeypatch, tmp_path):
     assert "Traceback" not in result.output
 
 
+def test_graphql_resource_limit_aborts_without_partial_output_or_cache(monkeypatch):
+    calls = []
+    cache_writes = []
+
+    def fake_get_prs(owner, _filters, _state):
+        calls.append(owner)
+        if owner == "second-owner":
+            raise api.GitHubGraphQLResourceLimitError(
+                [
+                    {
+                        "type": "RESOURCE_LIMITS_EXCEEDED",
+                        "path": [
+                            "repositoryOwner",
+                            "repositories",
+                            "nodes",
+                            index,
+                            "url",
+                        ],
+                        "message": "Resource limits for this query exceeded.",
+                    }
+                    for index in range(500)
+                ]
+            )
+        return ["https://github.com/first-owner/repo/pull/1"]
+
+    monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "tok")
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
+    monkeypatch.setattr(cli, "get_github_prs", fake_get_prs)
+    monkeypatch.setattr(
+        cli,
+        "write_graphql_cache",
+        lambda *args: cache_writes.append(args),
+    )
+
+    result = CliRunner().invoke(
+        cli.breakfast,
+        ["-o", "first-owner", "-o", "second-owner", "--cache"],
+    )
+
+    assert result.exit_code == 1
+    assert calls == ["first-owner", "second-owner"]
+    assert cache_writes == []
+    assert result.stdout == ""
+    assert "exceeded resource limits" in result.stderr
+    assert result.stderr.count("RESOURCE_LIMITS_EXCEEDED") == 0
+    assert len(result.stderr) < 300
+    assert "Traceback" not in result.output
+
+
+def test_other_graphql_errors_exit_cleanly(monkeypatch):
+    def fake_get_prs(_owner, _filters, _state):
+        raise api.GitHubGraphQLError(
+            [
+                {"type": "FORBIDDEN", "message": "Access denied."},
+                {
+                    "type": "RESOURCE_LIMITS_EXCEEDED",
+                    "message": "Resource limits for this query exceeded.",
+                },
+            ]
+        )
+
+    monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "tok")
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
+    monkeypatch.setattr(cli, "get_github_prs", fake_get_prs)
+
+    result = CliRunner().invoke(cli.breakfast, ["-o", "org"])
+
+    assert result.exit_code == 1
+    assert result.stdout == ""
+    assert "FORBIDDEN=1" in result.stderr
+    assert "RESOURCE_LIMITS_EXCEEDED=1" in result.stderr
+    assert len(result.stderr) < 300
+    assert "Traceback" not in result.output
+
+
 # ---------------------------------------------------------------------------
 # Multiple repo filters (#290)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- **Graceful GraphQL resource-limit handling**: Prevent GitHub's repeated `RESOURCE_LIMITS_EXCEEDED` errors from producing an enormous Python traceback or corrupting pipeable output.
- **Key Changes**:
  - Add bounded `GitHubGraphQLError` and `GitHubGraphQLResourceLimitError` exceptions with concise summaries and capped diagnostic payloads.
  - Fetch repository pages with an initial size of 25 and retry the same cursor at progressively smaller sizes down to one when a pure resource-limit response is returned.
  - Preserve the successful reduced page size for subsequent pages while keeping pagination cursors independent.
  - Treat mixed GraphQL failures as generic errors rather than retrying or misreporting them as resource-limit failures.
  - Exit cleanly through stderr without rendering partial stdout or writing partial GraphQL cache data when acquisition cannot recover.
  - Document the new behaviour and practical owner-filter mitigations in the troubleshooting manual.
- **Abstractions & Design Decisions**: Resource-limit classification lives at the GraphQL request boundary, while adaptive page sizing is isolated in the repository-page helper. This keeps retry policy separate from CLI presentation and prevents errors from leaking large raw GraphQL payloads.

## Test plan

- [x] `make format && make lint && make test` passes — 520 tests passed.
- [x] **GraphQL API coverage**:
  - `test_get_github_prs_starts_with_bounded_repository_page` — verifies the bounded initial page size.
  - `test_get_github_prs_reduces_page_size_after_resource_limit` — verifies adaptive retry behaviour.
  - `test_get_github_prs_retains_reduced_size_without_corrupting_cursor` — verifies page-size retention and cursor integrity.
  - `test_get_github_prs_propagates_resource_limit_at_page_size_one` — verifies bounded terminal failure.
  - `test_get_github_prs_does_not_retry_mixed_graphql_errors` — verifies mixed errors are not misclassified.
  - `test_make_github_graphql_request_bounds_repeated_resource_errors` — verifies exception and logging volume remains bounded.
  - `test_make_github_graphql_request_does_not_mask_mixed_errors` — verifies generic error classification.
- [x] **CLI and cache-safety coverage**:
  - Multi-owner resource failure exits with empty stdout, concise stderr, no traceback, and no partial GraphQL cache write.
  - Generic GraphQL failures exit cleanly with bounded stderr.
- [x] **Manual Verification / Smoke Test**:
  - Ran the reported multi-owner command successfully with cache enabled.
  - Repeated the run with `--no-cache` and verified clean output.
  - Verified a subsequent cache-hit run completed successfully.

Closes #397

🤖 Prepared by Codex
