### PR TITLE
#404: Avoid GitHub API rate limits when installing git-mkver in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,6 +173,8 @@ jobs:
           version: "latest"
 
       - name: Install git-mkver
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: utils/install_git_mkver.sh
 
       - name: Fetch tags

--- a/utils/install_git_mkver.sh
+++ b/utils/install_git_mkver.sh
@@ -5,12 +5,17 @@ api_url="https://api.github.com/repos/idc101/git-mkver/releases/latest"
 
 asset_url=$(python - <<'PY'
 import json
-import sys
-from urllib.request import urlopen
+import os
+from urllib.request import Request, urlopen
 
 api_url = "https://api.github.com/repos/idc101/git-mkver/releases/latest"
 
-with urlopen(api_url) as response:
+headers = {}
+token = os.environ.get("GITHUB_TOKEN")
+if token:
+    headers["Authorization"] = f"Bearer {token}"
+
+with urlopen(Request(api_url, headers=headers)) as response:
     data = json.load(response)
 
 assets = data.get("assets", [])


### PR DESCRIPTION
## Summary

- **Fix a flaky `release` job**: `utils/install_git_mkver.sh` queried GitHub's REST API unauthenticated to find git-mkver's Linux asset URL, subject to the shared 60 req/hour anonymous quota across the whole GitHub Actions runner pool. Same issue was found and fixed in jeeves: https://github.com/mrsixw/jeeves/pull/107
- **Key Changes**:
  - `utils/install_git_mkver.sh`: sends an `Authorization: Bearer $GITHUB_TOKEN` header when the env var is set, raising the quota to 1000 req/hour per repo. Falls back to unauthenticated when unset (local/dev use).
  - `.github/workflows/ci.yml`: passes `GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}` to the "Install git-mkver" step.

## Test plan

- [x] `make format` — clean
- [x] `make lint` — `ruff check .` and `black --check .` both clean (`docs-lint` fails locally only because `npx`/Node.js isn't installed in this environment — unrelated to this change)
- [x] `make test` — 537 passed
- [x] `bash -n utils/install_git_mkver.sh` — syntax check passes
- [x] **Manual verification**: ran the embedded Python snippet directly against the real GitHub API both without and with a token. Unauthenticated returns the correct asset URL (unchanged behaviour). Authenticated via `gh auth token` returns the same URL and reports `X-RateLimit-Remaining: 4978` (vs. the 60/hour anonymous bucket), confirming the header takes effect.

Closes #404

🤖 Generated with [Claude Code](https://claude.com/claude-code)