### PR TITLE
fix: zero-pad version tuples so equal versions never look like an update

### DIFF
--- a/src/breakfast/updater.py
+++ b/src/breakfast/updater.py
@@ -137,6 +137,20 @@ def _parse_version_tuple(version_str):
         return ()
 
 
+def _is_newer(latest: str, current: str) -> bool:
+    """Compare versions with zero-padding so ``0.2.0`` is not newer than ``0.2``.
+
+    _parse_version_tuple's length follows the number of dot-separated segments,
+    so a bare tuple comparison lets any longer tuple beat a shorter one sharing
+    its prefix — reporting an update from 0.98 to 0.98.0, which are the same
+    release.
+    """
+    lt = _parse_version_tuple(latest)
+    ct = _parse_version_tuple(current)
+    width = max(len(lt), len(ct))
+    return lt + (0,) * (width - len(lt)) > ct + (0,) * (width - len(ct))
+
+
 def get_release_summary(body: str, max_chars: int = 200) -> str:
     """Extract a short human-readable summary from a GitHub release body.
 
@@ -173,7 +187,7 @@ def check_for_update(show_summary: bool = False):
         latest = get_latest_version()
         if not latest:
             return None
-        if _parse_version_tuple(latest) > _parse_version_tuple(current):
+        if _is_newer(latest, current):
             msg = (
                 f"\U0001f373 A fresh breakfast is ready! "
                 f"v{current} → v{latest} "
@@ -218,7 +232,7 @@ def perform_update(executable_path) -> tuple[UpdateStatus, str, str | None]:
         return UpdateStatus.UNKNOWN, current, None
     # Same comparison check_for_update() uses, so the passive notice and this
     # command can never disagree about whether an update exists.
-    if not _parse_version_tuple(latest) > _parse_version_tuple(current):
+    if not _is_newer(latest, current):
         return UpdateStatus.UP_TO_DATE, current, latest
 
     # Download to a sibling and os.replace() it into position: the rename is

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -93,7 +93,7 @@ def test_is_newer_downgrades_and_equality():
     assert not updater._is_newer("0.98.3", "0.98.3")
 
 
-def test_is_newer_unparseable_versions_never_claim_an_update():
+def test_is_newer_unparsable_versions_never_claim_an_update():
     assert not updater._is_newer("bad", "0.98.0")
     assert not updater._is_newer("bad", "also-bad")
 

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -74,6 +74,30 @@ def test_check_for_update_handles_errors(monkeypatch):
     assert updater.check_for_update() is None
 
 
+def test_is_newer_equal_versions_of_different_lengths():
+    # The regression: a bare tuple comparison made 0.98.0 beat 0.98, so the
+    # updater reported an update between two spellings of the same release.
+    assert not updater._is_newer("0.98.0", "0.98")
+    assert not updater._is_newer("0.98", "0.98.0")
+    assert not updater._is_newer("1.0.0.0", "1.0")
+
+
+def test_is_newer_genuine_upgrades():
+    assert updater._is_newer("0.99.0", "0.98.0")
+    assert updater._is_newer("1.0", "0.98.3")
+    assert updater._is_newer("0.98.1", "0.98")
+
+
+def test_is_newer_downgrades_and_equality():
+    assert not updater._is_newer("0.98.0", "0.99.0")
+    assert not updater._is_newer("0.98.3", "0.98.3")
+
+
+def test_is_newer_unparseable_versions_never_claim_an_update():
+    assert not updater._is_newer("bad", "0.98.0")
+    assert not updater._is_newer("bad", "also-bad")
+
+
 def test_get_latest_version_from_cache(monkeypatch, tmp_path):
     monkeypatch.setattr(updater, "_CACHE_DIR", tmp_path)
     cache_file = tmp_path / "latest_version.json"


### PR DESCRIPTION
Closes #435.

`_parse_version_tuple` returns a tuple whose length follows the number of dot-separated segments, so comparing two of them directly lets any longer tuple beat a shorter one that shares its prefix:

| installed | latest tag | before | after |
| --- | --- | --- | --- |
| `0.98` | `0.98.0` | reported as newer ❌ | no update ✅ |
| `1.0` | `1.0.0` | reported as newer ❌ | no update ✅ |
| `0.98` | `0.98.1` | reported as newer ✅ | reported as newer ✅ |
| `0.2.0` | `0.2` | no update ✅ | no update ✅ |

The consequence is not only a spurious banner. `perform_update` gates on the same comparison, so `breakfast update` would have downloaded the release and replaced the binary with an identical version, then reported success.

**This is latent, not live.** git-mkver produces three-part versions on both sides today, so the lengths match and the bug stays hidden. It bites the moment a two-part tag appears, or in a fork that tags `v1.0`.

`_is_newer` pads both sides to the longer width before comparing. Both call sites use it, preserving the existing property that the passive notice and the update command cannot disagree about whether an update exists.

### Notes

- Unparseable versions parse to `()`, which pads to all-zeros and so never claims an update — covered by a test, since that path is easy to break later.
- Found while bringing five-clis to parity; five-clis already had this fix, and this is the back-port.

### Verification

`make format && make lint && make test` — clean, 663 passed (4 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F1J7DEsXqHhdiK1PMhLXPC