### PR TITLE
#428: Handle expired GitHub tokens without a traceback

### DIFF
--- a/docs/manual/troubleshooting.md
+++ b/docs/manual/troubleshooting.md
@@ -12,6 +12,24 @@ breakfast reads `GH_TOKEN` first (the variable used by the [`gh` CLI](https://cl
 
 The token needs `repo` scope to access pull request data. Generate one at [github.com/settings/tokens](https://github.com/settings/tokens).
 
+## "GitHub authentication failed: ... was rejected (HTTP 401)..."
+
+If breakfast exits with an error such as:
+
+```text
+🍳 GitHub authentication failed: GITHUB_TOKEN was rejected (HTTP 401). Refresh or replace the token and try again.
+```
+
+Your GitHub personal access token is invalid, revoked, or has expired.
+
+- Check your personal access tokens at [github.com/settings/tokens](https://github.com/settings/tokens) (or [github.com/settings/personal-access-tokens](https://github.com/settings/personal-access-tokens) for fine-grained tokens) and generate a new token if it has expired.
+- Update your environment variable (`export GH_TOKEN="ghp_..."` or `export GITHUB_TOKEN="ghp_..."`). Note that an exported `GH_TOKEN` or `GITHUB_TOKEN` takes precedence over stored credentials managed by `gh auth refresh`.
+- Verify authentication manually:
+
+```bash
+curl -H "Authorization: Bearer ${GH_TOKEN:-$GITHUB_TOKEN}" https://api.github.com/user
+```
+
 ## No PRs displayed
 
 - Verify the owner name is correct (`-o` / `--owner`)

--- a/src/breakfast/api.py
+++ b/src/breakfast/api.py
@@ -17,12 +17,24 @@ GITHUB_API_URL = "https://api.github.com"
 GITHUB_GRAPHQL_URL = "https://api.github.com/graphql"
 
 
+def _resolve_github_token_info():
+    """Resolve the GitHub auth token and variable name, preferring GH_TOKEN."""
+    gh_token = os.getenv("GH_TOKEN")
+    if gh_token:
+        return gh_token, "GH_TOKEN"
+    github_token = os.getenv("GITHUB_TOKEN")
+    if github_token:
+        return github_token, "GITHUB_TOKEN"
+    return None, None
+
+
 def _resolve_github_token():
     """Resolve the GitHub auth token, preferring GH_TOKEN (gh CLI convention)."""
-    return os.getenv("GH_TOKEN") or os.getenv("GITHUB_TOKEN")
+    token, _ = _resolve_github_token_info()
+    return token
 
 
-SECRET_GITHUB_TOKEN = _resolve_github_token()
+SECRET_GITHUB_TOKEN, SECRET_GITHUB_TOKEN_VAR = _resolve_github_token_info()
 
 _MAX_GRAPHQL_ERROR_TYPES = 3
 _MAX_GRAPHQL_ERROR_MESSAGE_LENGTH = 120
@@ -112,6 +124,26 @@ class OwnerNotFoundError(Exception):
         )
 
 
+class GitHubAuthenticationError(requests.exceptions.HTTPError):
+    """Raised when GitHub API authentication fails (HTTP 401).
+
+    Attributes:
+        token_var: The name of the environment variable used for auth.
+    """
+
+    def __init__(self, message=None, token_var=None, response=None):
+        if token_var is None:
+            _, resolved_var = _resolve_github_token_info()
+            token_var = resolved_var or "GITHUB_TOKEN"
+        self.token_var = token_var
+        if not message:
+            message = (
+                f"GitHub authentication failed: {token_var} was rejected (HTTP 401). "
+                "Refresh or replace the token and try again."
+            )
+        super().__init__(message, response=response)
+
+
 _MAX_RETRIES = 3
 _RETRY_STATUSES = {502, 503, 504}
 _REQUEST_TIMEOUT = (5, 30)
@@ -174,6 +206,15 @@ def make_github_api_request(query_string):
                     attempt + 1,
                 )
                 continue
+            if req.status_code == 401:
+                _, token_var = _resolve_github_token_info()
+                token_var = token_var or "GITHUB_TOKEN"
+                logger.warning(
+                    "api_call type=rest url=%s auth_failed status=401 token_var=%s",
+                    url,
+                    token_var,
+                )
+                raise GitHubAuthenticationError(token_var=token_var, response=req)
             if (
                 req.status_code == 403
                 and req.headers.get("X-RateLimit-Remaining") == "0"
@@ -283,6 +324,14 @@ def make_github_graphql_request(query, variables=None):
                     attempt + 1,
                 )
                 continue
+            if response.status_code == 401:
+                _, token_var = _resolve_github_token_info()
+                token_var = token_var or "GITHUB_TOKEN"
+                logger.warning(
+                    "api_call type=graphql auth_failed status=401 token_var=%s",
+                    token_var,
+                )
+                raise GitHubAuthenticationError(token_var=token_var, response=response)
             response.raise_for_status()
             resp_json = response.json()
             if "errors" in resp_json:

--- a/src/breakfast/cli.py
+++ b/src/breakfast/cli.py
@@ -14,6 +14,7 @@ import requests
 
 from .api import (
     SECRET_GITHUB_TOKEN,
+    GitHubAuthenticationError,
     GitHubGraphQLError,
     GitHubGraphQLResourceLimitError,
     GitHubRateLimitError,
@@ -178,6 +179,16 @@ def _handle_rate_limit(exc, json_output=False):
     click.echo(
         click.style(f"🥞 {exc}", fg="red", bold=True),
         err=True,
+    )
+    sys.exit(1)
+
+
+def _handle_auth_error(exc, colour=None, json_output=False):
+    """Print a friendly authentication error message and exit non-zero."""
+    click.echo(
+        click.style(f"🍳 {exc}", fg="red", bold=True),
+        err=True,
+        color=colour,
     )
     sys.exit(1)
 
@@ -1303,6 +1314,8 @@ def breakfast(
             try:
                 current_user_login = get_authenticated_user_login()
                 write_cached_user_login(current_user_login)
+            except GitHubAuthenticationError as exc:
+                _handle_auth_error(exc, colour=colour, json_output=json_output)
             except GitHubRateLimitError as exc:
                 _handle_rate_limit(exc, json_output)
             except (requests.exceptions.ConnectionError, requests.exceptions.Timeout):
@@ -1518,6 +1531,12 @@ def breakfast(
                                 nl=False,
                                 err=True,
                             )
+                        except GitHubAuthenticationError as exc:
+                            executor.shutdown(wait=False, cancel_futures=True)
+                            click.echo("", err=True)
+                            _handle_auth_error(
+                                exc, colour=colour, json_output=json_output
+                            )
                         except GitHubRateLimitError as exc:
                             click.echo("", err=True)
                             _handle_rate_limit(exc, json_output)
@@ -1564,6 +1583,9 @@ def breakfast(
             if cache_enabled:
                 needs_cache_write = True
 
+        except GitHubAuthenticationError as exc:
+            click.echo("", err=True)
+            _handle_auth_error(exc, colour=colour, json_output=json_output)
         except GitHubGraphQLResourceLimitError as exc:
             logger.warning(
                 "graphql_resource_limit_unrecoverable error_count=%d errors=%s",

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1298,6 +1298,96 @@ def test_make_github_api_request_403_without_rate_limit_header_raises_http_error
         api.make_github_api_request("/user")
 
 
+def _make_auth_error_response():
+    """Return a fake requests.Response that looks like an HTTP 401 Unauthorized."""
+
+    class FakeUnauthorized:
+        status_code = 401
+        headers = {}
+
+        def raise_for_status(self):
+            raise requests.exceptions.HTTPError(response=self)
+
+    return FakeUnauthorized()
+
+
+def test_make_github_api_request_raises_auth_error_on_401(monkeypatch):
+    monkeypatch.setattr(api, "SECRET_GITHUB_TOKEN", "expired-token")
+    calls = []
+
+    def fake_get(*_a, **_kw):
+        calls.append(1)
+        return _make_auth_error_response()
+
+    monkeypatch.setattr(api.requests, "get", fake_get)
+
+    with pytest.raises(api.GitHubAuthenticationError) as exc_info:
+        api.make_github_api_request("/user")
+
+    assert isinstance(exc_info.value, requests.exceptions.HTTPError)
+    assert "GitHub authentication failed" in str(exc_info.value)
+    assert "HTTP 401" in str(exc_info.value)
+    assert len(calls) == 1  # 401 is not retried
+
+
+def test_make_github_graphql_request_raises_auth_error_on_401(monkeypatch):
+    monkeypatch.setattr(api, "SECRET_GITHUB_TOKEN", "expired-token")
+    calls = []
+
+    def fake_post(*_a, **_kw):
+        calls.append(1)
+        return _make_auth_error_response()
+
+    monkeypatch.setattr(api.requests, "post", fake_post)
+
+    with pytest.raises(api.GitHubAuthenticationError) as exc_info:
+        api.make_github_graphql_request("query { viewer { login } }")
+
+    assert isinstance(exc_info.value, requests.exceptions.HTTPError)
+    assert "GitHub authentication failed" in str(exc_info.value)
+    assert "HTTP 401" in str(exc_info.value)
+    assert len(calls) == 1  # 401 is not retried
+
+
+def test_get_authenticated_user_login_raises_auth_error_on_401(monkeypatch):
+    monkeypatch.setattr(api, "SECRET_GITHUB_TOKEN", "expired-token")
+    monkeypatch.setattr(
+        api.requests, "get", lambda *_a, **_kw: _make_auth_error_response()
+    )
+
+    with pytest.raises(api.GitHubAuthenticationError):
+        api.get_authenticated_user_login()
+
+
+def test_make_github_api_request_401_names_active_token_variable(monkeypatch):
+    monkeypatch.setenv("GH_TOKEN", "cli-token")
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    monkeypatch.setattr(api, "SECRET_GITHUB_TOKEN", "cli-token")
+    monkeypatch.setattr(
+        api.requests, "get", lambda *_a, **_kw: _make_auth_error_response()
+    )
+
+    with pytest.raises(api.GitHubAuthenticationError) as exc_info_gh:
+        api.make_github_api_request("/user")
+    assert "GH_TOKEN was rejected" in str(exc_info_gh.value)
+
+    monkeypatch.delenv("GH_TOKEN", raising=False)
+    monkeypatch.setenv("GITHUB_TOKEN", "env-token")
+    monkeypatch.setattr(api, "SECRET_GITHUB_TOKEN", "env-token")
+
+    with pytest.raises(api.GitHubAuthenticationError) as exc_info_github:
+        api.make_github_api_request("/user")
+    assert "GITHUB_TOKEN was rejected" in str(exc_info_github.value)
+
+
+def test_github_auth_error_message_identifies_token_variable():
+    err = api.GitHubAuthenticationError(token_var="GH_TOKEN")
+    assert "GH_TOKEN was rejected" in str(err)
+
+    err2 = api.GitHubAuthenticationError(token_var="GITHUB_TOKEN")
+    assert "GITHUB_TOKEN was rejected" in str(err2)
+
+
 # ---------------------------------------------------------------------------
 # _fetch_pr_detail URL parsing (#241)
 # ---------------------------------------------------------------------------
@@ -1466,3 +1556,16 @@ def test_resolve_github_token_none_when_neither_set(monkeypatch):
     monkeypatch.delenv("GH_TOKEN", raising=False)
 
     assert api._resolve_github_token() is None
+
+
+def test_resolve_github_token_info(monkeypatch):
+    monkeypatch.setenv("GH_TOKEN", "cli-tok")
+    monkeypatch.setenv("GITHUB_TOKEN", "gh-tok")
+    assert api._resolve_github_token_info() == ("cli-tok", "GH_TOKEN")
+
+    monkeypatch.delenv("GH_TOKEN", raising=False)
+    monkeypatch.setenv("GITHUB_TOKEN", "gh-tok")
+    assert api._resolve_github_token_info() == ("gh-tok", "GITHUB_TOKEN")
+
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    assert api._resolve_github_token_info() == (None, None)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -563,6 +563,133 @@ def test_cli_mine_only_exits_cleanly_on_rate_limit(monkeypatch):
     assert "2026-04-10 16:04:48" in result.stderr
 
 
+def test_cli_mine_only_exits_cleanly_on_auth_error(monkeypatch):
+    from breakfast.api import GitHubAuthenticationError
+
+    monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "expired-token")
+    monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
+    monkeypatch.setattr(
+        cli,
+        "get_authenticated_user_login",
+        lambda: (_ for _ in ()).throw(
+            GitHubAuthenticationError(token_var="GITHUB_TOKEN")
+        ),
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(cli.breakfast, ["-o", "org", "-r", "repo", "--mine-only"])
+
+    assert result.exit_code == 1
+    assert result.stdout == ""
+    assert "GitHub authentication failed" in result.stderr
+    assert "GITHUB_TOKEN was rejected (HTTP 401)" in result.stderr
+
+
+def test_cli_needs_my_review_exits_cleanly_on_auth_error(monkeypatch):
+    from breakfast.api import GitHubAuthenticationError
+
+    monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "expired-token")
+    monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
+    monkeypatch.setattr(
+        cli,
+        "get_authenticated_user_login",
+        lambda: (_ for _ in ()).throw(
+            GitHubAuthenticationError(token_var="GITHUB_TOKEN")
+        ),
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli.breakfast, ["-o", "org", "-r", "repo", "--needs-my-review"]
+    )
+
+    assert result.exit_code == 1
+    assert result.stdout == ""
+    assert "GitHub authentication failed" in result.stderr
+    assert "GITHUB_TOKEN was rejected (HTTP 401)" in result.stderr
+
+
+def test_cli_graphql_fetch_exits_cleanly_on_auth_error(monkeypatch):
+    from breakfast.api import GitHubAuthenticationError
+
+    monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "expired-token")
+    monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
+    monkeypatch.setattr(
+        cli,
+        "get_github_prs",
+        lambda *_a, **_kw: (_ for _ in ()).throw(
+            GitHubAuthenticationError(token_var="GITHUB_TOKEN")
+        ),
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(cli.breakfast, ["-o", "org", "-r", "repo"])
+
+    assert result.exit_code == 1
+    assert result.stdout == ""
+    assert "GitHub authentication failed" in result.stderr
+    assert "GITHUB_TOKEN was rejected (HTTP 401)" in result.stderr
+
+
+def test_cli_pr_detail_fetch_exits_cleanly_on_auth_error(monkeypatch):
+    from breakfast.api import GitHubAuthenticationError
+
+    monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "expired-token")
+    monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
+    monkeypatch.setattr(
+        cli, "get_github_prs", lambda *_a, **_kw: ["https://github.com/org/repo/pull/1"]
+    )
+    monkeypatch.setattr(
+        cli,
+        "_fetch_pr_detail",
+        lambda *_a, **_kw: (_ for _ in ()).throw(
+            GitHubAuthenticationError(token_var="GH_TOKEN")
+        ),
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(cli.breakfast, ["-o", "org", "-r", "repo"])
+
+    assert result.exit_code == 1
+    assert result.stdout == ""
+    assert "GitHub authentication failed" in result.stderr
+    assert "GH_TOKEN was rejected (HTTP 401)" in result.stderr
+
+
+def test_cli_auth_error_leaves_cache_untouched(monkeypatch, tmp_path):
+    from breakfast import cache
+    from breakfast.api import GitHubAuthenticationError
+
+    cache_dir = tmp_path / "cache"
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    user_file = cache_dir / "user.json"
+    sentinel_content = '{"login": "cached_sentinel_user"}'
+    user_file.write_text(sentinel_content)
+
+    monkeypatch.setattr(cache, "get_cache_dir", lambda: str(cache_dir))
+    monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "expired-token")
+    monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: None)
+    monkeypatch.setattr(
+        cli,
+        "get_authenticated_user_login",
+        lambda: (_ for _ in ()).throw(
+            GitHubAuthenticationError(token_var="GITHUB_TOKEN")
+        ),
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(cli.breakfast, ["-o", "org", "-r", "repo", "--mine-only"])
+
+    assert result.exit_code == 1
+    assert result.stdout == ""
+    assert user_file.read_text() == sentinel_content
+
+
 def test_cli_needs_my_review_filters_to_requested_reviewer(monkeypatch):
     monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
     monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])


### PR DESCRIPTION
## Summary

- **Handle expired GitHub tokens without a traceback**: Catch HTTP 401 authentication errors across REST and GraphQL queries and surface a friendly, actionable diagnostic on `stderr` without exposing a raw Python traceback.
- **Key Changes**:
  - `src/breakfast/api.py`: Introduced `GitHubAuthenticationError` (inheriting from `requests.exceptions.HTTPError`) and `_resolve_github_token_info()`. Raised `GitHubAuthenticationError` immediately on HTTP 401 in `make_github_api_request` and `make_github_graphql_request` without retrying.
  - `src/breakfast/cli.py`: Added `_handle_auth_error()` to print formatted authentication errors to `stderr` and exit with code 1. Caught `GitHubAuthenticationError` in `get_authenticated_user_login()` (`--mine-only` / `--needs-my-review`), the concurrent PR detail fetch pool (cancelling pending futures), and the main GraphQL fetch block.
  - `docs/manual/troubleshooting.md`: Documented the HTTP 401 error message, token refreshing instructions, and manual curl verification.
  - `tests/test_api.py` & `tests/test_cli.py`: Added comprehensive unit and CLI regression tests.
- **Abstractions & Design Decisions**:
  - `GitHubAuthenticationError` inherits from `requests.exceptions.HTTPError` so existing generic request exception handlers remain compatible.
  - Resolved the active environment variable (`GH_TOKEN` vs `GITHUB_TOKEN`) dynamically so the error message accurately directs the user to the rejected variable.
  - Cancelled pending thread pool futures immediately on authentication failure to prevent unnecessary subsequent requests.

## Test plan

- [x] Formatting, linting, and tests pass:
  - `uv run ruff check .`
  - `uv run black --check .`
  - `uv run pytest -v` (all 630 tests pass)
- [x] **Specific unit tests added**:
  - `test_make_github_api_request_raises_auth_error_on_401` — verifies HTTP 401 raises `GitHubAuthenticationError` and is not retried.
  - `test_make_github_graphql_request_raises_auth_error_on_401` — verifies GraphQL HTTP 401 raises `GitHubAuthenticationError` and is not retried.
  - `test_get_authenticated_user_login_raises_auth_error_on_401` — verifies user login lookup raises on 401.
  - `test_make_github_api_request_401_names_active_token_variable` — verifies `GH_TOKEN` vs `GITHUB_TOKEN` is accurately reported.
  - `test_resolve_github_token_info` — verifies token and variable name resolution.
  - `test_cli_mine_only_exits_cleanly_on_auth_error` — verifies `--mine-only` with rejected token exits 1 to `stderr` with empty `stdout`.
  - `test_cli_needs_my_review_exits_cleanly_on_auth_error` — verifies `--needs-my-review` with rejected token exits 1 cleanly.
  - `test_cli_graphql_fetch_exits_cleanly_on_auth_error` — verifies listing fetch with rejected token exits 1 cleanly.
  - `test_cli_pr_detail_fetch_exits_cleanly_on_auth_error` — verifies mid-fetch per-PR detail error exits 1 cleanly.
  - `test_cli_auth_error_leaves_cache_untouched` — verifies cache is preserved when an authentication error occurs.
- [x] **Manual Verification / Smoke Test**:
  - Verified `GH_TOKEN=expired_token .venv/bin/breakfast -o mrsixw --mine-only --refresh-prs` outputs `🍳 GitHub authentication failed: GH_TOKEN was rejected (HTTP 401). Refresh or replace the token and try again.` and exits 1 with no traceback.
  - Verified `GITHUB_TOKEN=expired_token .venv/bin/breakfast -o mrsixw --mine-only --refresh-prs` names `GITHUB_TOKEN`.
  - Verified normal runs with valid token pass with and without cache.

Closes #428
Closes #427

🤖 Prepared by [Antigravity](https://github.com/google-deepmind)
