### PR TITLE
feat: add the --update-summary flag the config template already promised

### DIFF
--- a/docs/manual/options.md
+++ b/docs/manual/options.md
@@ -996,9 +996,9 @@ breakfast automatically checks for new versions once per day (cached for 24 hour
 
 The check is non-blocking and non-fatal — network failures are silently ignored. The notification is sent to stderr so it won't interfere with `--json` output piping.
 
-### `update-summary` (config only)
+### `--update-summary`
 
-When set to `true`, appends a short summary of what's new (pulled from the GitHub release notes) below the update banner:
+Appends a short summary of what's new (pulled from the GitHub release notes) below the update banner:
 
 ```text
 🍳 A fresh breakfast is ready! v0.10.0 → v0.11.0 — update at ...
@@ -1007,7 +1007,11 @@ When set to `true`, appends a short summary of what's new (pulled from the GitHu
       - New --exclude-label filter
 ```
 
-Enable in `~/.config/breakfast/config.toml`:
+```bash
+breakfast -o my-org -r my-app --update-summary
+```
+
+Or enable it permanently in `~/.config/breakfast/config.toml`:
 
 ```toml
 update-summary = true

--- a/src/breakfast/cli.py
+++ b/src/breakfast/cli.py
@@ -863,6 +863,15 @@ def _fetch_pr_bundle(url, fetch_checks, fetch_approvals):
     ),
 )
 @click.option(
+    "--update-summary",
+    is_flag=True,
+    default=False,
+    help=(
+        "When a newer version is available, include a short summary of"
+        " what's new (from the GitHub release notes) below the update banner."
+    ),
+)
+@click.option(
     "--no-colour",
     "--no-color",
     "no_colour",
@@ -978,6 +987,7 @@ def breakfast(
     legendary_only,
     search,
     api_stats,
+    update_summary,
     no_colour,
     colour_diagnostics,
     summarise_user_prs,
@@ -1217,7 +1227,7 @@ def breakfast(
     colour_index = cfg.get("colour-index", False)
     summarise_user_prs = summarise_user_prs or cfg.get("summarise-user-prs", False)
     summarise_repo_prs = summarise_repo_prs or cfg.get("summarise-repo-prs", False)
-    show_update_summary = cfg.get("update-summary", False)
+    show_update_summary = update_summary or cfg.get("update-summary", False)
     sort_by = sort_by if sort_by is not None else cfg.get("sort", "repo")
     sort_reverse = sort_reverse or cfg.get("sort-reverse", False)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5577,3 +5577,52 @@ def test_cli_christmas_without_colour_does_not_output_pizza(monkeypatch):
         result = _pizza_run(monkeypatch, ["--no-colour"])
         assert result.exit_code == 0
         assert "🍕" not in result.stderr
+
+
+# ── --update-summary ───────────────────────────────────────────────────────
+
+
+def _run_finish(monkeypatch, **kwargs):
+    """Call _finish_run with the update check stubbed, returning show_summary."""
+    seen = {}
+
+    def fake_check_for_update(show_summary=False):
+        seen["show_summary"] = show_summary
+        return None
+
+    monkeypatch.setattr(cli, "check_for_update", fake_check_for_update)
+    cli._finish_run(
+        0.0,
+        0,
+        no_update_check=False,
+        api_stats=False,
+        colour=False,
+        **kwargs,
+    )
+    return seen.get("show_summary")
+
+
+def test_update_summary_flag_is_offered(monkeypatch):
+    # The regression: the config template advertised "Equivalent to:
+    # --update-summary" for a flag that was never implemented.
+    result = CliRunner().invoke(cli.breakfast, ["--help"])
+    assert "--update-summary" in result.output
+
+
+def test_finish_run_forwards_the_update_summary_choice(monkeypatch):
+    assert _run_finish(monkeypatch, show_update_summary=True) is True
+    assert _run_finish(monkeypatch, show_update_summary=False) is False
+
+
+def test_config_template_only_promises_flags_that_exist():
+    # The root cause: the template advertised a flag nobody had written. Hold
+    # every "Equivalent to:" line in the template to the CLI's actual options.
+    from breakfast import config
+
+    help_text = CliRunner().invoke(cli.breakfast, ["--help"]).output
+    promised = re.findall(
+        r"^# Equivalent to: (--[\w-]+)", config._DEFAULT_CONFIG_CONTENT, re.MULTILINE
+    )
+    assert promised, "expected the template to document some flags"
+    missing = [flag for flag in promised if flag not in help_text]
+    assert not missing, f"config template promises flags that do not exist: {missing}"


### PR DESCRIPTION
Closes #434.

The config template advertised a flag that was never written:

```
# Equivalent to: --update-summary
# update-summary = false
```

Meanwhile the manual described the same key as `### update-summary (config only)`. The two documents disagreed, and the feature was reachable only by editing TOML — while every other key in that template has the command-line equivalent it claims.

This adds the flag, resolved as `update_summary or cfg.get("update-summary", False)` to match the neighbouring booleans (`--summarise-user-prs` and friends), and fixes the manual section to match.

### The regression test is the interesting part

Rather than pinning this one flag, the test holds the template to the CLI:

```python
promised = re.findall(r"^# Equivalent to: (--[\w-]+)", config._DEFAULT_CONFIG_CONTENT, re.MULTILINE)
missing = [flag for flag in promised if flag not in help_text]
assert not missing
```

So the next key documented with an `Equivalent to:` line it cannot honour fails the suite instead of shipping. I verified it genuinely catches this by deleting the new option and re-running — it fails with `assert not ['--update-summary']`.

### Verification

`make format && make lint && make test` — clean, 662 passed (3 new).

Found while bringing five-clis to parity; it had the mirror-image gap, where the summary machinery existed but nothing ever switched it on (mrsixw/five-clis#41).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F1J7DEsXqHhdiK1PMhLXPC