### PR TITLE
#387: Validate numeric options instead of crashing or silently dropping rows

### DIFF
--- a/docs/manual/options.md
+++ b/docs/manual/options.md
@@ -223,7 +223,7 @@ breakfast -o my-org --exclude-label wip --exclude-label blocked
 
 ### `--filter-stale`
 
-Only show PRs that have been open for more than N days (based on creation date). Pairs naturally with `--age` to see the age column.
+Only show PRs that have been open for more than N days (based on creation date). Pairs naturally with `--age` to see the age column. N must be `0` or greater.
 
 ```bash
 breakfast -o my-org --filter-stale 14         # PRs open for more than 14 days
@@ -232,7 +232,7 @@ breakfast -o my-org --filter-stale 30 --age   # stale PRs with age column visibl
 
 ### `--filter-inactive`
 
-Only show PRs that have not been updated in the last N days. Useful for surfacing PRs that need a nudge.
+Only show PRs that have not been updated in the last N days. Useful for surfacing PRs that need a nudge. N must be `0` or greater.
 
 ```bash
 breakfast -o my-org --filter-inactive 7       # not updated in the last 7 days
@@ -716,7 +716,7 @@ Auto-fit is a no-op when output is piped or redirected (not a TTY), so `--json` 
 
 ### `--limit`
 
-Cap the number of PRs displayed. Results are limited after all filtering is applied. There is no config file equivalent — this is intentionally a CLI-only flag.
+Cap the number of PRs displayed. Results are limited after all filtering is applied. Must be `1` or greater; zero and negative values are rejected with a usage error. There is no config file equivalent — this is intentionally a CLI-only flag.
 
 ```bash
 breakfast -o my-org -r my-app --limit 10
@@ -724,7 +724,7 @@ breakfast -o my-org -r my-app --limit 10
 
 ### `--max-title-length`
 
-Truncate PR titles to a maximum number of characters. Titles longer than the limit are cut and suffixed with `…`. When unset, titles are displayed in full.
+Truncate PR titles to a maximum number of characters. Titles longer than the limit are cut and suffixed with `…`. When unset, titles are displayed in full. Must be `1` or greater, whether set on the CLI or in the config file.
 
 ```bash
 breakfast -o my-org -r my-app --max-title-length 72
@@ -879,6 +879,8 @@ When `columns` is set in config, it controls the table layout for all runs. CLI 
 ### `--workers`
 
 Number of parallel workers used to fetch PR details, check statuses, and approval statuses. Defaults to `64`. Lower values reduce API concurrency (useful if you're hitting rate limits); higher values may speed things up on very large organisations.
+
+Must be `1` or greater. A value of `0` or less is rejected up front with a clear error, whether it comes from the CLI flag or the `workers` config key.
 
 ```bash
 breakfast -o my-org -r my-app --workers 16

--- a/docs/manual/options.md
+++ b/docs/manual/options.md
@@ -880,7 +880,7 @@ When `columns` is set in config, it controls the table layout for all runs. CLI 
 
 Number of parallel workers used to fetch PR details, check statuses, and approval statuses. Defaults to `64`. Lower values reduce API concurrency (useful if you're hitting rate limits); higher values may speed things up on very large organisations.
 
-Must be `1` or greater. A value of `0` or less is rejected up front with a clear error, whether it comes from the CLI flag or the `workers` config key.
+Must be a whole number of `1` or greater. Anything else — `0`, a negative, or a fractional value like `3.5` — is rejected up front with a clear error, whether it comes from the CLI flag or the `workers` config key.
 
 ```bash
 breakfast -o my-org -r my-app --workers 16

--- a/src/breakfast/cli.py
+++ b/src/breakfast/cli.py
@@ -137,6 +137,8 @@ def _require_positive_int(value, key, colour):
     """
     if isinstance(value, bool):
         parsed = None  # TOML booleans coerce to 0/1; that is never intentional here.
+    elif isinstance(value, float) and not value.is_integer():
+        parsed = None  # Reject 3.5 rather than silently running with 3.
     else:
         try:
             parsed = int(value)

--- a/src/breakfast/cli.py
+++ b/src/breakfast/cli.py
@@ -118,6 +118,41 @@ def _stdout_is_tty():
     return sys.stdout.isatty()
 
 
+def _require_positive_int(value, key, colour):
+    """Validate a config-sourced integer that must be 1 or greater.
+
+    Click's IntRange guards the command-line flags, but config keys are read
+    straight from TOML and bypass it entirely, so they need the same check.
+
+    Args:
+        value: The raw value read from the config file.
+        key: The config key name, used in the error message.
+        colour: Whether to colourise the error output.
+
+    Returns:
+        The value as an int.
+
+    Raises:
+        SystemExit: If the value is not an integer of 1 or greater.
+    """
+    if isinstance(value, bool):
+        parsed = None  # TOML booleans coerce to 0/1; that is never intentional here.
+    else:
+        try:
+            parsed = int(value)
+        except (TypeError, ValueError):
+            parsed = None
+    if parsed is None or parsed < 1:
+        logger.error("invalid_config_value key=%s value=%r", key, value)
+        msg = (
+            f"Error: invalid {key} value in config: {value!r}."
+            " Must be a whole number of 1 or greater."
+        )
+        click.echo(click.style(msg, fg="red", bold=True), err=True, color=colour)
+        sys.exit(1)
+    return parsed
+
+
 def _handle_rate_limit(exc, json_output=False):
     """Print a friendly rate-limit message and exit non-zero."""
     click.echo(
@@ -554,19 +589,19 @@ def _fetch_pr_bundle(url, fetch_checks, fetch_approvals):
 )
 @click.option(
     "--limit",
-    type=int,
+    type=click.IntRange(min=1),
     default=None,
     help="Cap the number of PRs shown. Unset means show all results.",
 )
 @click.option(
     "--workers",
-    type=int,
+    type=click.IntRange(min=1),
     default=None,
     help="Number of parallel workers for fetching PR data. Default: 64.",
 )
 @click.option(
     "--max-title-length",
-    type=int,
+    type=click.IntRange(min=1),
     default=None,
     help="Truncate PR titles to this many characters. Unset means no truncation.",
 )
@@ -685,13 +720,13 @@ def _fetch_pr_bundle(url, fetch_checks, fetch_approvals):
 )
 @click.option(
     "--filter-stale",
-    type=int,
+    type=click.IntRange(min=0),
     default=None,
     help="Only show PRs older than N days (by creation date).",
 )
 @click.option(
     "--filter-inactive",
-    type=int,
+    type=click.IntRange(min=0),
     default=None,
     help="Only show PRs not updated in the last N days.",
 )
@@ -1065,6 +1100,15 @@ def breakfast(
     api_stats = api_stats or cfg.get("api-stats", False)
     no_colour = no_colour or cfg.get("no-colour", False)
     colour = not no_colour
+
+    # Click's IntRange has already vetted any command-line values; these config
+    # keys bypass Click, so validate them before they reach ThreadPoolExecutor
+    # and the title truncation maths.
+    workers = _require_positive_int(workers, "workers", colour)
+    if max_title_length is not None:
+        max_title_length = _require_positive_int(
+            max_title_length, "max-title-length", colour
+        )
     seasonal_colours = cfg.get("seasonal-colours", True)
     seasonal_calendar = cfg.get("seasonal-calendar", "western")
     if not seasonal_colours:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4860,3 +4860,122 @@ def test_current_executable_path_is_absolute(monkeypatch):
     monkeypatch.setattr(cli.shutil, "which", lambda _name: None)
     monkeypatch.setattr(cli.sys, "argv", ["./breakfast"])
     assert cli._current_executable_path().startswith("/")
+
+
+# --- Numeric option validation (issue #387) ---------------------------------
+
+
+@pytest.mark.parametrize(
+    "flag,value",
+    [
+        ("--workers", "0"),
+        ("--workers", "-4"),
+        ("--limit", "0"),
+        ("--limit", "-1"),
+        ("--max-title-length", "0"),
+        ("--max-title-length", "-20"),
+        ("--filter-stale", "-1"),
+        ("--filter-inactive", "-7"),
+    ],
+)
+def test_out_of_range_numeric_options_are_rejected(monkeypatch, flag, value):
+    """Out-of-range integers fail as usage errors, never as tracebacks."""
+    monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
+
+    def explode(*_args, **_kwargs):
+        raise AssertionError("validation must reject the value before fetching")
+
+    monkeypatch.setattr(cli, "get_github_prs", explode)
+
+    result = CliRunner().invoke(cli.breakfast, ["-o", "org", "-r", "repo", flag, value])
+
+    assert result.exit_code == 2
+    assert "Traceback" not in result.output
+    assert flag in result.stderr
+    assert result.stdout == ""
+
+
+@pytest.mark.parametrize("bad_value", [0, -1, "many", True])
+def test_config_workers_out_of_range_is_rejected(monkeypatch, bad_value):
+    """The workers config key bypasses Click, so it needs its own guard."""
+    monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
+    monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
+    monkeypatch.setattr(cli, "load_config", lambda _: {"workers": bad_value})
+
+    def explode(*_args, **_kwargs):
+        raise AssertionError("validation must reject the value before fetching")
+
+    monkeypatch.setattr(cli, "get_github_prs", explode)
+
+    result = CliRunner().invoke(cli.breakfast, ["-o", "org", "-r", "repo"])
+
+    assert result.exit_code == 1
+    assert "Traceback" not in result.output
+    assert "workers" in result.stderr
+    assert result.stdout == ""
+
+
+def test_config_max_title_length_out_of_range_is_rejected(monkeypatch):
+    monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
+    monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
+    monkeypatch.setattr(cli, "load_config", lambda _: {"max-title-length": -5})
+
+    result = CliRunner().invoke(cli.breakfast, ["-o", "org", "-r", "repo"])
+
+    assert result.exit_code == 1
+    assert "max-title-length" in result.stderr
+    assert "Traceback" not in result.output
+
+
+def test_valid_numeric_options_still_work(monkeypatch):
+    """The happy path is untouched: in-range values behave exactly as before."""
+    monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
+    monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
+    monkeypatch.setattr(cli, "load_config", lambda _: {})
+    monkeypatch.setattr(
+        cli,
+        "get_github_prs",
+        lambda *a: ["https://api.github.com/repos/org/repo/pulls/1"],
+    )
+    monkeypatch.setattr(
+        cli, "_fetch_pr_bundle", lambda *a, **kw: (_make_pr_detail(1), None, None)
+    )
+
+    result = CliRunner().invoke(
+        cli.breakfast,
+        [
+            "-o",
+            "org",
+            "-r",
+            "repo",
+            "--workers",
+            "1",
+            "--limit",
+            "1",
+            "--max-title-length",
+            "10",
+            "--filter-stale",
+            "0",
+        ],
+    )
+
+    assert result.exit_code == 0
+
+
+def test_config_workers_default_is_used_when_unset(monkeypatch):
+    """An absent workers key must still resolve to the documented default."""
+    monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
+    monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
+    monkeypatch.setattr(cli, "load_config", lambda _: {})
+    monkeypatch.setattr(cli, "get_github_prs", lambda *a: [])
+
+    result = CliRunner().invoke(
+        cli.breakfast, ["-o", "org", "-r", "repo", "--show-config"]
+    )
+
+    assert result.exit_code == 0
+    assert "workers: 64" in result.stdout

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4979,3 +4979,34 @@ def test_config_workers_default_is_used_when_unset(monkeypatch):
 
     assert result.exit_code == 0
     assert "workers: 64" in result.stdout
+
+
+@pytest.mark.parametrize("bad_value", [3.5, -0.5, "3.5"])
+def test_config_workers_rejects_non_integral_values(monkeypatch, bad_value):
+    """workers = 3.5 must not be silently truncated to 3."""
+    monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
+    monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
+    monkeypatch.setattr(cli, "load_config", lambda _: {"workers": bad_value})
+
+    result = CliRunner().invoke(cli.breakfast, ["-o", "org", "-r", "repo"])
+
+    assert result.exit_code == 1
+    assert "workers" in result.stderr
+    assert "Traceback" not in result.output
+
+
+def test_config_workers_accepts_an_integral_string(monkeypatch):
+    """A quoted whole number in TOML keeps working — no gratuitous breakage."""
+    monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
+    monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
+    monkeypatch.setattr(cli, "load_config", lambda _: {"workers": "8"})
+    monkeypatch.setattr(cli, "get_github_prs", lambda *a: [])
+
+    result = CliRunner().invoke(
+        cli.breakfast, ["-o", "org", "-r", "repo", "--show-config"]
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "workers: 8" in result.stdout


### PR DESCRIPTION
## Summary

- **Reject out-of-range numeric input at the boundary**: `--workers 0` used to reach `ThreadPoolExecutor` and raise `ValueError: max_workers must be greater than 0` as a raw traceback — and only once there was work to fetch, so on a cache hit it didn't fire at all and the crash looked intermittent. Negative `--limit` was worse than a crash: `pr_details[:-1]` silently dropped the *last* row, and `--limit -999` showed nothing, with no indication anything had been discarded.
- **Key Changes**:
  - `src/breakfast/cli.py` — `--workers`, `--limit` and `--max-title-length` are now `click.IntRange(min=1)`; `--filter-stale` and `--filter-inactive` are `click.IntRange(min=0)` (zero days is meaningful there, negative is not).
  - `src/breakfast/cli.py` — new `_require_positive_int(value, key, colour)` helper. Config keys are read straight from TOML and never pass through Click, so `workers = 0` in a config file bypassed the range check entirely. It guards the `workers` and `max-title-length` config values, mirroring the existing `--cache-ttl` error style (red, bold, stderr, exit 1).
  - Booleans are rejected explicitly (`workers = true` would otherwise coerce to `1`), and fractional values are rejected rather than truncated (`workers = 3.5` silently became `3` while the message promised a whole number). Integral strings like `workers = "8"` still work — no gratuitous breakage for anyone who quoted the number.
  - `docs/manual/options.md` — documents the valid range for each option.
- **Abstractions & Design Decisions**: Click's `IntRange` does the work wherever Click is in the path, and the helper exists only for the config route that Click cannot see. Validating the *resolved* value means a CLI-sourced number can never reach the helper (Click rejects it first with its own exit-2 usage error), so the "in config" wording in the message is always accurate.

> **Note on `--limit 0`:** previously accepted, showing nothing. It is now a usage error, on the grounds that "unset means show all" makes `0` meaningless rather than useful. Flagging it as the one behaviour change here that isn't strictly a bug fix.

## Test plan

- [x] `make format && make lint && make test` passes — 575 tests green. (`make lint`'s `docs-lint` step needs `npx`, which isn't installed on this machine; `ruff check` and `black --check` both pass locally and CI covers the markdown lint.)
- [x] **Tests written test-first and confirmed red before the fix** — 13 of them failed against the unfixed source:
  - `test_out_of_range_numeric_options_are_rejected` — parametrised over all five flags, asserts exit 2, no traceback, empty stdout, and that fetching never starts.
  - `test_config_workers_out_of_range_is_rejected` — `0`, `-1`, `"many"` and `True` from config.
  - `test_config_max_title_length_out_of_range_is_rejected`.
  - `test_config_workers_rejects_non_integral_values` — `3.5` must not become `3`.
  - `test_config_workers_accepts_an_integral_string` — regression guard for `workers = "8"`.
  - `test_valid_numeric_options_still_work`, `test_config_workers_default_is_used_when_unset` — happy-path guards.
- [x] **Manual Verification / Smoke Test**:
  - `--workers 0`, `--limit -1`, `--max-title-length -20`, `--filter-stale -3` all produce Click range errors, exit 2, no traceback.
  - Config files with `workers = 0` and `max-title-length = -5` produce red stderr errors and exit 1; `workers = 8` resolves normally.
  - Real end-to-end runs against a live org with valid values, both `--cache` and `--no-cache`, render correctly.

Closes #387

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WfzZjnuj2iddq5mDsCxeSW