### PR TITLE
#402: Support GH_TOKEN as GitHub auth env var

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Thanks for your interest in contributing to **breakfast**! This guide covers set
 
 - Python >= 3.11
 - [uv](https://docs.astral.sh/uv/) package manager (not pip). If you do not already have it, install it with `python -m pip install --user uv`.
-- A `GITHUB_TOKEN` environment variable for running the tool
+- A `GH_TOKEN` environment variable for running the tool (falls back to `GITHUB_TOKEN` if `GH_TOKEN` is not set)
 
 ## Getting Started
 

--- a/README.md
+++ b/README.md
@@ -17,9 +17,11 @@ curl -sSL https://raw.githubusercontent.com/mrsixw/breakfast/main/install.sh | b
 ## Quick start
 
 ```bash
-export GITHUB_TOKEN="ghp_your_token_here"
+export GH_TOKEN="ghp_your_token_here"
 breakfast -o my-org -r my-app
 ```
+
+breakfast reads `GH_TOKEN` first (matching the `gh` CLI convention), falling back to `GITHUB_TOKEN` if `GH_TOKEN` isn't set.
 
 ## Usage
 

--- a/docs/manual/installation.md
+++ b/docs/manual/installation.md
@@ -67,11 +67,13 @@ make uninstall PREFIX=$HOME/.local
 
 ## Set up your GitHub token
 
-breakfast requires a `GITHUB_TOKEN` environment variable:
+breakfast requires a GitHub token, read from `GH_TOKEN` (preferred, matching the [`gh` CLI](https://cli.github.com/) convention) or `GITHUB_TOKEN` as a fallback:
 
 ```bash
-export GITHUB_TOKEN="ghp_your_token_here"
+export GH_TOKEN="ghp_your_token_here"
 ```
+
+If `GH_TOKEN` is already set in your environment (e.g. by CI or tooling built around the `gh` CLI), breakfast will use it automatically — no need to set `GITHUB_TOKEN` too.
 
 Add this to your shell profile (`~/.zshrc`, `~/.bashrc`, etc.) to make it persistent.
 

--- a/docs/manual/options.md
+++ b/docs/manual/options.md
@@ -263,7 +263,7 @@ Error: --search pattern is not valid regex: unterminated character set at positi
 
 ### `--mine-only`
 
-Show only PRs authored by the currently authenticated GitHub user (determined from `GITHUB_TOKEN`).
+Show only PRs authored by the currently authenticated GitHub user (determined from `GH_TOKEN`, or `GITHUB_TOKEN` as a fallback).
 
 ```text
 $ breakfast -o my-org -r platform --mine-only
@@ -278,7 +278,7 @@ Processing platform PRs...🍳...Done
 
 ### `--needs-my-review`
 
-Show only PRs where the authenticated GitHub user (determined from `GITHUB_TOKEN`) is a requested reviewer. Ideal for the morning triage: skip everything that isn't waiting on you.
+Show only PRs where the authenticated GitHub user (determined from `GH_TOKEN`, or `GITHUB_TOKEN` as a fallback) is a requested reviewer. Ideal for the morning triage: skip everything that isn't waiting on you.
 
 ```bash
 breakfast -o my-org --needs-my-review

--- a/docs/manual/troubleshooting.md
+++ b/docs/manual/troubleshooting.md
@@ -1,12 +1,14 @@
 # Troubleshooting
 
-## "GITHUB_TOKEN not set in environment - exiting..."
+## "GH_TOKEN or GITHUB_TOKEN not set in environment - exiting..."
 
 breakfast requires a GitHub personal access token. Set it in your environment:
 
 ```bash
-export GITHUB_TOKEN="ghp_your_token_here"
+export GH_TOKEN="ghp_your_token_here"
 ```
+
+breakfast reads `GH_TOKEN` first (the variable used by the [`gh` CLI](https://cli.github.com/)), falling back to `GITHUB_TOKEN` if `GH_TOKEN` is not set. If neither is set, this error is shown.
 
 The token needs `repo` scope to access pull request data. Generate one at [github.com/settings/tokens](https://github.com/settings/tokens).
 
@@ -43,7 +45,7 @@ If errors persist and no cached data exists:
 
 - Check [GitHub Status](https://www.githubstatus.com/) for ongoing incidents
 - Verify your token hasn't been revoked
-- Check your [API rate limit](https://docs.github.com/en/rest/rate-limit): `curl -H "Authorization: token $GITHUB_TOKEN" https://api.github.com/rate_limit`
+- Check your [API rate limit](https://docs.github.com/en/rest/rate-limit): `curl -H "Authorization: token $GH_TOKEN" https://api.github.com/rate_limit`
 
 ## GitHub GraphQL resource limits
 
@@ -142,13 +144,13 @@ organizations and personal accounts. If you see an owner-not-found error:
 - For organizations, you can verify with:
 
 ```bash
-curl -H "Authorization: token $GITHUB_TOKEN" https://api.github.com/orgs/YOUR_ORG
+curl -H "Authorization: token $GH_TOKEN" https://api.github.com/orgs/YOUR_ORG
 ```
 
 - For personal accounts:
 
 ```bash
-curl -H "Authorization: token $GITHUB_TOKEN" https://api.github.com/users/YOUR_USER
+curl -H "Authorization: token $GH_TOKEN" https://api.github.com/users/YOUR_USER
 ```
 
 ## Mergeable status shows "unknown" unexpectedly

--- a/src/breakfast/api.py
+++ b/src/breakfast/api.py
@@ -15,7 +15,14 @@ from .ui import BREAKFAST_ITEMS
 
 GITHUB_API_URL = "https://api.github.com"
 GITHUB_GRAPHQL_URL = "https://api.github.com/graphql"
-SECRET_GITHUB_TOKEN = os.getenv("GITHUB_TOKEN", None)
+
+
+def _resolve_github_token():
+    """Resolve the GitHub auth token, preferring GH_TOKEN (gh CLI convention)."""
+    return os.getenv("GH_TOKEN") or os.getenv("GITHUB_TOKEN")
+
+
+SECRET_GITHUB_TOKEN = _resolve_github_token()
 
 _MAX_GRAPHQL_ERROR_TYPES = 3
 _MAX_GRAPHQL_ERROR_MESSAGE_LENGTH = 120

--- a/src/breakfast/cli.py
+++ b/src/breakfast/cli.py
@@ -1170,7 +1170,7 @@ def breakfast(
         sys.exit(1)
 
     if SECRET_GITHUB_TOKEN is None:
-        message = "GITHUB_TOKEN not set in environment - exiting..."
+        message = "GH_TOKEN or GITHUB_TOKEN not set in environment - exiting..."
         click.echo(click.style(message, fg="red", bold=True), err=True, color=colour)
         sys.exit(1)
     current_user_login = None

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1438,3 +1438,31 @@ def test_make_github_api_request_retries_on_timeout_and_propagates(monkeypatch):
 
     # 1 initial attempt + 3 retries = 4 attempts total
     assert len(attempts) == 4
+
+
+def test_resolve_github_token_uses_gh_token_when_only_it_is_set(monkeypatch):
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    monkeypatch.setenv("GH_TOKEN", "gh-cli-token-value")
+
+    assert api._resolve_github_token() == "gh-cli-token-value"
+
+
+def test_resolve_github_token_falls_back_to_github_token(monkeypatch):
+    monkeypatch.setenv("GITHUB_TOKEN", "gh-token-value")
+    monkeypatch.delenv("GH_TOKEN", raising=False)
+
+    assert api._resolve_github_token() == "gh-token-value"
+
+
+def test_resolve_github_token_prefers_gh_token_over_github_token(monkeypatch):
+    monkeypatch.setenv("GITHUB_TOKEN", "gh-token-value")
+    monkeypatch.setenv("GH_TOKEN", "gh-cli-token-value")
+
+    assert api._resolve_github_token() == "gh-cli-token-value"
+
+
+def test_resolve_github_token_none_when_neither_set(monkeypatch):
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    monkeypatch.delenv("GH_TOKEN", raising=False)
+
+    assert api._resolve_github_token() is None

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -61,7 +61,7 @@ def test_cli_exits_when_token_missing(monkeypatch):
     result = runner.invoke(cli.breakfast, ["-o", "org", "-r", "repo"])
 
     assert result.exit_code == 1
-    assert "GITHUB_TOKEN not set" in result.stderr
+    assert "GH_TOKEN or GITHUB_TOKEN not set" in result.stderr
 
 
 def test_cli_outputs_table(monkeypatch):


### PR DESCRIPTION
## Summary

- **Support `GH_TOKEN` as a GitHub authentication environment variable**: breakfast previously required `GITHUB_TOKEN` exclusively. It now reads `GH_TOKEN` first — matching the `gh` CLI's own precedence convention — and falls back to `GITHUB_TOKEN` if `GH_TOKEN` is not set. This removes friction for users/CI environments that already have `GH_TOKEN` configured (e.g. via `gh auth login` or CI runners built around the `gh` CLI).
- **Key Changes**:
  - `src/breakfast/api.py`: extracted a `_resolve_github_token()` helper that resolves `SECRET_GITHUB_TOKEN` as `GH_TOKEN` if set, else `GITHUB_TOKEN`, else `None`.
  - `src/breakfast/cli.py`: updated the missing-token exit message to `"GH_TOKEN or GITHUB_TOKEN not set in environment - exiting..."`.
  - No new CLI flags or config keys — this is purely an environment-variable resolution change.
- **Abstractions & Design Decisions**: The token resolution logic was pulled into a small, directly-testable `_resolve_github_token()` function rather than testing the module-level assignment via `importlib.reload`, keeping the test suite free of module-reload side effects on shared module state.

## Test plan

- [x] `make format && make lint && make test` passes (`ruff check`, `black --check`, and `pytest` all clean; `make lint`'s `docs-lint` sub-target requires `npx`, which is unavailable in this sandboxed environment — unrelated to this change).
- [x] **New/updated unit tests**:
  - `test_resolve_github_token_uses_gh_token_when_only_it_is_set` — verifies `GH_TOKEN` alone is used.
  - `test_resolve_github_token_falls_back_to_github_token` — verifies fallback to `GITHUB_TOKEN` when `GH_TOKEN` is unset.
  - `test_resolve_github_token_prefers_gh_token_over_github_token` — verifies `GH_TOKEN` wins when both are set.
  - `test_resolve_github_token_none_when_neither_set` — verifies `None` when neither is set.
  - `test_cli_exits_when_token_missing` (updated) — verifies the new combined error message text.
- [x] **Manual Verification / Smoke Test** (against the real GitHub API, no cache involved):
  - `GH_TOKEN` only → successfully fetched live PR data.
  - `GITHUB_TOKEN` only → successfully fetched live PR data.
  - Both set (`GITHUB_TOKEN` set to a bogus value, `GH_TOKEN` valid) → succeeded, confirming `GH_TOKEN` precedence.
  - Neither set → exits with the updated `"GH_TOKEN or GITHUB_TOKEN not set in environment - exiting..."` message.

Closes #402

🤖 Generated with [Claude Code](https://claude.com/claude-code)