### PR TITLE
feat: add a no-update-check config key

### DIFF
--- a/docs/manual/options.md
+++ b/docs/manual/options.md
@@ -1023,6 +1023,14 @@ breakfast -o my-org -r my-app --no-update-check
 export BREAKFAST_NO_UPDATE_CHECK=1
 ```
 
+Or permanently, in `~/.config/breakfast/config.toml`:
+
+```toml
+no-update-check = true
+```
+
+Any one of the three switching it off is enough; there is no way for a later one to switch it back on.
+
 Like `NO_COLOR`, `BREAKFAST_NO_UPDATE_CHECK` is resolved by presence: any non-empty value disables the update check, and only unset or empty leaves it enabled.
 
 ## Colour control

--- a/src/breakfast/cli.py
+++ b/src/breakfast/cli.py
@@ -1200,6 +1200,9 @@ def breakfast(
         legendary = True  # --legendary-only implies marking
     api_stats = api_stats or cfg.get("api-stats", False)
     no_colour = no_colour or cfg.get("no-colour", False)
+    # Composed after the flag and BREAKFAST_NO_UPDATE_CHECK, both resolved
+    # further up: any one of the three switching it off is enough.
+    no_update_check = no_update_check or cfg.get("no-update-check", False)
     colour = not no_colour
 
     # Click's IntRange has already vetted any command-line values; these config

--- a/src/breakfast/config.py
+++ b/src/breakfast/config.py
@@ -276,8 +276,15 @@ _DEFAULT_CONFIG_CONTENT = """\
 # Control how version update alerts appear.
 # -----------------------------------------------------------------------------
 
+# Skip the automatic check for newer releases entirely.
+# Also honoured via the BREAKFAST_NO_UPDATE_CHECK environment variable, set to
+# any non-empty value.
+# Equivalent to: --no-update-check
+# no-update-check = false
+
 # When a newer version of breakfast is available, include a short summary of
 # what's new (pulled from the GitHub release notes) below the update banner.
+# Has no effect when no-update-check is true.
 # Equivalent to: --update-summary
 # update-summary = false
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5577,3 +5577,67 @@ def test_cli_christmas_without_colour_does_not_output_pizza(monkeypatch):
         result = _pizza_run(monkeypatch, ["--no-colour"])
         assert result.exit_code == 0
         assert "🍕" not in result.stderr
+
+
+# --- no-update-check config key (issue #439) --------------------------------
+
+
+def _update_check_probe(monkeypatch, cfg):
+    """Run breakfast with *cfg* loaded, returning the update-check call log."""
+    monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
+    monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
+    monkeypatch.setattr(cli, "load_config", lambda _: cfg)
+    monkeypatch.setattr(cli, "get_github_prs", lambda *a: [])
+    monkeypatch.delenv("BREAKFAST_NO_UPDATE_CHECK", raising=False)
+
+    checked = []
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: checked.append(1))
+    result = CliRunner().invoke(cli.breakfast, ["-o", "org", "-r", "repo"])
+    assert result.exit_code == 0, result.output
+    return checked
+
+
+def test_no_update_check_config_key_disables_check(monkeypatch):
+    assert _update_check_probe(monkeypatch, {"no-update-check": True}) == []
+
+
+def test_no_update_check_config_key_false_leaves_check_enabled(monkeypatch):
+    assert _update_check_probe(monkeypatch, {"no-update-check": False}) == [1]
+
+
+def test_no_update_check_absent_from_config_leaves_check_enabled(monkeypatch):
+    assert _update_check_probe(monkeypatch, {}) == [1]
+
+
+def test_no_update_check_flag_beats_a_false_config_key(monkeypatch):
+    # Any one of flag, env var, or config key switching it off is enough —
+    # none of the three can switch it back on.
+    monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
+    monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
+    monkeypatch.setattr(cli, "load_config", lambda _: {"no-update-check": False})
+    monkeypatch.setattr(cli, "get_github_prs", lambda *a: [])
+    monkeypatch.delenv("BREAKFAST_NO_UPDATE_CHECK", raising=False)
+
+    checked = []
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: checked.append(1))
+    result = CliRunner().invoke(
+        cli.breakfast, ["-o", "org", "-r", "repo", "--no-update-check"]
+    )
+
+    assert result.exit_code == 0, result.output
+    assert checked == []
+
+
+def test_no_update_check_env_beats_a_false_config_key(monkeypatch):
+    monkeypatch.setattr(cli, "SECRET_GITHUB_TOKEN", "token-123")
+    monkeypatch.setattr(cli, "BREAKFAST_ITEMS", ["*"])
+    monkeypatch.setattr(cli, "load_config", lambda _: {"no-update-check": False})
+    monkeypatch.setattr(cli, "get_github_prs", lambda *a: [])
+    monkeypatch.setenv("BREAKFAST_NO_UPDATE_CHECK", "1")
+
+    checked = []
+    monkeypatch.setattr(cli, "check_for_update", lambda **_kw: checked.append(1))
+    result = CliRunner().invoke(cli.breakfast, ["-o", "org", "-r", "repo"])
+
+    assert result.exit_code == 0, result.output
+    assert checked == []


### PR DESCRIPTION
Closes #439.

The update check could be silenced per-invocation with `--no-update-check`, or per-shell with `BREAKFAST_NO_UPDATE_CHECK`, but not permanently — there was no config key for it. An odd asymmetry, since the template already carried `update-summary`: you could configure what the update notice *said* but not whether the check ran at all.

```toml
# ~/.config/breakfast/config.toml
no-update-check = true
```

Composed exactly the way `no-colour` already is, after the flag and the environment variable:

```python
no_update_check = no_update_check or cfg.get("no-update-check", False)
```

Any one of the three switching it off is enough, and none of them can switch it back on. Two of the new tests pin that direction specifically, since an `or` chain rewritten as precedence-based resolution would silently let a `false` config key re-enable the check.

### Consistency

This is part of making the four CLIs agree on how the update check is disabled:

| tool | flag | env var | config key |
| --- | --- | --- | --- |
| breakfast | ✅ | ✅ | ✅ **this PR** |
| five-clis | ✅ | ✅ | ✅ |
| jeeves | ✅ | ✅ | ✅ |
| gh-snitch | ✅ | ❌ | ❌ (mrsixw/gh-snitch — next) |

### Verification

`make format && make lint && make test` — clean, 664 passed (5 new).

Independent of #437 and #438; all three branch from `main` and touch different code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F1J7DEsXqHhdiK1PMhLXPC