### PR TITLE
#365: Add "Made with ❤️ in the UK" credit to README and --help

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,3 +139,7 @@ breakfast --completion bash
 - [User Manual](docs/manual/) - Installation, usage, options reference, output formats, and troubleshooting
 - [Design Documents](docs/design/) - Technical designs for planned features
 - [Contributing](CONTRIBUTING.md) - How to contribute to the project
+
+---
+
+Made with ❤️ in the UK.

--- a/src/breakfast/cli.py
+++ b/src/breakfast/cli.py
@@ -334,7 +334,7 @@ def _fetch_pr_bundle(url, fetch_checks, fetch_approvals):
     return pr_detail, check_status, approval_detail
 
 
-@click.command(epilog="Made with ❤️  in the UK")
+@click.command(epilog="Made with ❤️ in the UK")
 @click.option(
     "--completion",
     "completion_shell",

--- a/src/breakfast/cli.py
+++ b/src/breakfast/cli.py
@@ -334,7 +334,7 @@ def _fetch_pr_bundle(url, fetch_checks, fetch_approvals):
     return pr_detail, check_status, approval_detail
 
 
-@click.command()
+@click.command(epilog="Made with ❤️  in the UK")
 @click.option(
     "--completion",
     "completion_shell",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4748,3 +4748,15 @@ def test_cli_auto_appends_optional_columns_missing_from_custom_columns_config(
     result_with = runner.invoke(cli.breakfast, ["-o", "org", "-r", "repo", "--age"])
     assert result_with.exit_code == 0
     assert "Age" in result_with.stdout
+
+
+# ---------------------------------------------------------------------------
+# --help credit (#365)
+# ---------------------------------------------------------------------------
+
+
+def test_help_shows_credit_line():
+    runner = CliRunner()
+    result = runner.invoke(cli.breakfast, ["--help"])
+    assert result.exit_code == 0
+    assert "Made with ❤️  in the UK" in result.stdout

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4759,4 +4759,4 @@ def test_help_shows_credit_line():
     runner = CliRunner()
     result = runner.invoke(cli.breakfast, ["--help"])
     assert result.exit_code == 0
-    assert "Made with ❤️  in the UK" in result.stdout
+    assert "Made with ❤️ in the UK" in result.stdout


### PR DESCRIPTION
## Issue

Closes #365

## Description

Adds a small "Made with ❤️ in the UK" attribution so it travels with both the README and the binary itself, mirroring what jeeves does (mrsixw/jeeves#38).

## Changes

- Added `epilog="Made with ❤️ in the UK"` to the `@click.command()` decorator in `src/breakfast/cli.py` so the credit appears at the bottom of `breakfast --help` output.
- Added a `Made with ❤️ in the UK.` footer to `README.md`, below the Documentation section.
- Added `test_help_shows_credit_line` in `tests/test_cli.py`, asserting the credit text appears in `--help` output.

## Testing

- [x] `make test` passes (533 tests)
- [x] `make lint` passes
- [x] `make format` passes
- [x] Manual verification: `uv run breakfast --help` shows the credit line; confirmed the epilog only renders on `--help` itself (not on `--version`, usage errors, or `--completion`), which matches the issue's acceptance criteria.

## Notes

- Kept spacing consistent (single space after ❤️) between the README footer and the `--help` epilog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)