### PR TITLE
#416: Bring the installer and update story to parity with jeeves

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,11 +143,19 @@ jobs:
           zsh -i -c "autoload -Uz compinit && compinit -u && source completions/_breakfast && echo 'zsh ok'"
           fish -c "source completions/breakfast.fish && echo 'fish ok'"
 
-      - name: Verify --completion flag works for all shells
+      - name: Verify completions subcommand works for all shells
         run: |
-          uv run python -m breakfast.cli --completion bash | grep -q "_BREAKFAST_COMPLETE"
-          uv run python -m breakfast.cli --completion zsh | grep -q "_BREAKFAST_COMPLETE"
-          uv run python -m breakfast.cli --completion fish | grep -q "_BREAKFAST_COMPLETE"
+          uv run python -m breakfast.cli completions bash | grep -q "_BREAKFAST_COMPLETE"
+          uv run python -m breakfast.cli completions zsh | grep -q "_BREAKFAST_COMPLETE"
+          uv run python -m breakfast.cli completions fish | grep -q "_BREAKFAST_COMPLETE"
+
+      - name: Verify the deprecated --completion flag keeps stdout evaluable
+        run: |
+          # The deprecation notice must stay on stderr: stdout is eval'd by the
+          # user's shell, so a stray notice there is a startup syntax error.
+          uv run python -m breakfast.cli --completion bash 2>/dev/null | grep -q "_BREAKFAST_COMPLETE"
+          ! uv run python -m breakfast.cli --completion bash 2>/dev/null | grep -q "deprecated"
+          uv run python -m breakfast.cli --completion bash 2>&1 >/dev/null | grep -q "deprecated"
 
   release:
     if: "github.ref == 'refs/heads/main' && github.event_name == 'push' && !startsWith(github.event.head_commit.message, 'chore: bump version')"

--- a/README.md
+++ b/README.md
@@ -62,7 +62,8 @@ breakfast -o my-org -r my-app --legendary
 breakfast -o my-org -r my-app --legendary-only
 breakfast -o my-org -r my-app --filter-mergeable clean
 breakfast -o my-org -r my-app --filter-mergeable clean --filter-approval approved
-breakfast --completion bash
+breakfast completions bash
+breakfast update
 ```
 
 ## Options
@@ -129,7 +130,8 @@ breakfast --completion bash
 
 ### Other
 
-- `--completion`: Print shell completion script for `bash`, `zsh`, or `fish` and exit. Eval in your shell config (e.g. `eval "$(breakfast --completion bash)"`).
+- `completions SHELL`: Print the shell completion script for `bash`, `zsh`, or `fish`. Eval in your shell config (e.g. `eval "$(breakfast completions bash)"`). The old `--completion` flag is deprecated.
+- `update`: Download the latest release and replace the running executable, atomically.
 - `--config`: Path to a config file.
 - `--show-config`: Print resolved config and exit.
 - `--init-config`: Generate a default config file.

--- a/docs/manual/installation.md
+++ b/docs/manual/installation.md
@@ -89,31 +89,36 @@ uv run breakfast --version
 
 ## Shell completions
 
-breakfast ships built-in tab completion for bash, zsh, and fish via the `--completion` flag.
+breakfast ships built-in tab completion for bash, zsh, and fish via the `completions` subcommand.
 
 ### Quick setup
 
 **Zsh** — add to `~/.zshrc`:
 
 ```zsh
-eval "$(breakfast --completion zsh)"
+eval "$(breakfast completions zsh)"
 ```
 
 **Bash** — add to `~/.bashrc` (requires bash ≥ 4.4):
 
 ```bash
-eval "$(breakfast --completion bash)"
+eval "$(breakfast completions bash)"
 ```
 
 **Fish** — write once to the completions directory:
 
 ```fish
-breakfast --completion fish > ~/.config/fish/completions/breakfast.fish
+breakfast completions fish > ~/.config/fish/completions/breakfast.fish
 ```
 
 ### How it works
 
-`breakfast --completion SHELL` prints the eval-able completion script for the named shell to stdout and exits. This means no token or `--owner` is needed — it works before any GitHub configuration.
+`breakfast completions SHELL` prints the eval-able completion script for the named shell to stdout and exits. This means no token or `--owner` is needed — it works before any GitHub configuration.
+
+> The older `--completion SHELL` flag still works but is deprecated and hidden
+> from `--help`. It prints a notice to stderr and will be removed in a future
+> release. `eval "$(breakfast --completion bash)"` stays safe in the meantime:
+> the notice goes to stderr, so only the script itself reaches your shell.
 
 For advanced users, the underlying Click completion mechanism is also available directly via the `_BREAKFAST_COMPLETE` environment variable:
 
@@ -125,7 +130,9 @@ _BREAKFAST_COMPLETE=fish_source breakfast  # fish
 
 ### Installer-managed completions
 
-The installer (`install.sh`) automatically installs tab-completion scripts for bash, zsh, and fish. After installation, you may need to activate them for your shell:
+The installer (`install.sh`) automatically installs tab-completion scripts for bash, zsh, and fish. Dropping the files into place is only half the job, though — bash and zsh both need a line in your rc file before they will load them. The installer detects your shell from `$SHELL` and prints exactly the snippet you need, falling back to all three when it cannot tell. It only prints: it never edits your rc files, since it is normally run piped through curl.
+
+The snippets it prints are reproduced here for reference:
 
 **Bash** — source the script in your `~/.bashrc`:
 
@@ -149,6 +156,18 @@ To regenerate completions manually from source:
 ```bash
 make completions   # writes to completions/
 ```
+
+## Updating
+
+Once installed, breakfast can replace itself with the latest release:
+
+```bash
+breakfast update
+```
+
+The swap is atomic — an interrupted download leaves the working binary in place — and nothing is written unless a newer release actually exists.
+
+The man page is not refreshed by `update`, because it can live somewhere that needs elevated privileges. Re-run `install.sh` if you want a fresh one. Completion scripts need no refresh: they call back into the binary, so they follow it automatically.
 
 ## Man page
 

--- a/docs/manual/options.md
+++ b/docs/manual/options.md
@@ -1109,17 +1109,44 @@ Can also be enabled persistently via config:
 api-stats = true
 ```
 
-### `--completion SHELL`
+## Commands
+
+Alongside the options above, breakfast has two subcommands. Both run before any
+GitHub token or `--owner` validation, so they work with no configuration at all.
+
+### `completions SHELL`
 
 Print the tab-completion script for `SHELL` to stdout and exit. `SHELL` must be one of `bash`, `zsh`, or `fish`.
 
 ```bash
-breakfast --completion zsh   # print zsh completion script
-breakfast --completion bash  # print bash completion script
-breakfast --completion fish  # print fish completion script
+breakfast completions zsh   # print zsh completion script
+breakfast completions bash  # print bash completion script
+breakfast completions fish  # print fish completion script
 ```
 
-This flag short-circuits before any GitHub token or `--owner` validation, so it works without any configuration. See [Installation → Shell completions](installation.md#shell-completions) for setup instructions.
+See [Installation → Shell completions](installation.md#shell-completions) for setup instructions.
+
+The older `--completion SHELL` flag is deprecated and hidden from `--help`. It
+still prints the same script to stdout, with a deprecation notice on stderr, and
+will be removed in a future release.
+
+### `update`
+
+Download the latest release and replace the running executable with it.
+
+```bash
+breakfast update
+```
+
+The replacement is atomic, so an interrupted download leaves the working binary
+in place. Nothing is written unless a newer release actually exists.
+
+The man page is not refreshed — re-run `install.sh` for that. Completion scripts
+need no refresh: they call back into the binary, so they follow it automatically.
+
+Not to be confused with `--update-config`, which merges new keys into your config
+file, or `--no-update-check`, which silences the passive "a new version exists"
+notice.
 
 ## Summary views
 

--- a/install.sh
+++ b/install.sh
@@ -98,6 +98,42 @@ else
     echo -e "${YELLOW}⚠️  Could not install fish completion (non-fatal).${RESET}"
 fi
 
+# Dropping the completion files into place is only half the job — bash and zsh
+# both need a line in the user's rc file before they will load them. Print the
+# snippet for the shell they are actually using rather than all three.
+# Print only: this script is normally run piped through curl, where prompting is
+# unreliable, so it never edits rc files on the user's behalf.
+echo -e "\n${BOLD}To finish enabling completions:${RESET}"
+case "${SHELL##*/}" in
+    *bash*)
+        echo -e "Add this to your ${BOLD}~/.bashrc${RESET}:"
+        echo -e "  ${BOLD}source \"${BASH_COMPLETION_DIR}/${BINARY_NAME}\"${RESET}"
+        echo -e "(If you already have the ${BOLD}bash-completion${RESET} package installed, it will be picked up automatically and you can skip this.)"
+        echo -e "Then restart your shell."
+        ;;
+    *zsh*)
+        echo -e "Add this to your ${BOLD}~/.zshrc${RESET}, above any existing ${BOLD}compinit${RESET} call:"
+        echo -e "  ${BOLD}fpath=(\"${ZSH_COMPLETION_DIR}\" \$fpath)${RESET}"
+        echo -e "If you don't already initialise completions (Oh My Zsh and friends do), add this too:"
+        echo -e "  ${BOLD}autoload -Uz compinit && compinit${RESET}"
+        echo -e "Then restart your shell."
+        ;;
+    *fish*)
+        echo -e "${GREEN}Nothing to do — fish loads completions from ${FISH_COMPLETION_DIR} automatically.${RESET}"
+        echo -e "New shells will pick them up."
+        ;;
+    *)
+        echo -e "bash — add to ${BOLD}~/.bashrc${RESET}:"
+        echo -e "  ${BOLD}source \"${BASH_COMPLETION_DIR}/${BINARY_NAME}\"${RESET}"
+        echo -e "zsh  — add to ${BOLD}~/.zshrc${RESET}, above any existing ${BOLD}compinit${RESET} call:"
+        echo -e "  ${BOLD}fpath=(\"${ZSH_COMPLETION_DIR}\" \$fpath)${RESET}"
+        echo -e "  ${BOLD}autoload -Uz compinit && compinit${RESET}  ${RESET}# only if you don't already initialise completions"
+        echo -e "fish — nothing to do, they load automatically."
+        echo -e "Then restart your shell."
+        ;;
+esac
+echo -e "You can also load them ad hoc with ${BOLD}eval \"\$(${BINARY_NAME} completions <shell>)\"${RESET}."
+
 # Check if INSTALL_DIR is in PATH
 if [[ ":$PATH:" != *":${INSTALL_DIR}:"* ]]; then
     echo -e "\n${BOLD}${YELLOW}⚠️  Warning: ${INSTALL_DIR} is not in your PATH.${RESET}"

--- a/src/breakfast/cli.py
+++ b/src/breakfast/cli.py
@@ -1,9 +1,12 @@
+import os
 import random
 import re
+import shutil
 import sys
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime, timezone
+from enum import StrEnum, auto
 from urllib.parse import urlparse
 
 import click
@@ -58,7 +61,39 @@ from .ui import (
     render_colour_diagnostics,
     render_pr_summary,
 )
-from .updater import check_for_update
+from .updater import UpdateStatus, check_for_update, perform_update
+
+
+class Shell(StrEnum):
+    """A shell that ``completions`` can emit a completion script for.
+
+    ``StrEnum`` + ``auto()`` yields the lowercase member name as the value, so
+    members pass straight into Click's completion machinery and into f-strings
+    without a trail of ``.value``.
+    """
+
+    BASH = auto()
+    ZSH = auto()
+    FISH = auto()
+
+
+# Click matches enum choices on member *names*, so click.Choice(Shell) would
+# demand "BASH" rather than "bash" — pass the values explicitly instead.
+_SHELL_CHOICES = [shell.value for shell in Shell]
+
+
+def _emit_completion_script(shell):
+    """Print the Click-generated completion script for *shell* to stdout."""
+    from click.shell_completion import get_completion_class
+
+    comp_cls = get_completion_class(Shell(shell))
+    comp = comp_cls(
+        cli=breakfast,
+        ctx_args={},
+        prog_name="breakfast",
+        complete_var="_BREAKFAST_COMPLETE",
+    )
+    click.echo(comp.source(), nl=False)
 
 
 def format_cache_age(age_seconds: float) -> str:
@@ -334,15 +369,17 @@ def _fetch_pr_bundle(url, fetch_checks, fetch_approvals):
     return pr_detail, check_status, approval_detail
 
 
-@click.command(epilog="Made with ❤️ in the UK")
+@click.group(invoke_without_command=True, epilog="Made with ❤️ in the UK")
+@click.pass_context
 @click.option(
     "--completion",
     "completion_shell",
-    type=click.Choice(["bash", "zsh", "fish"]),
+    type=click.Choice(_SHELL_CHOICES),
     default=None,
     is_eager=True,
     expose_value=True,
-    help="Print shell completion script for SHELL and exit. Eval in your shell config.",
+    hidden=True,
+    help="Deprecated: use 'breakfast completions SHELL' instead.",
 )
 @click.option("--config", help="Path to config file.")
 @click.option("--show-config", is_flag=True, help="Print the resolved config and exit.")
@@ -761,6 +798,7 @@ def _fetch_pr_bundle(url, fetch_checks, fetch_approvals):
 )
 @click.version_option(package_name="breakfast")
 def breakfast(
+    ctx,
     completion_shell,
     config,
     show_config,
@@ -822,17 +860,25 @@ def breakfast(
     t0_total = time.monotonic()
     configure_logging()
 
-    if completion_shell:
-        from click.shell_completion import get_completion_class
+    # This callback body *is* the program — without this guard, `breakfast
+    # completions bash` would go and fetch pull requests from GitHub before
+    # dispatching. Subcommands must also stay usable with no config file and no
+    # GITHUB_TOKEN, so return before any of the validation below.
+    if ctx.invoked_subcommand is not None:
+        return
 
-        comp_cls = get_completion_class(completion_shell)
-        comp = comp_cls(
-            cli=breakfast,
-            ctx_args={},
-            prog_name="breakfast",
-            complete_var="_BREAKFAST_COMPLETE",
+    if completion_shell:
+        click.echo(
+            click.style(
+                "⚠️  --completion is deprecated; use 'breakfast completions "
+                f"{completion_shell}' instead.",
+                fg="yellow",
+            ),
+            # stderr, always: this command's stdout gets eval'd by the user's
+            # shell, so a notice on stdout becomes a shell startup syntax error.
+            err=True,
         )
-        click.echo(comp.source(), nl=False)
+        _emit_completion_script(completion_shell)
         sys.exit(0)
 
     if colour_diagnostics:
@@ -1805,6 +1851,70 @@ def breakfast(
         show_update_summary=show_update_summary,
         api_stats=api_stats,
         colour=colour,
+    )
+
+
+# ── Shell completions ───────────────────────────────────────────────────────
+
+
+@breakfast.command()
+@click.argument("shell", type=click.Choice(_SHELL_CHOICES))
+def completions(shell):
+    """Print the shell completion script for SHELL.
+
+    Eval it in your shell config, e.g. ``eval "$(breakfast completions bash)"``.
+    """
+    _emit_completion_script(shell)
+
+
+# ── Self-update ─────────────────────────────────────────────────────────────
+
+
+def _current_executable_path():
+    """Resolve the absolute path of the running breakfast executable.
+
+    ``sys.argv[0]`` can be relative (``./breakfast``), and perform_update()
+    derives its temp file from this path — left relative, the replacement would
+    land next to the working directory rather than the real install location.
+    ``abspath`` rather than ``resolve`` so a symlinked install has its link
+    replaced, not the file it points at.
+    """
+    return os.path.abspath(shutil.which("breakfast") or sys.argv[0])
+
+
+@breakfast.command()
+def update():
+    """Fetch the latest breakfast release and serve it over this executable."""
+    click.echo(
+        click.style("🍳 Checking the kitchen for a fresher batch...", fg="cyan"),
+        err=True,
+    )
+    status, current, detail = perform_update(_current_executable_path())
+
+    if status is UpdateStatus.UNKNOWN:
+        raise click.ClickException("Could not reach GitHub to check for a new release.")
+    if status is UpdateStatus.ERROR:
+        raise click.ClickException(f"Update failed: {detail}")
+    if status is UpdateStatus.UP_TO_DATE:
+        click.echo(
+            click.style(
+                f"🥞 Already serving the freshest batch, v{current}.", fg="green"
+            ),
+            err=True,
+        )
+        return
+
+    click.echo(
+        click.style(f"🥞 A fresh batch is served — v{detail}.", fg="green"), err=True
+    )
+    # The completion scripts re-invoke the binary, so they track it for free.
+    # The man page is a static file and may sit somewhere needing privileges,
+    # so point at the installer rather than trying to rewrite it here.
+    click.echo(
+        click.style(
+            "   Re-run install.sh if you also want a refreshed man page.", fg="cyan"
+        ),
+        err=True,
     )
 
 

--- a/src/breakfast/cli.py
+++ b/src/breakfast/cli.py
@@ -1870,16 +1870,22 @@ def completions(shell):
 # ── Self-update ─────────────────────────────────────────────────────────────
 
 
-def _current_executable_path():
+def _current_executable_path() -> str:
     """Resolve the absolute path of the running breakfast executable.
 
-    ``sys.argv[0]`` can be relative (``./breakfast``), and perform_update()
-    derives its temp file from this path — left relative, the replacement would
-    land next to the working directory rather than the real install location.
+    ``sys.argv[0]`` is what the user actually invoked, so prefer it whenever it
+    names a real file: ``./breakfast update`` must update *that* copy, not a
+    different one that happens to sit earlier on PATH. Fall back to a PATH
+    lookup for the usual case, where argv[0] is the bare console-script name.
+
     ``abspath`` rather than ``resolve`` so a symlinked install has its link
-    replaced, not the file it points at.
+    replaced and not the file it points at, and so a relative argv[0] cannot
+    send ``os.replace()`` to the current working directory.
     """
-    return os.path.abspath(shutil.which("breakfast") or sys.argv[0])
+    invoked = sys.argv[0]
+    if os.sep in invoked and os.path.isfile(invoked):
+        return os.path.abspath(invoked)
+    return os.path.abspath(shutil.which("breakfast") or invoked)
 
 
 @breakfast.command()

--- a/src/breakfast/updater.py
+++ b/src/breakfast/updater.py
@@ -1,9 +1,12 @@
 import json
+import os
 import re
 import time
 from datetime import datetime, timezone
+from enum import Enum, auto
 from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version as pkg_version
+from pathlib import Path
 
 import requests
 
@@ -12,9 +15,26 @@ from .logger import logger
 from .xdg import get_cache_dir
 
 _UPDATE_CHECK_REPO = "mrsixw/breakfast"
+_PACKAGE_NAME = "breakfast"
+_RELEASE_ASSET_URL = (
+    f"https://github.com/{_UPDATE_CHECK_REPO}/releases/latest/download/{_PACKAGE_NAME}"
+)
 
 _CACHE_DIR = get_cache_dir()
 _CACHE_TTL_SECONDS = 86400  # 24 hours
+
+
+class UpdateStatus(Enum):
+    """Outcome of a :func:`perform_update` attempt.
+
+    The values are deliberately meaningless — nothing should serialise or
+    compare against them, so call sites use ``is`` against the members.
+    """
+
+    UPDATED = auto()
+    UP_TO_DATE = auto()
+    UNKNOWN = auto()
+    ERROR = auto()
 
 
 def _read_version_cache():
@@ -170,3 +190,41 @@ def check_for_update(show_summary: bool = False):
     except PackageNotFoundError as exc:
         logger.debug("package_not_found error=%r", str(exc))
         return None
+
+
+def perform_update(executable_path) -> tuple[UpdateStatus, str, str | None]:
+    """Download the latest breakfast release and replace executable_path in place.
+
+    Returns (status, current_version, detail):
+      - UPDATED: executable_path now holds the release named by detail.
+      - UP_TO_DATE: current_version already matches or exceeds detail (latest).
+      - UNKNOWN: the latest version could not be determined; detail is None.
+      - ERROR: the download or install failed; detail carries the error message.
+    """
+    current = pkg_version(_PACKAGE_NAME)
+    latest = get_latest_version()
+    if not latest:
+        return UpdateStatus.UNKNOWN, current, None
+    # Same comparison check_for_update() uses, so the passive notice and this
+    # command can never disagree about whether an update exists.
+    if not _parse_version_tuple(latest) > _parse_version_tuple(current):
+        return UpdateStatus.UP_TO_DATE, current, latest
+
+    # Download to a sibling and os.replace() it into position: the rename is
+    # atomic within a filesystem, so an interrupted download can never leave a
+    # half-written binary where the working one used to be.
+    executable_path = Path(executable_path)
+    tmp_path = executable_path.with_name(executable_path.name + ".new")
+    try:
+        resp = requests.get(_RELEASE_ASSET_URL, timeout=30, stream=True)
+        resp.raise_for_status()
+        with open(tmp_path, "wb") as fh:
+            for chunk in resp.iter_content(chunk_size=65536):
+                fh.write(chunk)
+        tmp_path.chmod(0o755)
+        os.replace(tmp_path, executable_path)
+    except (OSError, requests.exceptions.RequestException) as exc:
+        logger.debug("perform_update_failed error=%r", str(exc))
+        tmp_path.unlink(missing_ok=True)
+        return UpdateStatus.ERROR, current, str(exc)
+    return UpdateStatus.UPDATED, current, latest

--- a/src/breakfast/updater.py
+++ b/src/breakfast/updater.py
@@ -202,6 +202,17 @@ def perform_update(executable_path) -> tuple[UpdateStatus, str, str | None]:
       - ERROR: the download or install failed; detail carries the error message.
     """
     current = pkg_version(_PACKAGE_NAME)
+    executable_path = Path(executable_path)
+    if executable_path.suffix == ".py":
+        # Invoked from a source checkout (python -m <pkg>.cli), not an installed
+        # release. Writing a downloaded binary here would destroy the source.
+        return (
+            UpdateStatus.ERROR,
+            current,
+            f"{executable_path} is a source file, not an installed binary — "
+            "install a release before updating.",
+        )
+
     latest = get_latest_version()
     if not latest:
         return UpdateStatus.UNKNOWN, current, None
@@ -213,18 +224,21 @@ def perform_update(executable_path) -> tuple[UpdateStatus, str, str | None]:
     # Download to a sibling and os.replace() it into position: the rename is
     # atomic within a filesystem, so an interrupted download can never leave a
     # half-written binary where the working one used to be.
-    executable_path = Path(executable_path)
     tmp_path = executable_path.with_name(executable_path.name + ".new")
     try:
-        resp = requests.get(_RELEASE_ASSET_URL, timeout=30, stream=True)
-        resp.raise_for_status()
-        with open(tmp_path, "wb") as fh:
-            for chunk in resp.iter_content(chunk_size=65536):
-                fh.write(chunk)
+        with requests.get(_RELEASE_ASSET_URL, timeout=30, stream=True) as resp:
+            resp.raise_for_status()
+            with open(tmp_path, "wb") as fh:
+                for chunk in resp.iter_content(chunk_size=65536):
+                    fh.write(chunk)
         tmp_path.chmod(0o755)
         os.replace(tmp_path, executable_path)
     except (OSError, requests.exceptions.RequestException) as exc:
         logger.debug("perform_update_failed error=%r", str(exc))
-        tmp_path.unlink(missing_ok=True)
         return UpdateStatus.ERROR, current, str(exc)
+    finally:
+        # Also covers KeyboardInterrupt mid-download, which the except above
+        # deliberately does not catch. A successful os.replace leaves nothing
+        # to remove, so this is a no-op on the happy path.
+        tmp_path.unlink(missing_ok=True)
     return UpdateStatus.UPDATED, current, latest

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4602,48 +4602,69 @@ def test_cli_offline_respects_age_flag(monkeypatch, tmp_path):
 
 
 # ---------------------------------------------------------------------------
-# Shell completion (#350)
+# Shell completions (#350, #412)
 # ---------------------------------------------------------------------------
 
 
-def test_completion_zsh_exits_zero_and_outputs_script():
-    """--completion zsh prints a zsh script and exits 0 without needing a token."""
+def test_completions_zsh_exits_zero_and_outputs_script():
+    """completions zsh prints a zsh script and exits 0 without needing a token."""
     runner = CliRunner()
-    result = runner.invoke(cli.breakfast, ["--completion", "zsh"])
+    result = runner.invoke(cli.breakfast, ["completions", "zsh"])
     assert result.exit_code == 0
-    assert "_BREAKFAST_COMPLETE" in result.output
-    assert "breakfast" in result.output
+    assert "_BREAKFAST_COMPLETE" in result.stdout
+    assert "breakfast" in result.stdout
 
 
-def test_completion_bash_exits_zero_and_outputs_script():
+def test_completions_bash_exits_zero_and_outputs_script():
     runner = CliRunner()
-    result = runner.invoke(cli.breakfast, ["--completion", "bash"])
+    result = runner.invoke(cli.breakfast, ["completions", "bash"])
     assert result.exit_code == 0
-    assert "_BREAKFAST_COMPLETE" in result.output
-    assert "breakfast" in result.output
+    assert "_BREAKFAST_COMPLETE" in result.stdout
 
 
-def test_completion_fish_exits_zero_and_outputs_script():
+def test_completions_fish_exits_zero_and_outputs_script():
     runner = CliRunner()
-    result = runner.invoke(cli.breakfast, ["--completion", "fish"])
+    result = runner.invoke(cli.breakfast, ["completions", "fish"])
     assert result.exit_code == 0
-    assert "_BREAKFAST_COMPLETE" in result.output
-    assert "breakfast" in result.output
+    assert "_BREAKFAST_COMPLETE" in result.stdout
 
 
-def test_completion_requires_no_github_token(monkeypatch):
-    """--completion must work even with no GITHUB_TOKEN set."""
+def test_completions_requires_no_github_token(monkeypatch):
+    """completions must work even with no GITHUB_TOKEN set."""
     monkeypatch.delenv("GITHUB_TOKEN", raising=False)
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "")
     runner = CliRunner()
-    result = runner.invoke(cli.breakfast, ["--completion", "zsh"])
+    result = runner.invoke(cli.breakfast, ["completions", "zsh"])
     assert result.exit_code == 0
 
 
-def test_completion_rejects_unknown_shell():
+def test_completions_rejects_unknown_shell():
     runner = CliRunner()
-    result = runner.invoke(cli.breakfast, ["--completion", "powershell"])
+    result = runner.invoke(cli.breakfast, ["completions", "powershell"])
     assert result.exit_code != 0
+
+
+def test_shell_enum_members_are_their_lowercase_names():
+    assert [s.value for s in cli.Shell] == ["bash", "zsh", "fish"]
+    assert cli.Shell.BASH == "bash"
+
+
+def test_deprecated_completion_flag_keeps_stdout_evaluable():
+    """The notice must not land on stdout — the shell eval's it verbatim."""
+    runner = CliRunner()
+    result = runner.invoke(cli.breakfast, ["--completion", "bash"])
+    assert result.exit_code == 0
+    assert "_BREAKFAST_COMPLETE" in result.stdout
+    assert "deprecated" not in result.stdout
+    assert "deprecated" in result.stderr
+    assert "breakfast completions bash" in result.stderr
+
+
+def test_deprecated_completion_flag_is_hidden_from_help():
+    runner = CliRunner()
+    result = runner.invoke(cli.breakfast, ["--help"])
+    assert "--completion" not in result.stdout
+    assert "completions" in result.stdout
 
 
 # ---------------------------------------------------------------------------
@@ -4760,3 +4781,82 @@ def test_help_shows_credit_line():
     result = runner.invoke(cli.breakfast, ["--help"])
     assert result.exit_code == 0
     assert "Made with ❤️ in the UK" in result.stdout
+
+
+# ---------------------------------------------------------------------------
+# update (#416)
+# ---------------------------------------------------------------------------
+
+
+def _stub_update(monkeypatch, status, current="1.0.0", detail="2.0.0"):
+    monkeypatch.setattr(cli, "perform_update", lambda _path: (status, current, detail))
+    monkeypatch.setattr(cli, "_current_executable_path", lambda: "/tmp/breakfast")
+
+
+def test_update_reports_success(monkeypatch):
+    _stub_update(monkeypatch, cli.UpdateStatus.UPDATED)
+    result = CliRunner().invoke(cli.breakfast, ["update"])
+    assert result.exit_code == 0
+    assert "fresh batch is served — v2.0.0" in result.stderr
+    assert "install.sh" in result.stderr
+
+
+def test_update_reports_already_current(monkeypatch):
+    _stub_update(monkeypatch, cli.UpdateStatus.UP_TO_DATE)
+    result = CliRunner().invoke(cli.breakfast, ["update"])
+    assert result.exit_code == 0
+    assert "freshest batch, v1.0.0" in result.stderr
+
+
+def test_update_unreachable_github_fails_cleanly(monkeypatch):
+    _stub_update(monkeypatch, cli.UpdateStatus.UNKNOWN, detail=None)
+    result = CliRunner().invoke(cli.breakfast, ["update"])
+    assert result.exit_code != 0
+    assert "Could not reach GitHub" in result.stderr
+    assert "Traceback" not in result.output
+
+
+def test_update_error_surfaces_detail(monkeypatch):
+    _stub_update(monkeypatch, cli.UpdateStatus.ERROR, detail="Permission denied")
+    result = CliRunner().invoke(cli.breakfast, ["update"])
+    assert result.exit_code != 0
+    assert "Permission denied" in result.stderr
+    assert "Traceback" not in result.output
+
+
+def test_update_needs_no_github_token(monkeypatch):
+    """The group callback must not demand a token before dispatching."""
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "")
+    _stub_update(monkeypatch, cli.UpdateStatus.UP_TO_DATE)
+    result = CliRunner().invoke(cli.breakfast, ["update"])
+    assert result.exit_code == 0
+
+
+def test_update_does_not_also_fetch_pull_requests(monkeypatch):
+    """The subcommand guard must short-circuit before any GitHub work."""
+
+    def explode(*_args, **_kwargs):
+        raise AssertionError("the group callback body ran for a subcommand")
+
+    monkeypatch.setattr(cli, "get_github_prs", explode)
+    monkeypatch.setattr(cli, "check_for_update", explode)
+    _stub_update(monkeypatch, cli.UpdateStatus.UP_TO_DATE)
+    result = CliRunner().invoke(cli.breakfast, ["update"])
+    assert result.exit_code == 0
+
+
+def test_completions_does_not_also_fetch_pull_requests(monkeypatch):
+    def explode(*_args, **_kwargs):
+        raise AssertionError("the group callback body ran for a subcommand")
+
+    monkeypatch.setattr(cli, "get_github_prs", explode)
+    monkeypatch.setattr(cli, "check_for_update", explode)
+    result = CliRunner().invoke(cli.breakfast, ["completions", "bash"])
+    assert result.exit_code == 0
+
+
+def test_current_executable_path_is_absolute(monkeypatch):
+    monkeypatch.setattr(cli.shutil, "which", lambda _name: None)
+    monkeypatch.setattr(cli.sys, "argv", ["./breakfast"])
+    assert cli._current_executable_path().startswith("/")

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -348,3 +348,39 @@ def test_perform_update_permission_denied_reports_detail(installed_exe, monkeypa
         assert installed_exe.read_bytes() == b"old binary"
     finally:
         installed_exe.parent.chmod(0o755)
+
+
+def test_perform_update_refuses_to_overwrite_a_source_file(tmp_path, monkeypatch):
+    """`python -m breakfast.cli update` must not write a binary over cli.py."""
+    _pin_versions(monkeypatch, current="1.0.0", latest="2.0.0")
+    source = tmp_path / "cli.py"
+    source.write_text("# the actual source\n")
+    status, _current, detail = updater.perform_update(source)
+    assert status is UpdateStatus.ERROR
+    assert "source file" in detail
+    assert source.read_text() == "# the actual source\n"
+
+
+def test_perform_update_cleans_up_after_a_keyboard_interrupt(
+    installed_exe, monkeypatch
+):
+    """Ctrl-C mid-download must not strand a temp file next to the binary."""
+    _pin_versions(monkeypatch, current="1.0.0", latest="2.0.0")
+
+    class _Interrupting:
+        def __iter__(self):
+            yield b"partial"
+            raise KeyboardInterrupt
+
+    with req_mock.Mocker() as m:
+        m.get(updater._RELEASE_ASSET_URL, content=b"ignored")
+        # The 3-arg form, not the dotted-string form: breakfast wraps
+        # monkeypatch.setattr in an autouse fixture that only accepts it.
+        monkeypatch.setattr(
+            requests.Response, "iter_content", lambda self, **_kw: _Interrupting()
+        )
+        with pytest.raises(KeyboardInterrupt):
+            updater.perform_update(installed_exe)
+
+    assert installed_exe.read_bytes() == b"old binary"
+    assert [f.name for f in installed_exe.parent.iterdir()] == ["breakfast"]

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -2,9 +2,12 @@ import json
 from datetime import datetime, timezone
 from importlib.metadata import PackageNotFoundError
 
+import pytest
 import requests
+import requests_mock as req_mock
 
 from breakfast import updater, xdg
+from breakfast.updater import UpdateStatus
 
 
 def test_parse_version_tuple():
@@ -255,3 +258,93 @@ def test_get_cache_dir_xdg(tmp_path, monkeypatch):
 
     cache_dir = xdg.get_cache_dir()
     assert cache_dir == custom_path / "breakfast"
+
+
+# ---------------------------------------------------------------------------
+# perform_update (#416)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def installed_exe(tmp_path):
+    """A stand-in for the installed breakfast binary."""
+    exe = tmp_path / "bin" / "breakfast"
+    exe.parent.mkdir(parents=True)
+    exe.write_bytes(b"old binary")
+    exe.chmod(0o755)
+    return exe
+
+
+def _pin_versions(monkeypatch, current, latest):
+    monkeypatch.setattr(updater, "pkg_version", lambda _name: current)
+    monkeypatch.setattr(updater, "get_latest_version", lambda: latest)
+
+
+def test_perform_update_replaces_the_binary(installed_exe, monkeypatch):
+    _pin_versions(monkeypatch, current="1.0.0", latest="2.0.0")
+    with req_mock.Mocker() as m:
+        m.get(updater._RELEASE_ASSET_URL, content=b"new binary")
+        status, current, detail = updater.perform_update(installed_exe)
+    assert status is UpdateStatus.UPDATED
+    assert (current, detail) == ("1.0.0", "2.0.0")
+    assert installed_exe.read_bytes() == b"new binary"
+    assert installed_exe.stat().st_mode & 0o755 == 0o755
+    assert [f.name for f in installed_exe.parent.iterdir()] == ["breakfast"]
+
+
+def test_perform_update_already_current(installed_exe, monkeypatch):
+    _pin_versions(monkeypatch, current="2.0.0", latest="2.0.0")
+    status, current, detail = updater.perform_update(installed_exe)
+    assert status is UpdateStatus.UP_TO_DATE
+    assert (current, detail) == ("2.0.0", "2.0.0")
+    assert installed_exe.read_bytes() == b"old binary"
+
+
+def test_perform_update_unknown_when_latest_cannot_be_resolved(
+    installed_exe, monkeypatch
+):
+    _pin_versions(monkeypatch, current="1.0.0", latest=None)
+    status, _current, detail = updater.perform_update(installed_exe)
+    assert status is UpdateStatus.UNKNOWN
+    assert detail is None
+    assert installed_exe.read_bytes() == b"old binary"
+
+
+def test_perform_update_download_failure_leaves_binary_untouched(
+    installed_exe, monkeypatch
+):
+    _pin_versions(monkeypatch, current="1.0.0", latest="2.0.0")
+    with req_mock.Mocker() as m:
+        m.get(
+            updater._RELEASE_ASSET_URL,
+            exc=requests.exceptions.ConnectTimeout("boom"),
+        )
+        status, _current, detail = updater.perform_update(installed_exe)
+    assert status is UpdateStatus.ERROR
+    assert "boom" in detail
+    assert installed_exe.read_bytes() == b"old binary"
+    assert [f.name for f in installed_exe.parent.iterdir()] == ["breakfast"]
+
+
+def test_perform_update_http_error_leaves_binary_untouched(installed_exe, monkeypatch):
+    _pin_versions(monkeypatch, current="1.0.0", latest="2.0.0")
+    with req_mock.Mocker() as m:
+        m.get(updater._RELEASE_ASSET_URL, status_code=404)
+        status, _current, _detail = updater.perform_update(installed_exe)
+    assert status is UpdateStatus.ERROR
+    assert installed_exe.read_bytes() == b"old binary"
+
+
+def test_perform_update_permission_denied_reports_detail(installed_exe, monkeypatch):
+    """A make-installed binary under /usr/local/bin is not writable by the user."""
+    _pin_versions(monkeypatch, current="1.0.0", latest="2.0.0")
+    installed_exe.parent.chmod(0o555)
+    try:
+        with req_mock.Mocker() as m:
+            m.get(updater._RELEASE_ASSET_URL, content=b"new binary")
+            status, _current, detail = updater.perform_update(installed_exe)
+        assert status is UpdateStatus.ERROR
+        assert "Permission denied" in detail
+        assert installed_exe.read_bytes() == b"old binary"
+    finally:
+        installed_exe.parent.chmod(0o755)


### PR DESCRIPTION
## Issue

Closes #412
Closes #416

## Description

Brings breakfast up to parity with the self-update and installer work jeeves
landed in mrsixw/jeeves#113, and migrates shell completions from the
`--completion` flag to a `completions` subcommand — the spelling jeeves and
five-clis have both settled on.

The interesting part is that both new commands need breakfast to be a Click
**group**, which it was not: it was a single `@click.command` carrying ~60
options.

## Changes

- **Group conversion.** `@click.group(invoke_without_command=True)`, with every
  existing option staying on the group callback, so bare `breakfast` behaves
  exactly as before. The callback returns early for any subcommand — that guard
  matters, because the callback body *is* the program, so without it `breakfast
  completions bash` would fetch pull requests from GitHub before dispatching.
  Subcommands therefore work with no config file and no `GITHUB_TOKEN`.
- **`completions SHELL`** subcommand, driven by a new `Shell` StrEnum.
- **`--completion` kept for one release**, hidden and deprecated, per #412.
- **`update`** downloads the latest release and replaces the running executable
  atomically, returning an `UpdateStatus` enum from `perform_update`.
- **`install.sh` now says how to activate completions.** It already downloaded
  the files but never mentioned that this alone enables nothing: zsh needs the
  directory on `fpath` ahead of `compinit`, bash needs `bash-completion` or an
  explicit `source`. Only fish works untouched.
- Docs: `README.md`, `docs/manual/options.md`, and both the "Shell completions"
  and "Installer-managed completions" sections of `docs/manual/installation.md`.

## Notable decisions

**The deprecation notice goes to stderr, never stdout.** `--completion`'s stdout
is `eval`'d by the user's shell, so a notice landing there becomes a syntax error
at shell startup. Asserted both ways in the tests *and* in CI.

**`click.Choice` gets the enum's values, not the enum.** Click 8.3 matches enum
choices on member *names*, so `click.Choice(Shell)` would reject `bash` and
demand `BASH`. Verified against the pinned Click.

**Checked before converting** that no option uses `required=True` or `prompt=` —
Click enforces either ahead of subcommand dispatch, which would have broken
`breakfast update` with a spurious `UsageError`.

**The checked-in `completions/` scripts are byte-identical** after the group
conversion. They are thin shims that re-invoke the binary, which is also why
`update` does not need to refresh them. It does not refresh the man page either,
since that can need privileges; the success message points at `install.sh`.

## Review round

A cross-model review of the diff caught three real problems in the updater, fixed
in 056042f:

- `_current_executable_path()` resolved purely by name via `shutil.which`, so
  `./breakfast update` would have updated a *different* copy earlier on PATH, and
  `python -m breakfast.cli update` — an invocation CI actually uses — could have
  written a release binary over `cli.py`. Now prefers `argv[0]` when it names a
  real file, and `perform_update` refuses outright to write over a `.py` file.
- Temp-file cleanup moved to `finally`: neither `except` clause caught
  `KeyboardInterrupt`, so a Ctrl-C mid-download stranded a partial file.
- The download is wrapped in `with requests.get(...)`.

## Testing

- [x] `make test` passes — **556 passed**. All 537 pre-existing tests still green
      after the group conversion, which is the regression signal that matters here.
- [x] `make lint` passes (`ruff check` + `black --check` clean)
- [x] New tests: `completions` per shell, unknown shell rejected, no-token case,
      `Shell` values, deprecated flag's stdout/stderr split, flag hidden from
      `--help`, `update` for each `UpdateStatus`, subcommands proven not to reach
      GitHub, absolute path resolution, source-file refusal, Ctrl-C cleanup, and
      the full `perform_update` matrix
- [x] `bash -n install.sh`; activation block executed under `SHELL` = bash, zsh,
      fish and empty — correct branch each time
- [x] By hand: bare `breakfast` still fetches PRs; `--help` lists all options plus
      the new `Commands:` section; `breakfast --completion bash 2>/dev/null` is a
      clean `eval`-able script; `completions`/`update` work with no token
- [x] `make completions` regenerated — no diff, as expected

## Notes

This PR closes two issues (#412 and #416), departing from the one-issue-one-PR
rule. They land together because the group conversion is a prerequisite for both
and splitting it would leave an intermediate state where `update` exists with
nowhere to hang. Called out so it is a visible choice rather than an oversight.

Follow-ups filed, not actioned here:
- #417 — remove the deprecated `--completion` flag once a release has shipped
  with both spellings. Filed now deliberately: #412 asks for it, and a
  deprecation window with no removal issue behind it tends to become permanent.
- mrsixw/jeeves#114 — adopt the same `Shell` enum and absolute-path fix in jeeves.

Deliberately **not** touched: #391 (installer API rate limits), #396 (macOS CLT
Python).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
