### PR TITLE
#386: Resolve NO_COLOR and BREAKFAST_NO_UPDATE_CHECK by presence, not value

### DIFF
--- a/docs/manual/options.md
+++ b/docs/manual/options.md
@@ -1013,6 +1013,8 @@ breakfast -o my-org -r my-app --no-update-check
 export BREAKFAST_NO_UPDATE_CHECK=1
 ```
 
+Like `NO_COLOR`, `BREAKFAST_NO_UPDATE_CHECK` is resolved by presence: any non-empty value disables the update check, and only unset or empty leaves it enabled.
+
 ## Colour control
 
 ### `--no-colour` / `--no-color`
@@ -1028,6 +1030,13 @@ The `NO_COLOR` environment variable is also honoured (see [no-color.org](https:/
 
 ```bash
 NO_COLOR=1 breakfast -o my-org -r my-app
+```
+
+Following the spec, `NO_COLOR` is resolved by **presence, not value**: any non-empty value disables colour, whatever it says. `NO_COLOR=0`, `NO_COLOR=false` and `NO_COLOR=nonsense` all disable colour just as `NO_COLOR=1` does — the variable's content is deliberately ignored. Only leaving it unset, or setting it to the empty string, keeps colour on:
+
+```bash
+NO_COLOR= breakfast -o my-org -r my-app     # empty: colour stays enabled
+unset NO_COLOR                              # unset: colour stays enabled
 ```
 
 Can also be set persistently in config:

--- a/src/breakfast/cli.py
+++ b/src/breakfast/cli.py
@@ -118,6 +118,24 @@ def _stdout_is_tty():
     return sys.stdout.isatty()
 
 
+def _env_flag_is_set(name):
+    """Report whether an environment variable is set to any non-empty value.
+
+    This is the no-color.org convention: presence is the signal, and the value
+    is deliberately ignored, so `NO_COLOR=0` and `NO_COLOR=false` disable
+    colour just as `NO_COLOR=1` does. Click's `envvar=` on a boolean flag
+    cannot express this — it rejects unrecognised values outright and reads
+    `false` as "leave colour on", the opposite of the spec.
+
+    Args:
+        name: The environment variable to inspect.
+
+    Returns:
+        True if the variable is set to a non-empty value.
+    """
+    return bool(os.environ.get(name))
+
+
 def _require_positive_int(value, key, colour):
     """Validate a config-sourced integer that must be 1 or greater.
 
@@ -611,8 +629,14 @@ def _fetch_pr_bundle(url, fetch_checks, fetch_approvals):
     "--no-update-check",
     is_flag=True,
     default=False,
-    envvar="BREAKFAST_NO_UPDATE_CHECK",
-    help="Disable the automatic update check.",
+    # No envvar= here: Click would route BREAKFAST_NO_UPDATE_CHECK through its
+    # BOOL converter, so unrecognised values abort the run. Resolved by
+    # presence in the callback instead — see _env_flag_is_set.
+    help=(
+        "Disable the automatic update check."
+        " Also honoured via the BREAKFAST_NO_UPDATE_CHECK environment"
+        " variable, set to any non-empty value."
+    ),
 )
 @click.option(
     "--offline",
@@ -793,10 +817,12 @@ def _fetch_pr_bundle(url, fetch_checks, fetch_approvals):
     "no_colour",
     is_flag=True,
     default=False,
-    envvar="NO_COLOR",
+    # No envvar= here — see the note on --no-update-check. no-color.org
+    # requires presence semantics, which Click's BOOL conversion cannot express.
     help=(
         "Disable ANSI colour in all output."
-        " Also honoured via the NO_COLOR environment variable (no-color.org)."
+        " Also honoured via the NO_COLOR environment variable (no-color.org),"
+        " set to any non-empty value."
     ),
 )
 @click.option(
@@ -903,6 +929,12 @@ def breakfast(
     # GITHUB_TOKEN, so return before any of the validation below.
     if ctx.invoked_subcommand is not None:
         return
+
+    # Resolved by presence, not by parsing: see _env_flag_is_set. This runs
+    # before the first use of no_colour below, and composes with the config
+    # fallback further down.
+    no_colour = no_colour or _env_flag_is_set("NO_COLOR")
+    no_update_check = no_update_check or _env_flag_is_set("BREAKFAST_NO_UPDATE_CHECK")
 
     if completion_shell:
         click.echo(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5010,3 +5010,103 @@ def test_config_workers_accepts_an_integral_string(monkeypatch):
 
     assert result.exit_code == 0, result.output
     assert "workers: 8" in result.stdout
+
+
+# --- NO_COLOR / BREAKFAST_NO_UPDATE_CHECK presence semantics (issue #386) ----
+
+
+def _colour_probe(monkeypatch):
+    """Stub out a minimal run and report the resolved colour setting."""
+    monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
+    monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
+    monkeypatch.setattr(cli, "load_config", lambda _: {})
+    monkeypatch.setattr(cli, "get_github_prs", lambda *a: [])
+
+
+@pytest.mark.parametrize(
+    "value", ["nonsense", "1", "false", "0", "no", "off", "please"]
+)
+def test_no_color_any_non_empty_value_disables_colour(monkeypatch, value):
+    """no-color.org: any non-empty value disables colour, and never errors."""
+    _colour_probe(monkeypatch)
+    monkeypatch.setenv("NO_COLOR", value)
+
+    result = CliRunner().invoke(
+        cli.breakfast, ["-o", "org", "-r", "repo", "--show-config"]
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "no-colour: True" in result.stdout
+
+
+def test_no_color_empty_value_leaves_colour_enabled(monkeypatch):
+    """An empty NO_COLOR is explicitly *not* a request to disable colour."""
+    _colour_probe(monkeypatch)
+    monkeypatch.setenv("NO_COLOR", "")
+
+    result = CliRunner().invoke(
+        cli.breakfast, ["-o", "org", "-r", "repo", "--show-config"]
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "no-colour: False" in result.stdout
+
+
+def test_no_color_unset_leaves_colour_enabled(monkeypatch):
+    _colour_probe(monkeypatch)
+    monkeypatch.delenv("NO_COLOR", raising=False)
+
+    result = CliRunner().invoke(
+        cli.breakfast, ["-o", "org", "-r", "repo", "--show-config"]
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "no-colour: False" in result.stdout
+
+
+def test_no_colour_flag_still_disables_colour(monkeypatch):
+    """The explicit flag keeps working with no environment variable set."""
+    _colour_probe(monkeypatch)
+    monkeypatch.delenv("NO_COLOR", raising=False)
+
+    result = CliRunner().invoke(
+        cli.breakfast, ["-o", "org", "-r", "repo", "--no-colour", "--show-config"]
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "no-colour: True" in result.stdout
+
+
+@pytest.mark.parametrize("value", ["anything", "1", "false", "off", "please"])
+def test_no_update_check_env_any_non_empty_value_disables_check(monkeypatch, value):
+    """BREAKFAST_NO_UPDATE_CHECK follows the same presence-based semantics."""
+    monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
+    monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
+    monkeypatch.setattr(cli, "load_config", lambda _: {})
+    monkeypatch.setattr(cli, "get_github_prs", lambda *a: [])
+    monkeypatch.setenv("BREAKFAST_NO_UPDATE_CHECK", value)
+
+    checked = []
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: checked.append(1))
+
+    result = CliRunner().invoke(cli.breakfast, ["-o", "org", "-r", "repo"])
+
+    assert result.exit_code == 0, result.output
+    assert checked == [], f"NO_UPDATE_CHECK={value!r} should suppress the check"
+
+
+def test_no_update_check_env_empty_leaves_check_enabled(monkeypatch):
+    monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
+    monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
+    monkeypatch.setattr(cli, "load_config", lambda _: {})
+    monkeypatch.setattr(cli, "get_github_prs", lambda *a: [])
+    monkeypatch.setenv("BREAKFAST_NO_UPDATE_CHECK", "")
+
+    checked = []
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: checked.append(1))
+
+    result = CliRunner().invoke(cli.breakfast, ["-o", "org", "-r", "repo"])
+
+    assert result.exit_code == 0, result.output
+    assert checked == [1], "an empty value must not suppress the update check"


### PR DESCRIPTION
> **Stacked on #420 (issue #387).** Base is `issue-387_validate_numeric_options`; the diff to review is the top commit. Rebase onto `main` once #420 merges.

## Summary

- **Honour the no-color.org convention the help text already cites**: `--no-colour` was wired to `NO_COLOR` via Click's `envvar=`, which routes the raw string through Click's BOOL converter. Two distinct failures came out of that:
  - `NO_COLOR=nonsense breakfast -o my-org` aborted the whole program with a usage error and exit 2. Users export all sorts of values; none of them should stop the tool running.
  - `NO_COLOR=false` and `NO_COLOR=0` parsed as boolean false and **kept colour on** — the exact opposite of the spec, which says the value is irrelevant.
- `BREAKFAST_NO_UPDATE_CHECK` on `--no-update-check` had the identical defect.
- **Key Changes**:
  - `src/breakfast/cli.py` — dropped `envvar=` from both options and added `_env_flag_is_set(name)`, which reports whether a variable is set to any non-empty value.
  - Both flags are resolved in the group callback (`no_colour or _env_flag_is_set("NO_COLOR")`), placed before the first use of `no_colour` and composing with the existing `cfg.get("no-colour", False)` fallback further down.
  - Help text for both options now states that any non-empty value works.
  - `docs/manual/options.md` — spells out presence-based semantics and that `0`/`false`/`nonsense` all disable colour, while unset or empty leaves it on.
- **Abstractions & Design Decisions**: Presence semantics simply cannot be expressed through a type converter — the converter's job is to interpret the value, and the spec's whole point is that the value carries no meaning. Resolving manually is the only correct option here.

**On empty values:** unset and empty-string leave colour enabled. That follows no-color.org's "present and *not an empty string*" wording and the acceptance criteria on #386, and is covered by a test — worth stating explicitly since it's easy to assume "presence" means bare presence.

**Observed while here, not fixed:** the `update` and `completions` subcommands don't honour `NO_COLOR` at all — they call `click.style()` directly and never receive the resolved flag. That predates this change and is out of scope; happy to raise it separately if you want it.

## Test plan

- [x] `make format && make lint && make test` passes — 591 tests green. (`docs-lint` needs `npx`, not installed locally; ruff and black pass, CI covers the rest.)
- [x] **Tests written test-first and confirmed red before the fix** — 10 failed against the unfixed source, reproducing *both* halves of the bug (usage errors on arbitrary values, and `false`/`0` wrongly enabling colour):
  - `test_no_color_any_non_empty_value_disables_colour` — parametrised over `nonsense`, `1`, `false`, `0`, `no`, `off`, `please`.
  - `test_no_color_empty_value_leaves_colour_enabled`, `test_no_color_unset_leaves_colour_enabled`.
  - `test_no_colour_flag_still_disables_colour` — the explicit flag keeps working.
  - `test_no_update_check_env_any_non_empty_value_disables_check` and `..._empty_leaves_check_enabled` — asserts on whether `check_for_update` was actually called, not just on the resolved flag.
- [x] **Manual Verification / Smoke Test**: real runs with `NO_COLOR` set to `nonsense`, `false`, `0` and empty — all exit 0, with `--show-config` confirming the resolved value each time. Also verified `breakfast completions bash` and `breakfast update` now exit 0 under `NO_COLOR=nonsense` where they exited 2 on `main`, so subcommands get *less* broken, not more.

Closes #386

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WfzZjnuj2iddq5mDsCxeSW